### PR TITLE
feat(externalnetwork): intial external network support

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -49,6 +49,9 @@
 [#assign ES_COMPONENT_TYPE = "es"]
 [#assign ES_LEGACY_COMPONENT_TYPE = "elasticsearch"]
 
+[#assign EXTERNALNETWORK_COMPONENT_TYPE = "externalnetwork" ]
+[#assign EXTERNALNETWORK_CONNECTION_COMPONENT_TYPE = "externalnetworkconnection" ]
+
 [#assign EXTERNALSERVICE_COMPONENT_TYPE = "externalservice" ]
 
 [#assign FEDERATEDROLE_COMPONENT_TYPE = "federatedrole" ]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -183,6 +183,10 @@
             "Type" : STRING_TYPE
         },
         {
+            "Names" : [ "Connection" ],
+            "Type" : STRING_TYPE
+        },
+        {
             "Names" : [ "AuthProvider" ],
             "Type" : STRING_TYPE
         },

--- a/providers/shared/components/externalnetwork/id.ftl
+++ b/providers/shared/components/externalnetwork/id.ftl
@@ -1,0 +1,90 @@
+[#ftl]
+
+[@addComponent
+    type=EXTERNALNETWORK_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "An external private network segment which can integrate with other networks"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "segment"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "IPAddressGroups",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
+                "Names" : "BGP",
+                "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "ASN",
+                        "Description" : "The BGP ASN (Autonomous system) Id of the external network",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 65000
+                    }
+                ]
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=EXTERNALNETWORK_CONNECTION_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "An external network connection endpoint"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "segment"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Type" : BOOLEAN_TYPE,
+                "Values" : [ "SiteToSite" ]
+                "Default" : "SiteToSite"
+            },
+            {
+                "Names" : "SiteToSite",
+                "Children" : [
+                    {
+                        "Names" : "PublicIP",
+                        "Description" : "The public IP address of the VPN tunnel",
+                        "Type" : STRING_TYPE
+                    }
+                ]
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            }
+        ]
+    parent=EXTERNALNETWORK_COMPONENT_TYPE
+    childAttribute="Connnections"
+    linkAttributes="Connection"
+/]

--- a/providers/shared/components/externalnetwork/id.ftl
+++ b/providers/shared/components/externalnetwork/id.ftl
@@ -36,7 +36,7 @@
                         "Names" : "ASN",
                         "Description" : "The BGP ASN (Autonomous system) Id of the external network",
                         "Type" : NUMBER_TYPE,
-                        "Default" : 65000
+                        "Default" : 64512
                     }
                 ]
             }
@@ -64,8 +64,8 @@
         [
             {
                 "Names" : "Engine",
-                "Type" : BOOLEAN_TYPE,
-                "Values" : [ "SiteToSite" ]
+                "Type" : STRING_TYPE,
+                "Values" : [ "SiteToSite" ],
                 "Default" : "SiteToSite"
             },
             {
@@ -85,6 +85,6 @@
             }
         ]
     parent=EXTERNALNETWORK_COMPONENT_TYPE
-    childAttribute="Connnections"
+    childAttribute="Connections"
     linkAttributes="Connection"
 /]

--- a/providers/shared/components/gateway/id.ftl
+++ b/providers/shared/components/gateway/id.ftl
@@ -53,6 +53,22 @@
                 "Values" : [ "Peering", "Transit", "NetworkInterface", "Instance" ]
             },
             {
+                "Names" : "BGP",
+                "Description" : "BGP Network routing",
+                "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "ASN",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 65000
+                    }
+                ]
+            },
+            {
                 "Names" : "Endpoints",
                 "Description" : "Endpoint Engine resources",
                 "Subobjects" : true,
@@ -115,20 +131,15 @@
                 "Default" : []
             },
             {
+                "Names" : "DynamicRouting",
+                "Description" : "Use dynamic routing to determine destinations",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
                 "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
-            },
-            {
-                "Names" : "Private",
-                "Description" : "Private Network specific configuration",
-                "Children" : [
-                    {
-                        "Names" : "UseGatewayNetwork",
-                        "Description" : "Use the network provided by the gateway or its links",
-                        "Enabled" : true
-                    }
-                ]
             }
         ]
     parent=NETWORK_GATEWAY_COMPONENT_TYPE

--- a/providers/shared/components/gateway/id.ftl
+++ b/providers/shared/components/gateway/id.ftl
@@ -27,7 +27,7 @@
             {
                 "Names" : "Engine",
                 "Type" : STRING_TYPE,
-                "Values" : [ "natgw", "igw", "vpcendpoint", "endpoint", "router" ],
+                "Values" : [ "natgw", "igw", "vpcendpoint", "endpoint", "router", "private" ],
                 "Required" : true
             },
             {
@@ -118,6 +118,17 @@
                 "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Private",
+                "Description" : "Private Network specific configuration",
+                "Children" : [
+                    {
+                        "Names" : "UseGatewayNetwork",
+                        "Description" : "Use the network provided by the gateway or its links",
+                        "Enabled" : true
+                    }
+                ]
             }
         ]
     parent=NETWORK_GATEWAY_COMPONENT_TYPE

--- a/providers/shared/services/external/id.ftl
+++ b/providers/shared/services/external/id.ftl
@@ -1,4 +1,3 @@
 [#ftl]
 
 [#assign SHARED_EXTERNAL_RESOURCE_TYPE = "external" ]
-[#assign SHARED_EXTERNALNETWORK_RESOURCE_TYPE = "externalNetwork" ]

--- a/providers/shared/services/external/id.ftl
+++ b/providers/shared/services/external/id.ftl
@@ -1,3 +1,4 @@
 [#ftl]
 
 [#assign SHARED_EXTERNAL_RESOURCE_TYPE = "external" ]
+[#assign SHARED_EXTERNALNETWORK_RESOURCE_TYPE = "externalNetwork" ]


### PR DESCRIPTION
## Description
Adds support for the external network component, it represents networks connected via VPN's or private network connections that are not part of the cloud provider network

External network components have a subcomponent of connections, these represent the "physical" network link between a network and externalnetwork. A gateway and destination is still required to route the network traffic to the external network. 

## Motivation and Context
Support for representing networks as part of hamlet

## How Has This Been Tested?
Tested in local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
