### PR TITLE
<feature> container run mode explicit configuration

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -30,8 +30,8 @@
 [/#function]
 
 [#function getContainerMode container]
-    [#if (container.Mode!"")?has_content ]
-        [#return container.Mode ]
+    [#if container?is_hash && (container.RunMode!"")?has_content ]
+        [#return container.RunMode ]
     [#else]
         [#assign idParts = container?is_hash?then(
                             container.Id?split("-"),

--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -30,12 +30,16 @@
 [/#function]
 
 [#function getContainerMode container]
-    [#assign idParts = container?is_hash?then(
-                        container.Id?split("-"),
-                        container?split("-"))]
-    [#return idParts[1]?has_content?then(
-                idParts[1]?upper_case,
-                "WEB")]
+    [#if (container.Mode!"")?has_content ]
+        [#return container.Mode ]
+    [#else]
+        [#assign idParts = container?is_hash?then(
+                            container.Id?split("-"),
+                            container?split("-"))]
+        [#return idParts[1]?has_content?then(
+                    idParts[1]?upper_case,
+                    "WEB")]
+    [/#if]
 [/#function]
 
 [#-- Fragment List Macros --]

--- a/providers/shared/components/ecs/id.ftl
+++ b/providers/shared/components/ecs/id.ftl
@@ -103,6 +103,12 @@
                         "Default" : "default"
                     }
                 ]
+        },
+        {
+            "Names" : "Mode",
+            "Description" : "Sets the mode of a specific container within a task - defaults to the second half of a dash separated id",
+            "Type" : STRING_TYPE,
+            "Default" : ""
         }
     ]
 ]

--- a/providers/shared/components/ecs/id.ftl
+++ b/providers/shared/components/ecs/id.ftl
@@ -105,8 +105,8 @@
                 ]
         },
         {
-            "Names" : "Mode",
-            "Description" : "Sets the mode of a specific container within a task - defaults to the second half of a dash separated id",
+            "Names" : "RunMode",
+            "Description" : "A per container setting which can be used by the app to determine run mode for a container in a task - defaults to the second half of a dash separated id",
             "Type" : STRING_TYPE,
             "Default" : ""
         }


### PR DESCRIPTION
## Description
Allows the RunMode of a container to be explicitly set in the solution configuration. The existing mode setup is still the default. This just allows for it to be set explicitly 

## Motivation and Context
Wanted to use the mode to define a list of different modes that can be applied to a container that is part of a task

## How Has This Been Tested?
Tested on deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
