### PR TITLE
<feature> adaptor generic component

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -226,6 +226,18 @@
     [@Settings  variables /]
 [/#macro]
 
+[#macro ContextSetting name value ]
+    [#assign _context =
+                mergeObjects(
+                    _context,
+                    {
+                        "ContextSettings" : {
+                            name : value
+                        }
+                    }
+                )]
+[/#macro]
+
 [#macro Host name value]
     [#assign _context +=
         {
@@ -484,7 +496,12 @@
                         )
                         context.DefaultEnvironmentVariables
                     ) +
-                    context.Environment
+                    context.Environment +
+                    valueIfTrue(
+                        context.ContextSettings,
+                        ( context.ContextSettings?has_content && ! (serialisationConfig.Escaped)!true),
+                        {}
+                    )
                 )
         } ]
 [/#function]

--- a/providers/shared/components/adaptor/id.ftl
+++ b/providers/shared/components/adaptor/id.ftl
@@ -1,0 +1,33 @@
+[#ftl]
+
+[@addComponent
+    type=ADAPTOR_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A generic deployment process for non standard components"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "application"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : ["Fragment", "Container"],
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            }
+        ]
+/]

--- a/providers/shared/components/adaptor/setup.ftl
+++ b/providers/shared/components/adaptor/setup.ftl
@@ -1,0 +1,97 @@
+[#ftl]
+[#macro shared_adaptor_cf_generationcontract_application occurrence ]
+    [@addDefaultGenerationContract subsets=["prologue", "config", "epilogue" ] /]
+[/#macro]
+
+[#macro shared_adaptor_cf_setup_application occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
+
+    [#local core = occurrence.Core ]
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local resources = occurrence.State.Resources ]
+    [#local attributes = occurrence.State.Attributes ]
+
+    [#-- Baseline component lookup --]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData" ] )]
+
+    [#local codeSrcBucket = getRegistryEndPoint("scripts", occurrence)]
+    [#local codeSrcPrefix = formatRelativePath(
+                                getRegistryPrefix("scripts", occurrence),
+                                    productName,
+                                    getOccurrenceBuildScopeExtension(occurrence),
+                                    getOccurrenceBuildUnit(occurrence),
+                                    getOccurrenceBuildReference(occurrence))]
+
+    [#local buildSettings = occurrence.Configuration.Settings.Build ]
+    [#local buildRegistry = buildSettings["BUILD_FORMATS"].Value[0] ]
+
+    [#local asFiles = getAsFileSettings(occurrence.Configuration.Settings.Product) ]
+
+    [#local fragment = getOccurrenceFragmentBase(occurrence) ]
+
+    [#local contextLinks = getLinkTargets(occurrence) ]
+    [#assign _context =
+        {
+            "Id" : fragment,
+            "Name" : fragment,
+            "Instance" : core.Instance.Id,
+            "Version" : core.Version.Id,
+            "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks, baselineLinks),
+            "Environment" : {},
+            "ContextSettings" : {},
+            "Links" : contextLinks,
+            "BaselineLinks" : baselineLinks,
+            "DefaultCoreVariables" : false,
+            "DefaultEnvironmentVariables" : true,
+            "DefaultLinkVariables" : false,
+            "DefaultBaselineVariables" : false
+        }
+    ]
+
+    [#-- Add in fragment specifics including override of defaults --]
+    [#local fragmentId = formatFragmentId(_context)]
+    [#include fragmentList?ensure_starts_with("/")]
+
+    [#local EnvironmentSettings =
+        {
+            "Json" : {
+                "Escaped" : false
+            }
+        }
+    ]
+
+    [#local finalEnvironment = getFinalEnvironment(occurrence, _context, EnvironmentSettings) ]
+    [#if deploymentSubsetRequired("config", false)]
+        [@addToDefaultJsonOutput
+            content=finalEnvironment.Environment
+        /]
+    [/#if]
+
+    [#if deploymentSubsetRequired("epilogue", false) ]
+        [@addToDefaultBashScriptOutput
+            content=
+                getBuildScript(
+                    "src_zip",
+                    regionId,
+                    buildRegistry,
+                    productName,
+                    occurrence,
+                    buildRegistry + ".zip"
+                ) +
+                [
+                    "addToArray src \"$\{tmpdir}/src/\"",
+                    "unzip \"$\{src_zip}\" -d \"$\{src}\""
+                ] +
+                asFiles?has_content?then(
+                     findAsFilesScript("settingsFiles", asFiles),
+                     []
+                ) +
+                getLocalFileScript(
+                    "config",
+                    "$\{CONFIG}",
+                    configFileName
+                )
+            section="1-Start"
+        /]
+    [/#if]
+[/#macro]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1,6 +1,7 @@
 [#ftl]
 
 [#-- Known component types --]
+[#assign ADAPTOR_COMPONENT_TYPE = "adaptor"]
 
 [#assign APIGATEWAY_COMPONENT_TYPE = "apigateway"]
 [#assign APIGATEWAY_USAGEPLAN_COMPONENT_TYPE = "apiusageplan"]


### PR DESCRIPTION
## Description
Adds support for the adaptor component. This component has no resources and relies on fragment files to define how it works. It has a scripts code image and registry which can be used to deploy support files or code to make the adaptor component deploy

## Motivation and Context
Following on from the template component #1281 we also need a way to generically define any resource or script to deploy something. This essentially allows us to integrate with any thing we want 

## How Has This Been Tested?
Tested with a local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
