### PR TITLE
<fix> Crash when no context settings

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -498,7 +498,7 @@
                     ) +
                     context.Environment +
                     valueIfTrue(
-                        context.ContextSettings,
+                        context.ContextSettings!{},
                         ( context.ContextSettings?has_content && ! (serialisationConfig.Escaped)!true),
                         {}
                     )


### PR DESCRIPTION
## Description
When context settings were not present, getFinalEnvironment crashes.

## Motivation and Context
Configurations that did not use contextSettings would crash whenever processing a unit that created an environment using ```getFinalEnvironment()```

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
