### PR TITLE
<fix> jenkins jnlp alternate endpoint

### DIFF
--- a/legacy/fragment/fragment_jenkins.ftl
+++ b/legacy/fragment/fragment_jenkins.ftl
@@ -36,15 +36,22 @@
     [#if ! settings["ECS_ARN"]?? ]
         [@fatal
             message="Could not find ecs host for agents - add a link to the ECS Host that will run your agents"
-            context=_context.Links 
+            context=_context.Links
             detail="Add a link with the id ecs"
+        /]
+    [/#if]
+
+    [#if (settings["JENKINS_JNLP_FQDN"]!"")?has_content ]
+        [@Settings
+            {
+                "AGENT_JNLP_TUNNEL" : settings["JENKINS_JNLP_FQDN"] + ":50000"
+            }
         /]
     [/#if]
 
     [#if (settings["JENKINS_LOCAL_FQDN"]!"")?has_content ]
         [@Settings
             {
-                "AGENT_JNLP_TUNNEL" : settings["JENKINS_LOCAL_FQDN"] + ":50000",
                 "AGENT_JENKINS_URL" : "http://" + settings["JENKINS_LOCAL_FQDN"] + ":8080"
             }
         /]


### PR DESCRIPTION
## Description
Separates the Jenkins HTTP url from the Jenkins JNLP alternate endpoints for ecs agents. This was in place but was incorrectly merged

## Motivation and Context
Allows for the JNLP endpoint to be hosted on a network load balancer with the normal jenkins endpoint on an http load balancer. This allows for agents outside of the VPC to connect to the Jenkins host over JNLP

## How Has This Been Tested?
Deployed to our codepublican service

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Actions
Change required to the link name when you want to use the JNLP alternate endpoint instead of 

JENKINS_LOCAL_FQDN the setting tested for the FQDN is now JENKINS_JNLP_FQDN 
JENKINS_LOCAL_FQDN is still usable but only for the Jenkins HTTP url endpoint


## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
