### PR TITLE
feat(jenkins): add support for permanent ecs agents

### DIFF
--- a/legacy/fragment/fragment_hamlet.ftl
+++ b/legacy/fragment/fragment_hamlet.ftl
@@ -84,6 +84,24 @@
             ]
         /]
     [/#if]
+
+    [#if (settings["JENKINS_PERMANENT_AGENT"]!"false")?boolean  ]
+
+        [#assign jenkinsUrl = settings["JENKINS_URL"] ]
+
+        [#if (settings["JENKINS_LOCAL_FQDN"]!"")?has_content ]
+            [#assign jenkinsUrl = "http://" + settings["JENKINS_LOCAL_FQDN"] + ":8080" ]
+        [/#if]
+
+        [@Command
+            [
+                "-url",
+                jenkinsUrl,
+                settings["JENKINS_PERMANENT_AGENT_SECRET"],
+                settings["JENKINS_PERMANENT_AGENT_NAME"]
+            ]
+        /]
+    [/#if]
     [#break]
 
 [#case "_jenkinsecs" ]


### PR DESCRIPTION
## Description
Adds support for jenkins hamlet agents to run as permanent jenkins agents along with ECS ephemeral agents. The expectation is that the these permanent agents will run as services on an ECS cluster alongside task based agents. 


## Motivation and Context
Permanent agents allow for agent level security to be configured when strict permissions are required on who can use the agent. 


## How Has This Been Tested?
Tested in Codepublican deployment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
