### PR TITLE
feat(fragment): startup command setting for agent

### DIFF
--- a/legacy/fragment/fragment_hamlet.ftl
+++ b/legacy/fragment/fragment_hamlet.ftl
@@ -20,7 +20,8 @@
     [@Settings {
         "AWS_AUTOMATION_USER" : "ROLE",
         "AWS_AUTOMATION_ROLE" : awsAgentAutomationRole,
-        "DOCKER_STAGE_DIR" : dockerStageDir
+        "DOCKER_STAGE_DIR" : dockerStageDir,
+        "STARTUP_COMMANDS" : (settings["STARTUP_COMMANDS"])!""
     }/]
 
     [@Volume


### PR DESCRIPTION
## Description
Supports the ability to add a startup command that is run when a container agent starts up

## Motivation and Context
Sometimes we need to shim in some commands whenever a jenkins agent starts up

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
