### PR TITLE
<fix> WAFRule Group Loading

### DIFF
--- a/providers/shared/references/WAFRuleGroup/id.ftl
+++ b/providers/shared/references/WAFRuleGroup/id.ftl
@@ -2,7 +2,7 @@
 
 [@addReference
     type=WAFRULEGROUP_REFERENCE_TYPE
-    pluralType="WAFRuleGroup"
+    pluralType="WAFRuleGroups"
     properties=[
             {
                 "Type"  : "Description",


### PR DESCRIPTION
## Description
Minor fix to the reference lookup of the WAF Rule groups

## Motivation and Context
Rule groups were not loading which meant that WAF rules were not being applied

## How Has This Been Tested?
TEsted with deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
