### PR TITLE
<feature> external service links

### DIFF
--- a/providers/shared/components/externalservice/id.ftl
+++ b/providers/shared/components/externalservice/id.ftl
@@ -43,6 +43,11 @@
             "Names" : ["Fragment", "Container"],
             "Type" : STRING_TYPE,
             "Default" : ""
+        },
+        {
+            "Names" : "Links",
+            "Subobjects" : true,
+            "Children" : linkChildrenConfiguration
         }
     ]
     provider=SHARED_PROVIDER

--- a/providers/shared/components/externalservice/state.ftl
+++ b/providers/shared/components/externalservice/state.ftl
@@ -12,6 +12,7 @@
     [/#if]
 
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
+    [#local contextLinks = getLinkTargets(occurrence) ]
     [#assign _context =
         {
             "Id" : fragment,
@@ -20,7 +21,7 @@
             "Version" : core.Version.Id,
             "DefaultEnvironment" : defaultEnvironment(occurrence, {}, {}),
             "Environment" : {},
-            "Links" : {},
+            "Links" : contextLinks,
             "BaselineLinks" : {},
             "DefaultCoreVariables" : false,
             "DefaultEnvironmentVariables" : true,


### PR DESCRIPTION
## Description
Adds link support on the externalservice component

## Motivation and Context
Adding link support to the external service component allows you to build attributes based on other components deployed in your solution, combined with fragment support this allows for a method of link indirection. 

One example where this is useful is for user pools and SPA's. User pools need to whitelist the auth urls that are used by the SPA to perform the login and logout actions. Linking through an external service allows us this whitelist to be populated using the SPA attributes along with additional Urls for local development 

## How Has This Been Tested?
Tested on local deployment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
