### PR TITLE
feature(gateway): link based gateways

### DIFF
--- a/providers/shared/components/gateway/id.ftl
+++ b/providers/shared/components/gateway/id.ftl
@@ -27,7 +27,7 @@
             {
                 "Names" : "Engine",
                 "Type" : STRING_TYPE,
-                "Values" : [ "natgw", "igw", "vpcendpoint" ],
+                "Values" : [ "natgw", "igw", "vpcendpoint", "endpoint" ],
                 "Required" : true
             },
             {
@@ -35,6 +35,42 @@
                 "Description" : "IP Address Groups which can access this gateway",
                 "Type" : ARRAY_OF_STRING_TYPE,
                 "Default" : [ "_localnet" ]
+            },
+            {
+                "Names" : "EndpointScope",
+                "Description" : "The scope of the endpoint gateway component",
+                "Values" : [ "network", "zone" ],
+                "Type" : STRING_TYPE,
+                "Mandatory" : true
+            },
+            {
+                "Names" : "EndpointType",
+                "Description" : "The type of the route resource",
+                "Values" : [ "Peering", "Transit", "NetworkInterface", "Instance" ],
+                "Mandatory" : true
+            },
+            {
+                "Names" : "Endpoints",
+                "Description" : "Endpoint Engine resources",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Zone",
+                        "Description" : "The zone the endpoint belongs to",
+                        "Type" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "Attribute",
+                        "Description" : "The attribute of the endpoint",
+                        "Type" : STRING_TYPE,
+                        "Mandatory" : true
+                    },
+                    {
+                        "Names" : "Link",
+                        "Description" : "The link to the component",
+                        "Children" : linkChildrenConfiguration
+                    }
+                ]
             }
         ]
 /]


### PR DESCRIPTION
## Description
Adds support for link based network gateways using the `endpoint` engine type 

## Motivation and Context

Allows for integration of complex network component setups like peering which are difficult to cooridinate with infrastructure as code deployments as they require two parties to setup the infrastructure at the same time. With the endpoint engine the details of the peering connection can be provided through an external component attribute. This can also be extended to support linking to other components which offer routing services such as vm instances or network interfaces
 
## How Has This Been Tested?
Tested on active deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
