### PR TITLE
Feature - Sku Profiles

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -385,6 +385,20 @@ behaviour.
     [/#if]
 [/#function]
 
+[#function getSkuProfile occurrence type extensions... ]
+    [#local tc = formatComponentShortName(
+                    occurrence.Core.Tier,
+                    occurrence.Core.Component,
+                    extensions)]
+    [#local defaultProfile = "default"]
+    [#if (skuProfiles[defaultProfile][tc])??]
+        [#return skuProfiles[defaultProfile][tc]]
+    [/#if]
+    [#if (skuProfiles[defaultProfile][type])??]
+        [#return skuProfiles[defaultProfile][type]]
+    [/#if]
+[/#function]
+
 [#function getSecurityProfile profileName type engine="" ]
 
     [#local profile = (securityProfiles[profileName][type])!{} ]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -117,6 +117,10 @@
 [#assign wafConditions = getReferenceData(WAFCONDITION_REFERENCE_TYPE) ]
 [#assign wafValueSets = getReferenceData(WAFVALUESET_REFERENCE_TYPE) ]
 
+[#-- SKU --]
+[@addReferenceData type=SKU_PROFILE_REFERENCE_TYPE base=blueprintObject /]
+[#assign skuProfiles = getReferenceData(SKU_PROFILE_REFERENCE_TYPE) ]
+
 [#-- Regions --]
 [#if commandLineOptions.Regions.Segment?has_content]
     [#assign regionId = commandLineOptions.Regions.Segment]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR implements `skuProfiles` the loading of the skuProfiles reference type into the shared provider. Though the skuProfiles reference type exists within the Azure plugin, there is a current issue with the load-order of reference data from plugins that will be looked at in another ticket. This allows correct loading in the meantime.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Azure has a common concept of a SKU or "Stock Keeping Unit" (think of it like a make/model information) across many resources. The SKU requirements change across resources - sometimes its just a name to indicate the pricing tier of a resource you want, other times its make, model, family, generation etc. This reference type allows for the base provider to implement some default profiles within masterdata, whilst allowing customisation through the CMDB.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation alongside hamlet-io/engine-plugin-azure#112

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
