### PR TITLE
<feature> Dynamic CMDB Loading

### DIFF
--- a/engine/bootstrap.ftl
+++ b/engine/bootstrap.ftl
@@ -7,6 +7,9 @@
 [#include "logging.ftl" ]
 
 [#-- Input data handling --]
+[#include "inputdata/context.ftl" ]
+[@initialiseInputsContext /]
+
 [#include "inputdata/commandLineOptions.ftl" ]
 [#include "inputdata/masterdata.ftl" ]
 [#include "inputdata/blueprint.ftl" ]
@@ -43,6 +46,12 @@
 
 [#-- Set desired logging level --]
 [@setLogLevel commandLineOptions.Logging.Level /]
+
+[#-- CMDB Handling --]
+[#if commandLineOptions.Input.Source == "composite"]
+    [#include "cmdb.ftl" ]
+    [@initialiseCMDB /]
+[/#if]
 
 [#-- Get the provider specific command line options/masterdata --]
 [@includeProviders commandLineOptions.Deployment.Provider.Names /]

--- a/engine/inputdata/context.ftl
+++ b/engine/inputdata/context.ftl
@@ -1,0 +1,291 @@
+[#ftl]
+
+[#-----------------------------
+-- Inputs context management --
+-------------------------------]
+
+[#assign PLACEMENT_INPUTS_CONTEXT = "placement"]
+[#assign PRODUCT_INPUTS_CONTEXT = "product"]
+
+[#macro initialiseInputsContext ]
+    [#-- Inputs context stacks --]
+    [#assign inputsPlacementStack = initialiseStack() ]
+    [#assign inputsProductStack = initialiseStack() ]
+
+    [#-- Inputs state caches --]
+    [#assign inputsPlacementDictionary = initialiseDictionary() ]
+    [#assign inputsProductDictionary = initialiseDictionary() ]
+
+    [#-- The current inputs contexts --]
+    [#assign inputsPlacementContext = {} ]
+    [#assign inputsProductContext = {} ]
+
+    [#-- The current inputs state --]
+    [#assign inputsPlacementState = {} ]
+    [#assign inputsProductState = {} ]
+
+    [#-- Effective State --]
+    [#assign inputsDictionary = initialiseDictionary() ]
+    [#assign inputsState = {} ]
+[/#macro]
+
+[#macro pushInputsPlacementContext context={} ]
+    [@internalPushInputsContext PLACEMENT_INPUTS_CONTEXT context /]
+[/#macro]
+
+[#macro pushInputsProductContext context={} ]
+    [@internalPushInputsContext PRODUCT_INPUTS_CONTEXT context /]
+[/#macro]
+
+[#macro conditionalPushInputsPlacementContext context={} ]
+    [@internalConditionalPushInputsContext PLACEMENT_INPUTS_CONTEXT context /]
+[/#macro]
+
+[#macro conditionalPushInputsProductContext context={} ]
+    [@internalConditionalPushInputsContext PRODUCT_INPUTS_CONTEXT context /]
+[/#macro]
+
+[#macro popInputsPlacementContext context={} ]
+    [@internalPopInputsContext PLACEMENT_INPUTS_CONTEXT context /]
+[/#macro]
+
+[#macro popInputsProductContext context={} ]
+    [@internalPopInputsContext PRODUCT_INPUTS_CONTEXT context /]
+[/#macro]
+
+[#macro conditionalPopInputsPlacementContext context={} ]
+    [@internalConditionalPopInputsContext PLACEMENT_INPUTS_CONTEXT context /]
+[/#macro]
+
+[#macro conditionalPopInputsProductContext context={} ]
+    [@internalConditionalPopInputsContext PRODUCT_INPUTS_CONTEXT context /]
+[/#macro]
+
+[#-- Product helper functions --]
+[#function getTenantInputsContext]
+    [#return inputsProductContext.Tenant!""]
+[/#function]
+
+[#function getProductInputsContext]
+    [#return inputsProductContext.Product!""]
+[/#function]
+
+[#function getEnvironmentInputsContext]
+    [#return inputsProductContext.Environment!""]
+[/#function]
+
+[#function getSegmentInputsContext]
+    [#return inputsProductContext.Segment!""]
+[/#function]
+
+[#-- Placement helper functions --]
+[#function getAccountInputsContext]
+    [#return inputsPlacementContext.Account!""]
+[/#function]
+
+[#function getRegionInputsContext]
+    [#return inputsPlacementContext.Region!""]
+[/#function]
+
+[#-----------------------------------------------------------
+-- Internal support functions for input context processing --
+-------------------------------------------------------------]
+
+[#-- Determine the inputs --]
+[#function internalGetInputsState inputTypes]
+    [#local state = {} ]
+    [#list asArray(inputTypes) as inputType]
+        [#-- TODO(mfl): replace with loading of providers and seeding of inputs --]
+        [#local state += {inputType : {} }]
+    [/#list]
+    [#return state]
+[/#function]
+
+[#-- Get the combined state of placement and product   --]
+[#-- Qualify the results based on the current contexts --]
+[#function internalGetEffectiveState]
+    [#local state = {} ]
+    [#local keys = getUniqueArrayElements(inputsPlacementState?keys, inputsProductState?keys)]
+    [#list keys as key]
+        [#-- Determine the expected base type --]
+        [#switch getBaseType(inputsPlacementState[key]!inputsProductState[key])]
+            [#case ARRAY_TYPE]
+                [#local missingValue = [] ]
+                [#break]
+            [#default]
+                [#local missingValue = {} ]
+                [#break]
+        [/#switch]
+        [#local state +=
+            {
+                key :
+                    combineEntities(
+                        inputsPlacementState[key]!missingValue,
+                        inputsProductState[key]!missingValue,
+                        APPEND_COMBINE_BEHAVIOUR
+                    )
+            }
+        ]
+    [/#list]
+
+    [#-- TODO(mfl): Add qualification --]
+
+    [#return state]
+[/#function]
+
+[#-- Seed on the basis of the inputs context --]
+[#macro internalSeedInputsState type ]
+
+    [#-- First determine the dictionary index --]
+    [#switch type]
+        [#case PLACEMENT_INPUTS_CONTEXT]
+            [#local context = inputsPlacementContext]
+            [#break]
+        [#default]
+            [#local context = inputsProductContext]
+            [#break]
+    [/#switch]
+    [#local dictionaryIndex = [] ]
+    [#list context?keys?sort as key]
+        [#local dictionaryIndex += [ context[key] ] ]
+    [/#list]
+
+    [#-- Check for an already calculated state --]
+    [#switch type]
+        [#case PLACEMENT_INPUTS_CONTEXT]
+            [#assign inputsPlacementState = getDictionaryEntry(inputsPlacementDictionary, dictionaryIndex)]
+            [#local state = inputsPlacementState]
+            [#break]
+        [#default]
+            [#assign inputsProductState = getDictionaryEntry(inputsProductDictionary, dictionaryIndex)]
+            [#local state = inputsProductState]
+            [#break]
+    [/#switch]
+
+    [#if !state?has_content]
+        [#-- Calculate inputs state --]
+        [#switch type]
+            [#case PLACEMENT_INPUTS_CONTEXT]
+                [#assign inputsPlacementState =
+                    internalGetInputsState(
+                        [
+                            "MasterData",
+                            "Blueprint",
+                            "References",
+                            "Settings",
+                            "StackOutputs"
+                        ]
+                    )
+                ]
+                [#assign inputsPlacementDictionary = addDictionaryEntry(inputsPlacementDictionary, dictionaryIndex, inputsPlacementState) ]
+                [#break]
+        [#default]
+                [#assign inputsProductState =
+                    internalGetInputsState(
+                        [
+                            "Blueprint",
+                            "References",
+                            "Settings",
+                            "StackOutputs",
+                            "Definitions"
+                        ]
+                    )
+                ]
+                [#assign inputsProductDictionary = addDictionaryEntry(inputsProductDictionary, dictionaryIndex, inputsProductState) ]
+                [#break]
+        [/#switch]
+    [/#if]
+
+    [#-- Calculate the effective state --]
+    [#local dictionaryIndex = getUniqueArrayElements(inputsPlacementContext?keys, inputsProductContext?keys)?sort]
+    [#assign inputsState = getDictionaryEntry(inputsDictionary, dictionaryIndex) ]
+    [#if !inputsState?has_content]
+        [#assign inputsState = internalGetEffectiveState() ]
+        [#assign inputsDictionary = addDictionaryEntry(inputsDictionary, dictionaryIndex, inputsState) ]
+    [/#if]
+[/#macro]
+
+[#-- Determine whether a "new" context will actually change the current one --]
+[#function internalIsNewInputsContext type context ]
+    [#switch type]
+        [#case PLACEMENT_INPUTS_CONTEXT]
+            [#local currentContext = inputsPlacementContext]
+            [#break]
+        [#default]
+            [#local currentContext = inputsProductContext]
+            [#break]
+    [/#switch]
+
+    [#list context as key,value]
+        [#if !currentContext[key]??]
+            [#return true]
+        [/#if]
+        [#if currentContext[key] != value]
+            [#return true]
+        [/#if]
+    [/#list]
+
+    [#return false]
+[/#function]
+
+[#macro internalPushInputsContext type context ]
+    [#switch type]
+        [#case PLACEMENT_INPUTS_CONTEXT]
+            [#-- Remember previous context --]
+            [#assign inputsPlacementStack = pushOnStack(inputsPlacementStack, context) ]
+
+            [#-- Update inputs context --]
+            [#assign inputsPlacementContext += context ]
+            [#break]
+        [#default]
+            [#-- Remember previous context --]
+            [#assign inputsProductStack = pushOnStack(inputsProductStack, context) ]
+
+            [#-- Update inputs context --]
+            [#assign inputsProductContext += context ]
+            [#break]
+        [/#switch]
+
+    [#-- Update inputs state --]
+    [@internalSeedInputsState type /]
+[/#macro]
+
+[#macro internalConditionalPushInputsContext type context={} ]
+    [#-- First ensure we need to create a new context --]
+    [#if !internalIsNewInputsContext(type, context) ]
+        [#-- No change --]
+        [#return]
+    [/#if]
+
+    [#-- Create the new context --]
+    [@internalPushInputsContext type context /]
+[/#macro]
+
+[#macro internalPopInputsContext type]
+    [#switch type]
+        [#case PLACEMENT_INPUTS_CONTEXT]
+            [#-- Restore previous context --]
+            [#assign inputsPlacementContext = getTopOfStack(inputsPlacementStack) ]
+            [#assign inputsPlacementStack = popOffStack(inputsPlacementStack) ]
+            [#break]
+        [#default]
+            [#-- Restore previous context --]
+            [#assign inputsProductContext = getTopOfStack(inputsProductStack) ]
+            [#assign inputsProductStack = popOffStack(inputsProductStack) ]
+            [#break]
+    [/#switch]
+
+    [#-- Update inputs state --]
+    [@internalSeedInputsState type /]
+[/#macro]
+
+[#-- Only use if paired with internalConditionalPushInputsContext --]
+[#macro internalConditionalPopInputsContext type context ]
+    [#if !internalIsNewInputsContext(type, context)]
+        [#return]
+    [/#if]
+
+    [#-- Need to pop the stack --]
+    [@internalPopInputsContext type /]
+[/#macro]
+

--- a/engine/inputdata/stackOutput.ftl
+++ b/engine/inputdata/stackOutput.ftl
@@ -1,10 +1,10 @@
 [#ftl]
 
-[#---------------------------------------------------
+[#------------------------------------------------
 -- Public functions for stack output processing --
------------------------------------------------------]
+--------------------------------------------------]
 
-[#assign stackOutputsList = []]
+[#assign stackOutputsList = [] ]
 
 [#assign stackOutputConfiguration = {
     "Properties" : [

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -366,7 +366,7 @@
     [#return result]
 [/#function]
 
-
+[#-- TODO(mfl): remove unused root parameter --]
 [#function internalCreateOccurrenceSettings possibilities root prefixes alternatives]
     [#local contexts = [] ]
 
@@ -377,7 +377,7 @@
             [#local value = possibilities[key] ]
             [#if value?has_content]
                 [#list alternatives as alternative]
-                    [#local alternativeKey = formatName(root, prefix, alternative.Key) ]
+                    [#local alternativeKey = formatName(prefix, alternative.Key) ]
                     [@debug
                         message=alternative.Match + " comparison of " + matchKey + " to " + alternativeKey
                         enabled=false

--- a/engine/provider.ftl
+++ b/engine/provider.ftl
@@ -4,8 +4,11 @@
 
 [#assign SHARED_PROVIDER = "shared"]
 
-[#assign providerDictionary = [] ]
-[#assign providerMarkers = [] ]
+[#macro initialiseProviders]
+    [#local result = initialisePluginFileSystem() ]
+    [#assign providerDictionary = initialiseDictionary() ]
+    [#assign providerMarkers = findProviderMarkers()  ]
+[/#macro]
 
 [#-- Only load configuration once --]
 [#function isConfigurationIncluded configuration]
@@ -36,12 +39,6 @@
     [#return markers?sort_by("Path") ]
 
 [/#function]
-
-[#macro initialiseProviders]
-    [#local result = initialisePluginFileSystem() ]
-    [#assign providerDictionary = initialiseDictionary() ]
-    [#assign providerMarkers = findProviderMarkers()  ]
-[/#macro]
 
 [#-- Determine what providers have been configured --]
 [#-- Include their input sources                   --]
@@ -488,12 +485,6 @@
     [@internalIncludeTemplatesInDirectory
         [providerMarker.Path, "references"],
         ["reference" ]
-    /]
-
-    [#-- aws/references/reference.ftl --]
-    [@internalIncludeTemplatesInDirectory
-        [providerMarker.Path, "tasks"],
-        ["task" ]
     /]
 
     [#-- aws/resourcegroups/resourcegroup.ftl --]

--- a/engine/task.ftl
+++ b/engine/task.ftl
@@ -1,7 +1,7 @@
 [#ftl]
 
 [#-- tasks are executed in contracts --]
-[#-- Each task should perform a specifc action to manage a deployment --]
+[#-- Each task should perform a specific action to manage a deployment --]
 
 [#assign taskConfiguration = {}]
 

--- a/providers/shared/inputsources/composite/blueprint.ftl
+++ b/providers/shared/inputsources/composite/blueprint.ftl
@@ -3,6 +3,11 @@
 [#-- Intial seeding of settings data based on input data --]
 [#macro shared_input_composite_blueprint_seed ]
     [@addBlueprint
-        blueprint=commandLineOptions.Composites.Blueprint
+        blueprint=
+            mergeObjects(
+                getCMDBTenantBlueprint(),
+                getCMDBAccountBlueprint(),
+                getCMDBProductBlueprint()
+            )
     /]
 [/#macro]

--- a/providers/shared/inputsources/composite/definition.ftl
+++ b/providers/shared/inputsources/composite/definition.ftl
@@ -3,7 +3,7 @@
 [#-- Intial seeding of settings data based on input data --]
 [#macro shared_input_composite_definition_seed ]
     [@addDefinition
-        definition=commandLineOptions.Composites.Definitions
+        definition=getCMDBProductDefinitions()
     /]
 [/#macro]
 

--- a/providers/shared/inputsources/composite/setting.ftl
+++ b/providers/shared/inputsources/composite/setting.ftl
@@ -2,158 +2,21 @@
 
 [#-- Initial seeding of settings data based on input data --]
 [#macro shared_input_composite_setting_seed ]
+    [#-- Account settings --]
     [@addSettings
         type="Settings"
         scope="Accounts"
-        settings=
-            internalReformatSettings(
-                (commandLineOptions.Composites.Settings.Accounts.Settings)!{}
-            )
+        settings=getCMDBAccountSettings().General
     /]
 
-    [#-- (?! ) negates the remaining expression --]
-    [@addSettings
-        type="Settings"
-        scope="Products"
-        settings=
-            mergeObjects(
-                internalReformatSettings(
-                    (commandLineOptions.Composites.Settings.Products.Settings)!{},
-                    r"^(?!.*build\.json|.*credentials\.json|.*sensitive\.json$).*$"
-                ),
-                internalReformatSettings(
-                    (commandLineOptions.Composites.Settings.Products.Operations)!{},
-                    r"^(?!.*build\.json|.*credentials\.json|.*sensitive\.json$).*$"
-                )
-            )
-    /]
+    [#-- Product settings --]
+    [#local settings = getCMDBProductSettings() ]
+    [@addSettings type="Settings"  scope="Products" settings=settings.General /]
+    [@addSettings type="Builds"    scope="Products" settings=settings.Builds /]
+    [@addSettings type="Sensitive" scope="Products" settings=settings.Sensitive /]
 
-    [@addSettings
-        type="Builds"
-        scope="Products"
-        settings=
-            mergeObjects(
-                internalReformatSettings(
-                    (commandLineOptions.Composites.Settings.Products.Settings)!{},
-                    r"^.*build\.json$"
-                ),
-                internalReformatSettings(
-                    (commandLineOptions.Composites.Settings.Products.Builds)!{},
-                    r"^.*build\.json$"
-                )
-            )
-    /]
-
-    [@addSettings
-        type="Sensitive"
-        scope="Products"
-        settings=
-            mergeObjects(
-                internalReformatSettings(
-                    (commandLineOptions.Composites.Settings.Products.Settings)!{},
-                    r"^.*credentials\.json|.*sensitive\.json$"
-                ),
-                internalReformatSettings(
-                    (commandLineOptions.Composites.Settings.Products.Operations)!{},
-                    r"^.*credentials\.json|.*sensitive\.json$"
-                )
-            )
-    /]
 [/#macro]
 
 [#---------------------------------------------------------------
 -- Internal support functions for composite setting processing --
 -----------------------------------------------------------------]
-
-[#function internalReformatSettings objects fileRegex=".*"]
-    [#local result = {}]
-    [#list objects!{} as key,value]
-        [#local result =
-            mergeObjects(
-                result,
-                internalReformatFiles(key, value!{}, fileRegex)
-            )]
-    [/#list]
-    [#return result]
-[/#function]
-
-[#function internalReformatFiles key settingsFiles fileRegex]
-    [#local result = {} ]
-    [#list settingsFiles.Files![] as file ]
-        [#-- Ignore the file if it doesn't match the desired regex --]
-        [#if ! file.FileName?lower_case?trim?matches(fileRegex)]
-            [#continue]
-        [/#if]
-
-        [#-- Locate files reative to the CMDB root --]
-        [#local relativeFile =
-            concatenate(
-                [
-                    file.FilePath?remove_beginning(settingsFiles.RootDirectory)?remove_beginning("/"),
-                    file.FileName
-                ],
-                "/"
-            ) ]
-
-        [#-- The namespace starts with the key, followed by any parts of the file path --]
-        [#-- relative to the base directory --]
-        [#local extension = file.FileName?keep_after_last(".")]
-        [#local base = file.FileName?remove_ending("." + extension)]
-        [#local namespace =
-            concatenate(
-                [
-                    key,
-                    file.FilePath?remove_beginning(settingsFiles.BaseDirectory)?lower_case?replace("/", " ")?trim?split(" ")
-                ],
-                "-"
-            ) ]
-
-        [#-- Attribute for file contents --]
-        [#local attribute = base?replace("-","_")?upper_case]
-
-        [#-- asFile --]
-        [#if file.FilePath?lower_case?contains("asfile")]
-            [#local result =
-                mergeObjects(
-                    result,
-                    {
-                        namespace : {
-                            attribute : {
-                                "Value" : file.FileName,
-                                "AsFile" : relativeFile
-                            }
-                        }
-                    }
-                 ) ]
-            [#continue]
-        [/#if]
-
-        [#-- Settings format depends on file extension --]
-        [#switch extension?lower_case]
-            [#case "json"]
-                [#local result =
-                    mergeObjects(
-                        result,
-                        {
-                            namespace : file.Content[0]
-                        }
-                     ) ]
-                [#break]
-            [#default]
-                [#local result =
-                    mergeObjects(
-                        result,
-                        {
-                            namespace : {
-                                attribute : {
-                                    "Value" : file.Content[0],
-                                    "FromFile" : relativeFile
-                                }
-                            }
-                        }
-                    ) ]
-                [#break]
-        [/#switch]
-    [/#list]
-    [#return result]
-[/#function]

--- a/providers/shared/inputsources/composite/stackoutput.ftl
+++ b/providers/shared/inputsources/composite/stackoutput.ftl
@@ -10,7 +10,11 @@
     [#-- The component level is determined by the first part of the file name --]
 
     [#-- cloudformation stack outputs are used as the default shared format to align with PseudoStack Output script --]
-    [#list commandLineOptions.Composites.StackOutputs as stackOutputFile ]
+    [#local stackOutputFiles =
+        getCMDBAccountStackOutputs() +
+        getCMDBProductStackOutputs() ]
+
+    [#list stackOutputFiles as stackOutputFile ]
 
         [#local level = ((stackOutputFile["FileName"])?split('-'))[0] ]
 
@@ -34,7 +38,12 @@
                         [/#if]
 
                         [#if stackOutput?has_content ]
-                            [#local stackOutputs += [ mergeObjects( { "Level" : level} , stackOutput) ] ]
+                            [#-- Ensure mandatory attributes present --]
+                            [#if
+                                (stackOutput.Account?has_content || stackOutput.Subscription?has_content) &&
+                                stackOutput.Region?has_content ]
+                                [#local stackOutputs += [ mergeObjects( { "Level" : level} , stackOutput) ] ]
+                            [/#if]
                         [/#if]
                     [/#if]
                 [/#list]

--- a/providers/shared/inputsources/shared/commandlineoption.ftl
+++ b/providers/shared/inputsources/shared/commandlineoption.ftl
@@ -58,4 +58,19 @@
         }
     /]
 
+    [@pushInputsPlacementContext
+        {
+            "Account" : account!"",
+            "Region" : region!""
+        }
+    /]
+
+    [@pushInputsProductContext
+        {
+            "Tenant" : tenant!"",
+            "Product" : product!"",
+            "Environment" : environment!"",
+            "Segment" : segment!""
+        }
+    /]
 [/#macro]


### PR DESCRIPTION
## Description
Dynamically load the CMDB information in the freemarker wrapper rather than in the executor.

Add the idea of a stack of input contexts to permit changing of the inputs for instance when following cross segment links. A subsequent will move a lot of the logic currently inside the
bootstrap into the input context switching logic.

Some effort has gone into caching both the dynamically loaded CMDB information and input contexts. More work will be needed.

## Motivation and Context
- improve execution speed
- decrease coupling between engine and executor
- support cross product lookups e.g. for account information

## How Has This Been Tested?
TBD

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
Associated PRs to be merged at the same time
- [ ] executor PR - https://github.com/hamlet-io/executor-bash/pull/9

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] None of the above.
