### PR TITLE
feat(router): make BGP ASN mandatory

### DIFF
--- a/providers/shared/components/router/id.ftl
+++ b/providers/shared/components/router/id.ftl
@@ -35,7 +35,7 @@
                     },
                     {
                         "Names" : "ASN",
-                        "Description" : "The private BGP ASN ( Autonomous system) Id of the router",
+                        "Description" : "The BGP ASN ( Autonomous system ) Id of the router",
                         "Type" : NUMBER_TYPE,
                         "Mandatory" : true
                     },

--- a/providers/shared/components/router/id.ftl
+++ b/providers/shared/components/router/id.ftl
@@ -37,7 +37,7 @@
                         "Names" : "ASN",
                         "Description" : "The private BGP ASN ( Autonomous system) Id of the router",
                         "Type" : NUMBER_TYPE,
-                        "Default" : 64512
+                        "Mandatory" : true
                     },
                     {
                         "Names" : "ECMP",


### PR DESCRIPTION
## Description
Make BGP ASN mandatory for routers 

## Motivation and Context
Even when not using BGP for dyanamic routing providers often still require the BGP ASN to be specified. This allows for different mixes of routing on network resources. To ensure they are unique between the different components they are now mandatory for router components

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
