### PR TITLE
<refactor> jenkins agent hamlet updates

### DIFF
--- a/legacy/fragment/fragment_hamlet.ftl
+++ b/legacy/fragment/fragment_hamlet.ftl
@@ -45,11 +45,11 @@
     [/#if]
 
     [#-- Validate that the appropriate settings have been provided for the container to work --]
-    [#if settings["HAMLETVOLUME"]?has_content ]
+    [#if settings["PROPERTIESVOLUME"]?has_content ]
         [@Volume
-            name="hamlet"
-            containerPath="/var/opt/hamlet/"
-            hostPath=settings["HAMLETVOLUME"]
+            name="properties"
+            containerPath=(settings["PROPERTIES_DIR"])!"/var/opt/properties/"
+            hostPath=settings["PROPERTIESVOLUME"]
             readOnly=true
         /]
     [/#if]
@@ -58,23 +58,25 @@
         [@ManagedPolicy settings["AWS_AUTOMATION_POLICIES"]?split(",") /]
     [/#if]
 
-    [#assign automationAccounts = asArray( (settings["AWS_AUTOMATION_ACCOUNTS"]!"")?eval ) ]
+    [#if (settings["AWS_AUTOMATION_ACCOUNTS"]!"")?has_content ]
+        [#assign automationAccounts = asArray( (settings["AWS_AUTOMATION_ACCOUNTS"]!"")?eval ) ]
 
-    [#assign automationAccountRoles = []]
-    [#list automationAccounts as automationAccount ]
-        [#assign automationAccountRoles += [
-                                                formatGlobalArn(
-                                                    "iam",
-                                                    formatRelativePath("role", awsAgentAutomationRole),
-                                                    automationAccount  )
-                                            ]]
-    [/#list]
+        [#assign automationAccountRoles = []]
+        [#list automationAccounts as automationAccount ]
+            [#assign automationAccountRoles += [
+                                                    formatGlobalArn(
+                                                        "iam",
+                                                        formatRelativePath("role", awsAgentAutomationRole),
+                                                        automationAccount  )
+                                                ]]
+        [/#list]
 
-    [@Policy
-        [
-            getPolicyStatement( ["sts:AssumeRole"], automationAccountRoles)
-        ]
-    /]
+        [@Policy
+            [
+                getPolicyStatement( ["sts:AssumeRole"], automationAccountRoles)
+            ]
+        /]
+    [/#if]
     [#break]
 
 [#case "_jenkinsecs" ]

--- a/legacy/fragment/fragment_jenkins.ftl
+++ b/legacy/fragment/fragment_jenkins.ftl
@@ -1,9 +1,10 @@
 [#case "jenkins"]
 [#case "_jenkins"]
 
-    [@Attributes image="jenkins-master" /]
-
     [#assign settings = _context.DefaultEnvironment]
+
+    [#assign jenkinsImage = settings["JENKINS_IMAGE"]!"hamletio/jenkins"]
+    [@Attributes image=jenkinsImage /]
 
     [#assign pingInterval = (settings["AGENT_PING_INTERVAL"])!"300" ]
     [#assign pingTimeout = (settings["AGENT_PING_TIMEOUT"])!"30"]
@@ -116,6 +117,14 @@
 
     [#if settings["CODEONTAPVOLUME"]?has_content ]
         [@Volume "codeontap" "/var/opt/codeontap/" settings["CODEONTAPVOLUME"] /]
+    [/#if]
+
+    [#if settings["PROPERTIESVOLUME"]?has_content ]
+        [@Volume
+            name="properties"
+            containerPath=(settings["PROPERTIES_DIR"])!"/var/opt/properties/"
+            hostPath=settings["PROPERTIESVOLUME"]
+        /]
     [/#if]
 
     [#break]


### PR DESCRIPTION
## Description
Adds support for a new properties volume which will replace the codeontap volume that we use to share data between the jenkins master and its agents via EFS

## Motivation and Context
Part of our rename from codeontap to hamlet. Chose a generic name ( properties ) to make things easier to understand

## How Has This Been Tested?
Tested in our codepublican deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [] To use the new volume the environment variable `PROPERTIESVOLUME` which will then mount to the containers under `/var/opt/properties` 
- [ ] Existing jenkins installations will need to update all properties file references to the new location - backwards compatability is available with the environment variable 'PROPERTIES_DIR' which controls where the directory will be mounted

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] None of the above.
