### PR TITLE
fix: Remove auth provider defaults

### DIFF
--- a/providers/shared/components/userpool/id.ftl
+++ b/providers/shared/components/userpool/id.ftl
@@ -343,8 +343,7 @@
                     {
                         "Names" : "MetadataUrl",
                         "Description" : "The SAML metadataUrl endpoint",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "EnableIDPSignOut",
@@ -359,13 +358,11 @@
                 "Children" : [
                     {
                         "Names" : "ClientId",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "ClientSecret",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "Scopes",
@@ -380,28 +377,23 @@
                     },
                     {
                         "Names" : "Issuer",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "AuthorizeUrl",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "TokenUrl",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "AttributesUrl",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "JwksUrl",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     }
                 ]
             },
@@ -410,13 +402,11 @@
                 "Children" : [
                     {
                         "Names" : "ClientId",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "ClientSecret",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "Scopes",
@@ -425,8 +415,7 @@
                     },
                     {
                         "Names" : "APIVersion",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     }
                 ]
             },
@@ -435,13 +424,11 @@
                 "Children" : [
                     {
                         "Names" : "ClientId",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "ClientSecret",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "Scopes",
@@ -455,13 +442,11 @@
                 "Children" : [
                     {
                         "Names" : "ClientId",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "ClientSecret",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "Scopes",
@@ -475,23 +460,19 @@
                 "Children" : [
                     {
                         "Names" : "ClientId",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "TeamId",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "KeyId",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Type" : STRING_TYPE
                     },
                     {
-                        "Names" : "PriviateKey",
-                        "Type" : STRING_TYPE,
-                        "Default" : ""
+                        "Names" : "PrivateKey",
+                        "Type" : STRING_TYPE
                     },
                     {
                         "Names" : "Scopes",


### PR DESCRIPTION
## Description
In order that missing configuration can be correctly reported, remove the defaults for most of the auth provider config settings.

Also correct a spelling error in one of the attributes.

## Motivation and Context
Defaulting logic wasn't detecting missing values.

## How Has This Been Tested?
Customer deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
