### PR TITLE
refactor: Constrain usepool identity provider names

### DIFF
--- a/providers/shared/components/userpool/id.ftl
+++ b/providers/shared/components/userpool/id.ftl
@@ -248,8 +248,9 @@
             },
             {
                 "Names" : "AuthProviders",
-                "Description" : "A list of user pool auth providers which can use this client",
+                "Description" : "A list of user pool auth providers which can use this client. AuthProvider component names are constrained to these fixed values.",
                 "Type" : ARRAY_OF_STRING_TYPE,
+                "Values" : ["COGNITO", "Facebook", "Google", "LoginWithAmazon"],
                 "Default" : [ "COGNITO" ]
             },
             {


### PR DESCRIPTION
## Description
The names for identity providers for a client have fixed values so ensure only these names are used. The processing checks for that the identity provider is defined as an auth provider, so the names used for auth providers are effectively constrained as well.

## Motivation and Context
Maximise chance of configuration deploying first time.

## How Has This Been Tested?
Customer Deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
