### PR TITLE
feat(apigateway): support gateway and cdn https profiles

### DIFF
--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -1560,7 +1560,8 @@
               }
             },
             "apigateway": {
-              "HTTPSProfile": "TLSv1",
+              "CDNHTTPSProfile": "TLSv1",
+              "GatewayHTTPSProfile" : "TLS_1_0",
               "ProtocolPolicy": "redirect-to-https",
               "WAFProfile": "OWASP2017",
               "WAFValueSet": "default"

--- a/providers/shared/references/SecurityProfile/id.ftl
+++ b/providers/shared/references/SecurityProfile/id.ftl
@@ -45,8 +45,13 @@
             "Names" : "apigateway",
             "Children" : [
                 {
-                    "Names" : "HTTPSProfile",
+                    "Names" : [ "CDNHTTPSProfile" "HTTPSProfile"],
                     "Type" : STRING_TYPE
+                },
+                {
+                    "Names" : "GatewayHTTPSProfile",
+                    "Type" : STRING_TYPE,
+                    "Default" : "TLS_1_0"
                 },
                 {
                     "Names" : "ProtocolPolicy",

--- a/providers/shared/references/SecurityProfile/id.ftl
+++ b/providers/shared/references/SecurityProfile/id.ftl
@@ -45,7 +45,7 @@
             "Names" : "apigateway",
             "Children" : [
                 {
-                    "Names" : [ "CDNHTTPSProfile" "HTTPSProfile"],
+                    "Names" : [ "CDNHTTPSProfile", "HTTPSProfile"],
                     "Type" : STRING_TYPE
                 },
                 {


### PR DESCRIPTION
## Description
Allows for security profile configuration of API Gateway Custom domain names and if configured the CDN in front of the API Gateway. 

## Motivation and Context
When not using a CDN infront of an API Gateway you can still configure the TLS profile for the APIGateway itself. This is configured independently as providers use different values to set the profile configuration

## How Has This Been Tested?
Tested on live deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
