### PR TITLE
<fix> Pregeneration output filename

### DIFF
--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -286,7 +286,7 @@
             parameters=
                 getGenerationContractStepParameters(
                     "pregeneration",
-                    "pregeneration",
+                    "primary",
                     (commandLineOptions.Deployment.Provider.Names)[0]
                 )
         /]


### PR DESCRIPTION
## Description
Correct the alternative value used for the pregeneration step.

## Motivation and Context
Pregeneration processing does not require the use of alternatives, and having a non-default value affects the output filename used to save it in the CMDB.

## How Has This Been Tested?
- Ran a local template creation and confirmed the correct output file was generated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Actions
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above