### PR TITLE
<feature> WAF GeoMatch Support

### DIFF
--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -650,6 +650,18 @@
     [#return valueIfTrue(true, asBoolean, cidrs) ]
 [/#function]
 
+[#function getGroupCountryCodes groups blacklist=false]
+    [#local codes = [] ]
+    [#list asFlattenedArray(groups) as group]
+        [#local groupEntry = (countryGroups[group])!{}]
+        [#if (groupEntry.Blacklist!false) == blacklist ]
+            [#local codes += asArray(groupEntry.Locations![]) ]
+        [/#if]
+    [/#list]
+    [#return codes]
+[/#function]
+
+
 [#-- Level utility support --]
 
 [#include "commonApplication.ftl"]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -533,7 +533,12 @@
         {
             "Names" : "IPAddressGroups",
             "Type" : ARRAY_OF_STRING_TYPE,
-            "Mandatory" : true
+            "Default" : []
+        },
+        {
+            "Names" : "CountryGroups",
+            "Type" : ARRAY_OF_STRING_TYPE,
+            "Default" : []
         },
         {
             "Names" : "OWASP",

--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -995,6 +995,8 @@
             ],
             "blacklistedips": [],
             "whitelistedips": [],
+            "blacklistedcountrycodes": [],
+            "whitelistedcountrycodes": [],
             "sqlheaders": [
               {
                 "Type": "HEADER",
@@ -1326,9 +1328,9 @@
               }
             ]
           },
-          "blacklist": {
+          "blacklistips": {
             "Type": "IPMatch",
-            "Description": "Blacklist",
+            "Description": "Blacklist IPs",
             "Filters": [
               {
                 "Targets": [
@@ -1337,13 +1339,35 @@
               }
             ]
           },
-          "whitelist": {
+          "whitelistips": {
             "Type": "IPMatch",
-            "Description": "Whitelist",
+            "Description": "Whitelist IPs",
             "Filters": [
               {
                 "Targets": [
                   "whitelistedips"
+                ]
+              }
+            ]
+          },
+          "blacklistcountries": {
+            "Type": "GeoMatch",
+            "Description": "Blacklist Countries",
+            "Filters": [
+              {
+                "Targets": [
+                  "blacklistedcountrycodes"
+                ]
+              }
+            ]
+          },
+          "whitelistcountries": {
+            "Type": "GeoMatch",
+            "Description": "Whitelist Countries",
+            "Filters": [
+              {
+                "Targets": [
+                  "whitelistedcountrycodes"
                 ]
               }
             ]
@@ -1452,22 +1476,42 @@
               }
             ]
           },
-          "blacklist": {
-            "Description": "Blacklist",
-            "NameSuffix": "blacklist",
+          "blacklistips": {
+            "Description": "Blacklist IPs",
+            "NameSuffix": "blacklistips",
             "Conditions": [
               {
-                "Condition": "blacklist",
+                "Condition": "blacklistips",
                 "Negated": false
               }
             ]
           },
-          "whitelist": {
-            "Description": "Whitelist",
-            "NameSuffix": "whitelist",
+          "whitelistips": {
+            "Description": "Whitelist IPs",
+            "NameSuffix": "whitelistips",
             "Conditions": [
               {
-                "Condition": "whitelist",
+                "Condition": "whitelistips",
+                "Negated": false
+              }
+            ]
+          },
+          "blacklistcountries": {
+            "Description": "Blacklist Countries",
+            "NameSuffix": "blacklistcountries",
+            "Conditions": [
+              {
+                "Condition": "blacklistcountries",
+                "Negated": false
+              }
+            ]
+          },
+          "whitelistcountries": {
+            "Description": "Whitelist Countries",
+            "NameSuffix": "whitelistcountries",
+            "Conditions": [
+              {
+                "Condition": "whitelistcountries",
                 "Negated": false
               }
             ]

--- a/providers/shared/references/WAFProfile/reference.ftl
+++ b/providers/shared/references/WAFProfile/reference.ftl
@@ -10,7 +10,7 @@
         [/#if]
         [#list ruleList as ruleListEntry]
             [#local conditionList = [] ]
-            [#list asArray((rules[ruleListEntry].Conditions))![] as condition]
+            [#list asArray((rules[ruleListEntry].Conditions)![]) as condition]
                 [#local conditionDetail = conditions[condition.Condition]!{} ]
                 [#if conditionDetail?has_content]
                     [#local conditionList += [

--- a/providers/shared/references/WAFRule/id.ftl
+++ b/providers/shared/references/WAFRule/id.ftl
@@ -46,7 +46,10 @@
         "ResourceType" : "ByteMatchSet",
         "TuplesAttributeKey" : "ByteMatchTuples"
     },
-    AWS_WAF_GEO_MATCH_CONDITION_TYPE : {},
+    AWS_WAF_GEO_MATCH_CONDITION_TYPE : {
+        "ResourceType" : "GeoMatchSet",
+        "TuplesAttributeKey" : "GeoMatchConstraints"
+    },
     AWS_WAF_IP_MATCH_CONDITION_TYPE : {
         "ResourceType" : "IPSet",
         "TuplesAttributeKey" : "IPSetDescriptors"

--- a/providers/shared/references/WAFRule/reference.ftl
+++ b/providers/shared/references/WAFRule/reference.ftl
@@ -67,6 +67,20 @@
     [#return result]
 [/#function]
 
+[#function formatWAFGeoMatchTuples filter={} valueSet={} ]
+    [#local result= [] ]
+    [#list getWAFValueList(filter.Targets, valueSet) as target]
+        [#local result += [
+                {
+                    "Type" : "Country",
+                    "Value" : target
+                }
+            ]
+        ]
+    [/#list]
+    [#return result]
+[/#function]
+
 [#function formatWAFSizeConstraintTuples filter={} valueSet={} ]
     [#local result = [] ]
     [#list getWAFValueList(filter.FieldsToMatch, valueSet) as field]

--- a/
+++ b/
@@ -1,0 +1,84 @@
+[1mdiff --git a/engine/setContext.ftl b/engine/setContext.ftl[m
+[1mindex 24d498e9..066ee057 100644[m
+[1m--- a/engine/setContext.ftl[m
+[1m+++ b/engine/setContext.ftl[m
+[36m@@ -650,12 +650,12 @@[m
+     [#return valueIfTrue(true, asBoolean, cidrs) ][m
+ [/#function][m
+ [m
+[31m-[#function getGroupCountryCodes countryGroups blacklist=false][m
+[32m+[m[32m[#function getGroupCountryCodes groups blacklist=false][m
+     [#local codes = [] ][m
+[31m-    [#list asFlattenedArray(countryGroups) as countryGroup][m
+[31m-        [#local group = (countryGroups[countryGroup])!{}][m
+[31m-        [#if (group.Blacklist!false) == blacklist)][m
+[31m-            [#local codes += asArray(group.Locations![]) ][m
+[32m+[m[32m    [#list asFlattenedArray(groups) as group][m
+[32m+[m[32m        [#local groupEntry = (countryGroups[group])!{}][m
+[32m+[m[32m        [#if (groupEntry.Blacklist!false) == blacklist ][m
+[32m+[m[32m            [#local codes += asArray(groupEntry.Locations![]) ][m
+         [/#if][m
+     [/#list][m
+     [#return codes][m
+[1mdiff --git a/providers/shared/inputsources/shared/masterdata.ftl b/providers/shared/inputsources/shared/masterdata.ftl[m
+[1mindex f4532711..b073e3a4 100644[m
+[1m--- a/providers/shared/inputsources/shared/masterdata.ftl[m
+[1m+++ b/providers/shared/inputsources/shared/masterdata.ftl[m
+[36m@@ -1351,7 +1351,7 @@[m
+             ][m
+           },[m
+           "blacklistcountries": {[m
+[31m-            "Type": "IPMatch",[m
+[32m+[m[32m            "Type": "GeoMatch",[m
+             "Description": "Blacklist Countries",[m
+             "Filters": [[m
+               {[m
+[36m@@ -1362,7 +1362,7 @@[m
+             ][m
+           },[m
+           "whitelistcountries": {[m
+[31m-            "Type": "IPMatch",[m
+[32m+[m[32m            "Type": "GeoMatch",[m
+             "Description": "Whitelist Countries",[m
+             "Filters": [[m
+               {[m
+[36m@@ -1486,7 +1486,7 @@[m
+               }[m
+             ][m
+           },[m
+[31m-          "whitelist": {[m
+[32m+[m[32m          "whitelistips": {[m
+             "Description": "Whitelist IPs",[m
+             "NameSuffix": "whitelistips",[m
+             "Conditions": [[m
+[36m@@ -1501,7 +1501,7 @@[m
+             "NameSuffix": "blacklistcountries",[m
+             "Conditions": [[m
+               {[m
+[31m-                "Condition": "blacklistcountrycodes",[m
+[32m+[m[32m                "Condition": "blacklistcountries",[m
+                 "Negated": false[m
+               }[m
+             ][m
+[36m@@ -1511,7 +1511,7 @@[m
+             "NameSuffix": "whitelistcountries",[m
+             "Conditions": [[m
+               {[m
+[31m-                "Condition": "whitelistcountrycodes",[m
+[32m+[m[32m                "Condition": "whitelistcountries",[m
+                 "Negated": false[m
+               }[m
+             ][m
+[1mdiff --git a/providers/shared/references/WAFProfile/reference.ftl b/providers/shared/references/WAFProfile/reference.ftl[m
+[1mindex 77378711..331f1bac 100644[m
+[1m--- a/providers/shared/references/WAFProfile/reference.ftl[m
+[1m+++ b/providers/shared/references/WAFProfile/reference.ftl[m
+[36m@@ -10,7 +10,7 @@[m
+         [/#if][m
+         [#list ruleList as ruleListEntry][m
+             [#local conditionList = [] ][m
+[31m-            [#list asArray((rules[ruleListEntry].Conditions))![] as condition][m
+[32m+[m[32m            [#list asArray((rules[ruleListEntry].Conditions)![]) as condition][m
+                 [#local conditionDetail = conditions[condition.Condition]!{} ][m
+                 [#if conditionDetail?has_content][m
+                     [#local conditionList += [[m


### PR DESCRIPTION
## Description
Add support for blacklisted and whitelisted geo matches in WAF configurations.

Countries will be allowed/blocked based no the blacklist status of the country group. The WAF configuration is the same as for Cloudfront;

```
"WAF" : { "CountryGroups" : "Australia"}
```

## Motivation and Context
This will permit regional APIs to to geoblocked.

## How Has This Been Tested?
Via deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [ ] merge corresponding AWS specific PR - https://github.com/hamlet-io/engine-plugin-aws/pull/13

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
