### PR TITLE
Refactor - Move Environment Flow Logs to Shared

### DIFF
--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -11,7 +11,11 @@
             "Description": "Normally only one environment for the alm. Entry mainly here for naming consistency",
             "Category": "alm",
             "Operations": {
-              "Expiration": 90
+              "Expiration": 90,
+              "FlowLogs": {
+                "Enabled": true,
+                "Expiration": 7
+              }
             },
             "DomainBehaviours": {
               "Segment": "segmentInHost"
@@ -41,7 +45,11 @@
             "Description": "Prototyping environment according to DTO classification",
             "Category": "test",
             "Operations": {
-              "Expiration": 14
+              "Expiration": 14,
+              "FlowLogs": {
+                "Enabled": true,
+                "Expiration": 2
+              }
             },
             "DomainBehaviours": {
               "Segment": "segmentInHost"
@@ -53,7 +61,11 @@
             "Category": "stg",
             "MultiAZ": true,
             "Operations": {
-              "Expiration": 90
+              "Expiration": 90,
+              "FlowLogs": {
+                "Enabled": true,
+                "Expiration": 7
+              }
             },
             "DomainBehaviours": {
               "Segment": "segmentInHost"
@@ -65,7 +77,11 @@
             "Description": "Mainly for devs to confirm components work together",
             "Category": "test",
             "Operations": {
-              "Expiration": 30
+              "Expiration": 30,
+              "FlowLogs": {
+                "Enabled": true,
+                "Expiration": 7
+              }
             },
             "DomainBehaviours": {
               "Segment": "segmentInHost"
@@ -77,7 +93,11 @@
             "Description": "Execution of automated tests",
             "Category": "test",
             "Operations": {
-              "Expiration": 30
+              "Expiration": 30,
+              "FlowLogs": {
+                "Enabled": true,
+                "Expiration": 7
+              }
             },
             "DomainBehaviours": {
               "Segment": "segmentInHost"
@@ -89,7 +109,11 @@
             "Description": "Manual customer testing",
             "Category": "test",
             "Operations": {
-              "Expiration": 30
+              "Expiration": 30,
+              "FlowLogs": {
+                "Enabled": true,
+                "Expiration": 7
+              }
             },
             "DomainBehaviours": {
               "Segment": "segmentInHost"
@@ -102,7 +126,11 @@
             "Category": "test",
             "MultiAZ": true,
             "Operations": {
-              "Expiration": 30
+              "Expiration": 30,
+              "FlowLogs": {
+                "Enabled": true,
+                "Expiration": 7
+              }
             },
             "DomainBehaviours": {
               "Segment": "segmentInHost"
@@ -115,7 +143,11 @@
             "Category": "stg",
             "MultiAZ": true,
             "Operations": {
-              "Expiration": 90
+              "Expiration": 90,
+              "FlowLogs": {
+                "Enabled": true,
+                "Expiration": 7
+              }
             },
             "DomainBehaviours": {
               "Segment": "segmentInHost"
@@ -128,7 +160,11 @@
             "Category": "stg",
             "MultiAZ": true,
             "Operations": {
-              "Expiration": 90
+              "Expiration": 90,
+              "FlowLogs": {
+                "Enabled": true,
+                "Expiration": 7
+              }
             },
             "DomainBehaviours": {
               "Segment": "segmentInHost"
@@ -141,7 +177,11 @@
             "Category": "prod",
             "MultiAZ": true,
             "Operations": {
-              "Expiration": 365
+              "Expiration": 365,
+              "FlowLogs": {
+                "Enabled": true,
+                "Expiration": 7
+              }
             },
             "DomainBehaviours": {
               "Segment": "naked"
@@ -153,7 +193,11 @@
             "Description": "",
             "Category": "prod",
             "Operations": {
-              "Expiration": 90
+              "Expiration": 90,
+              "FlowLogs": {
+                "Enabled": true,
+                "Expiration": 7
+              }
             },
             "DomainBehaviours": {
               "Segment": "segmentInHost"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Moving the Environmental flow log configuration into the shared provider instead of AWS. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows for individual override by providers/users but also ensures a default setting is available for the usual environment names.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation and deployment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
