### PR TITLE
feature: public login provider support

### DIFF
--- a/providers/shared/components/userpool/id.ftl
+++ b/providers/shared/components/userpool/id.ftl
@@ -299,7 +299,7 @@
                 "Names" : "Engine",
                 "Description" : "The authentication provider type",
                 "Type" : STRING_TYPE,
-                "Values" : [ "SAML", "OIDC" ],
+                "Values" : [ "SAML", "OIDC", "Facebook", "Google", "Apple", "Amazon" ],
                 "Mandatory" : true
             },
             {
@@ -402,6 +402,101 @@
                         "Names" : "JwksUrl",
                         "Type" : STRING_TYPE,
                         "Default" : ""
+                    }
+                ]
+            },
+            {
+                "Names" : "Facebook",
+                "Children" : [
+                    {
+                        "Names" : "ClientId",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "ClientSecret",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "Scopes",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : [ "email", "public_profile" ]
+                    },
+                    {
+                        "Names" : "APIVersion",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    }
+                ]
+            },
+            {
+                "Names" : "Amazon",
+                "Children" : [
+                    {
+                        "Names" : "ClientId",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "ClientSecret",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "Scopes",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : [ "profile" ]
+                    }
+                ]
+            },
+            {
+                "Names" : "Google",
+                "Children" : [
+                    {
+                        "Names" : "ClientId",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "ClientSecret",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "Scopes",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : [ "openid", "profile", "email"  ]
+                    }
+                ]
+            },
+            {
+                "Names" : "Apple",
+                "Children" : [
+                    {
+                        "Names" : "ClientId",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "TeamId",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "KeyId",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "PriviateKey",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "Scopes",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : [ "email", "name"  ]
                     }
                 ]
             }


### PR DESCRIPTION
## Description
Enables the ability to configure userpool federation with the different public identity providers ( google, apple, amazon and facebook ) 

## Motivation and Context
Support public identity logins instead of just enterprise level providers ( SAML or OIDC )

## How Has This Been Tested?
Tested with a template generation on a userpool, haven't tested with an app as I didn't have one configured with the providers 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
