### PR TITLE
fix(gateway): remove mandatory requirement on Endpoint details

### DIFF
--- a/providers/shared/components/gateway/id.ftl
+++ b/providers/shared/components/gateway/id.ftl
@@ -40,14 +40,12 @@
                 "Names" : "EndpointScope",
                 "Description" : "The scope of the endpoint gateway component",
                 "Values" : [ "network", "zone" ],
-                "Type" : STRING_TYPE,
-                "Mandatory" : true
+                "Type" : STRING_TYPE
             },
             {
                 "Names" : "EndpointType",
                 "Description" : "The type of the route resource",
-                "Values" : [ "Peering", "Transit", "NetworkInterface", "Instance" ],
-                "Mandatory" : true
+                "Values" : [ "Peering", "Transit", "NetworkInterface", "Instance" ]
             },
             {
                 "Names" : "Endpoints",


### PR DESCRIPTION
## Description
Make Endpoint Type and scope optional on gateway component

## Motivation and Context
Not required for all gateway types and when set to mandatory other gateway types could not be deployed as their configuration was invalid

## How Has This Been Tested?
Caught by testing and tested on local deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
