### PR TITLE
feat(mobileapp): OTA Support on CDN routes

### DIFF
--- a/providers/shared/components/mobileapp/id.ftl
+++ b/providers/shared/components/mobileapp/id.ftl
@@ -40,6 +40,12 @@
                 "Names" : ["Fragment", "Container"],
                 "Type" : STRING_TYPE,
                 "Default" : ""
+            },
+            {
+                "Names" : "UseOTAPrefix",
+                "Description" : "Include the OTA Prefix in the OTA Url",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
             }
         ]
 /]


### PR DESCRIPTION
## Description
Companion PR to https://github.com/hamlet-io/engine-plugin-aws/pull/36 
Allows you to specify the path behaviour for a mobile OTA 

## Motivation and Context
Backwards compatibility with the current mobile app deployment process

## How Has This Been Tested?
Tested on active deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
