### PR TITLE
<fix> Include suboccurrences in unitlist

### DIFF
--- a/client/createUnitlist.ftl
+++ b/client/createUnitlist.ftl
@@ -21,6 +21,14 @@
                       asArray((occurrence.Configuration.Solution.DeploymentUnits)![]),
                       UNIQUE_COMBINE_BEHAVIOUR
                     )]
+          [#list (occurrence.Occurrences)![] as subOccurrence ]
+            [#local deploymentUnits =
+              combineEntities(
+                deploymentUnits,
+                asArray((subOccurrence.Configuration.Solution.DeploymentUnits)![]),
+                UNIQUE_COMBINE_BEHAVIOUR
+              )]
+          [/#list]
         [/#list]
       [/#if]
     [/#list]


### PR DESCRIPTION
## Description
Includes suboccurences in the unlist list assembly 

## Motivation and Context
the unit list allows you to find all of the deployment units for a given segment, this is useful for script deployments across units in bulk. It didn't include suboccurences though so you couldn't get everything

## How Has This Been Tested?
tested locally with `${GENERATION_DIR}/createTemplate.sh -l unitlist`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] None of the above.
