### PR TITLE
source all plugin-provided utility.sh files

### DIFF
--- a/aws/createTemplate.sh
+++ b/aws/createTemplate.sh
@@ -93,6 +93,13 @@ function options() {
   fi
   GENERATION_PROVIDERS=$(listFromArray "GENERATION_PROVIDERS" ",")
 
+  # load utility functions for all loaded providers
+  for provider in "${GENERATION_PROVIDERS}"; do
+    if [[ -f "${GENERATION_PLUGIN_DIRS}/${provider}/utility.sh" ]]; then
+      . ${GENERATION_PLUGIN_DIRS}/${provider}/utility.sh
+    fi
+  done
+
   # Check level and deployment unit
   ! isValidUnit "${LEVEL}" "${DEPLOYMENT_UNIT}" && fatal "Deployment unit/level not valid" &&  return 1
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
createTemplate will now dot-source all specified provider plugin utility scripts as well as the shared provider one.
Though a common need, this could not be added into the common.sh script as it will not consistently have access to the GENERATION_PROVIDERS variable. Moving the dot-sourcing of common.sh until later in existing shell scripts (say, to after getopts and defaults have been applied) only causes other problems due to other variables now being missing.

## Motivation and Context
Currently, the createTemplate.sh script only loads the shared provider utility.sh when it dot-sources the file common.sh at the top of the script. This change implements a check for a similar utility.sh script within all specified provider plugin directories and dot-sources those too, if found. This allows for each provider to load provider-specific related utilities which are particularly important for non-"template" generation-contract passes such as "pregeneration".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
As this is a minimal change effecting only the azure plugin at this stage. I have tested it by executing the following on my existing test CMDB (successful): 
`cot create template -p azure -f arm -l application -u apigw`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
-->
Non-breaking change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] none above apply.
