### PR TITLE
<feature> rds minor version support

### DIFF
--- a/providers/shared/components/db/id.ftl
+++ b/providers/shared/components/db/id.ftl
@@ -39,6 +39,10 @@
                 "Mandatory" : true
             },
             {
+                "Names" : "EngineMinorVersion",
+                "Type" : STRING_TYPE
+            },
+            {
                 "Names" : "Port",
                 "Type" : STRING_TYPE
             },


### PR DESCRIPTION
## Description
Companion PR to https://github.com/hamlet-io/engine-plugin-aws/pull/2 
Allows you to set either the major or minor version of database engine to use

## Motivation and Context
sometimes you might want to control the specific minor version that you are on for an RDS database engine or you want to restrict the auto update service support 

## How Has This Been Tested?
Tested with client site

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Actions
None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
