### PR TITLE
<fix> support codeontap and properties volume

### DIFF
--- a/legacy/fragment/fragment_hamlet.ftl
+++ b/legacy/fragment/fragment_hamlet.ftl
@@ -42,6 +42,13 @@
             hostPath=settings["CODEONTAPVOLUME"]
             readOnly=true
         /]
+    [#elseif settings["PROPERTIESVOLUME"]?has_content ]
+        [@Volume
+            name="codeontap"
+            containerPath="/var/opt/codeontap/"
+            hostPath=settings["PROPERTIESVOLUME"]
+            readOnly=true
+        /]
     [/#if]
 
     [#-- Validate that the appropriate settings have been provided for the container to work --]

--- a/legacy/fragment/fragment_jenkins.ftl
+++ b/legacy/fragment/fragment_jenkins.ftl
@@ -116,7 +116,17 @@
     [/#if]
 
     [#if settings["CODEONTAPVOLUME"]?has_content ]
-        [@Volume "codeontap" "/var/opt/codeontap/" settings["CODEONTAPVOLUME"] /]
+        [@Volume
+            name="codeontap"
+            containerPath="/var/opt/codeontap/"
+            hostPath=settings["CODEONTAPVOLUME"]
+        /]
+    [#elseif settings["PROPERTIESVOLUME"]?has_content ]
+        [@Volume
+            name="codeontap"
+            containerPath="/var/opt/codeontap/"
+            hostPath=settings["PROPERTIESVOLUME"]
+        /]
     [/#if]
 
     [#if settings["PROPERTIESVOLUME"]?has_content ]


### PR DESCRIPTION
## Description
Fixes an issue with the migration from the `/var/opt/codeontap/` to `/var/opt/properties` volumes which created a disconnect between the Jenkins master and the agents 

## Motivation and Context
To share shared properties between the agent and the jenkins master in container deployments we use an EFS share which is mounted to the same location in both the Jenkins master and agents. With the move to hamlet this was renamed from the codeontap directory to the properties directory. 

## How Has This Been Tested?
Tested on codepublican deployment 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
