### PR TITLE
feat(globaldb): intial support for global dbs

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -54,6 +54,8 @@
 [#assign FEDERATEDROLE_COMPONENT_TYPE = "federatedrole" ]
 [#assign FEDERATEDROLE_ASSIGNMENT_COMPONENT_TYPE = "federatedroleassignment" ]
 
+[#assign GLOBALDB_COMPONENT_TYPE = "globaldb" ]
+
 [#assign LAMBDA_COMPONENT_TYPE = "lambda"]
 [#assign LAMBDA_FUNCTION_COMPONENT_TYPE = "function"]
 
@@ -818,6 +820,12 @@
         "Type"  : STRING_TYPE,
         "Values" : [ "provisioned", "per-request" ],
         "Default" : "provisioned"
+    },
+    {
+        "Names" : "Encrypted",
+        "Description" : "Enable Service side encryption",
+        "Type" : BOOLEAN_TYPE,
+        "Default" : true
     },
     {
         "Names" : "Capacity",

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -823,7 +823,7 @@
     },
     {
         "Names" : "Encrypted",
-        "Description" : "Enable Service side encryption",
+        "Description" : "Enable at rest encryption",
         "Type" : BOOLEAN_TYPE,
         "Default" : true
     },

--- a/providers/shared/components/globaldb/id.ftl
+++ b/providers/shared/components/globaldb/id.ftl
@@ -6,7 +6,7 @@
         [
             {
                 "Type"  : "Description",
-                "Value" : "A global database instance"
+                "Value" : "A global NoSQL database table"
             },
             {
                 "Type" : "Providers",
@@ -37,7 +37,7 @@
             },
             {
                 "Names" : "TTLKey",
-                "Description" : "A key in the table used to manage the items expiriy",
+                "Description" : "A key in the table used to manage the items expiry",
                 "Type" : STRING_TYPE,
                 "Default" : ""
             }

--- a/providers/shared/components/globaldb/id.ftl
+++ b/providers/shared/components/globaldb/id.ftl
@@ -1,0 +1,45 @@
+[#ftl]
+
+[@addComponent
+    type=GLOBALDB_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A global database instance"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "Table",
+                "Children" : dynamoDbTableChildConfiguration
+            },
+            {
+                "Names" : "PrimaryKey",
+                "Description" : "The primary key for the table",
+                "Type" : STRING_TYPE,
+                "Mandatory" : true
+            },
+            {
+                "Names" : "SecondaryKey",
+                "Description" : "The secondary sort key for the table",
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            },
+            {
+                "Names" : "TTLKey",
+                "Description" : "A key in the table used to manage the items expiriy",
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            }
+        ]
+/]


### PR DESCRIPTION
## Description
Adds a new component type, globaldb which represents managed NoSQL database tables

## Motivation and Context
While we have been leaving some of this configuration to be managed through application code there is quite a bit of system level configuration that you might want to control from the infrastructure as code perspective. 

While this does require some application logic as part of the infrastructure as code deployment to define some keys in the table, such as the primary and secondary keys. All other keys in the table can still be defined by the application. 

## How Has This Been Tested?
Tested locally using a live deployment CMDB in AWS

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
