### PR TITLE
fix(fragment): agent override for aws user

### DIFF
--- a/legacy/fragment/fragment_hamlet.ftl
+++ b/legacy/fragment/fragment_hamlet.ftl
@@ -8,6 +8,8 @@
     [#assign dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/tmp/docker-build" ]
     [#assign dockerHostDaemon = settings["DOCKER_HOST_DAEMON"]!"/var/run/docker.sock"]
     [#assign jenkinsAgentImage = settings["DOCKER_AGENT_IMAGE"]!"hamletio/hamlet"]
+
+    [#assign awsAutomationUser = settings["AWS_AUTOMATION_USER"]!"ROLE" ]
     [#assign awsAgentAutomationRole = settings["AWS_AUTOMATION_ROLE"]!"codeontap-automation" ]
 
     [@Attributes image=jenkinsAgentImage /]
@@ -18,7 +20,7 @@
     [@DefaultBaselineVariables      enabled=false /]
 
     [@Settings {
-        "AWS_AUTOMATION_USER" : "ROLE",
+        "AWS_AUTOMATION_USER" : awsAutomationUser,
         "AWS_AUTOMATION_ROLE" : awsAgentAutomationRole,
         "DOCKER_STAGE_DIR" : dockerStageDir,
         "STARTUP_COMMANDS" : (settings["STARTUP_COMMANDS"])!""


### PR DESCRIPTION
## Description
Allows automation user to be overridden for hamlet jenkins agents. By default the user is set to ROLE, however you might want to have agents  which use fixed credentials for the agent.

## Motivation and Context
This is a fix to allow the user to configure the agent with sensible defaults

## How Has This Been Tested?
Test locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
