### PR TITLE
<feature> Namespaced provider specific configuration attributes

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -204,8 +204,8 @@
     [#list getComponentResourceGroups(occurrence.Core.Type) as key, value]
         [#local placement = (occurrence.State.ResourceGroups[key].Placement)!{}]
         [#local attributes +=
-            value.Attributes[SHARED_ATTRIBUTES]![] +
-            value.Attributes[placement.Provider!""]![]]
+            (value.Attributes[SHARED_ATTRIBUTES]![]) +
+            (value.Attributes[placement.Provider!""]![]) ]
     [/#list]
     [#return attributes]
 [/#function]


### PR DESCRIPTION
## Description
Configuration attributes that are provider specific must now be prefixed with the provider value, e.g.

```
"aws:Parameter" : "xyz"
```

It also fixes a bug in the combining of shared and provider specific attributes, where the precedence of the missing value operator prevented the provider specific attributes from being considered.

## Motivation and Context
It is desirable to explicitly identify parameters which are targetted at a specific provider. It will also permit documentation to indicate what are the shared and provider specific attributes for a component.

To date, no provider specific attributes have been used so it is a good time to make this change. 

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
