### PR TITLE
refactor: Namespace matching support

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -368,36 +368,24 @@
 
 
 [#function internalCreateOccurrenceSettings possibilities root prefixes alternatives]
-    [#local contexts = [] ]
 
-    [#-- Order possibilities in increasing priority --]
+    [#-- Add the root to each prefix --]
+    [#local namespacePrefixes = [] ]
     [#list prefixes as prefix]
-        [#list possibilities?keys?sort as key]
-            [#local matchKey = key?lower_case?remove_ending("-asfile") ]
-            [#local value = possibilities[key] ]
-            [#if value?has_content]
-                [#list alternatives as alternative]
-                    [#local alternativeKey = formatName(root, prefix, alternative.Key) ]
-                    [@debug
-                        message=alternative.Match + " comparison of " + matchKey + " to " + alternativeKey
-                        enabled=false
-                    /]
-                    [#if
-                        (
-                            ((alternative.Match == "exact") && (alternativeKey == matchKey)) ||
-                            ((alternative.Match == "partial") && (alternativeKey?starts_with(matchKey)))
-                        ) ]
-                        [@debug
-                            message=alternative.Match + " comparison of " + matchKey + " to " + alternativeKey + " successful"
-                            enabled=false
-                        /]
-                        [#local contexts += [value] ]
-                        [#break]
-                    [/#if]
-                [/#list]
-            [/#if]
-        [/#list]
+        [#local namespacePrefixes += [formatName(root, prefix)] ]
     [/#list]
+
+    [#-- Get the keys of the matching possibilities --]
+    [#local matches = getMatchingNamespaces(possibilities?keys, namespacePrefixes, alternatives, ["-asfile"]) ]
+
+    [#-- Get the values of matching possibilities --]
+    [#local contexts = [] ]
+    [#list matches as match]
+        [#if possibilities[match]?has_content]
+            [#local contexts += [possibilities[match]] ]
+        [/#if]
+    [/#list]
+
     [#return asFlattenedSettings(getCompositeObject(["InhibitEnabled", { "Names" : "*" }], contexts)) ]
 [/#function]
 


### PR DESCRIPTION
## Description
Place the code that does namespace matching into its own routine and use this routine when processing occurrence settings.

## Motivation and Context
This is to enable reuse of this functionality as part of the dynamic CMDB work.

Essentially the plan is to use the same logic for assembly of solutions, potentially allowing the namespace concept we use for settings to enable selective inclusion of solution fragments based on name not hierarchical position.

## How Has This Been Tested?
Rerun existing template generation noting no change in templates.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
