### PR TITLE
feat(privateservice): intial support for private services

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -81,6 +81,8 @@
 
 [#assign OBJECTSQL_COMPONENT_TYPE = "objectsql"]
 
+[#assign PRIVATE_SERVICE_COMPONENT_TYPE = "privateservice" ]
+
 [#assign S3_COMPONENT_TYPE = "s3" ]
 
 [#assign SERVICE_REGISTRY_COMPONENT_TYPE = "serviceregistry" ]

--- a/providers/shared/components/privateservice/id.ftl
+++ b/providers/shared/components/privateservice/id.ftl
@@ -1,0 +1,66 @@
+[#ftl]
+
+[@addComponent
+    type=PRIVATE_SERVICE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "Private service offering to other entities"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "DomainName",
+                "Children" : domainNameChildConfiguration
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Sharing",
+                "Children" : [
+                    {
+                        "Names" : "Principals",
+                        "Description" : "A list of external entities to share the service with",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : []
+                    },
+                    {
+                        "Names" : "ApprovalRequired",
+                        "Description" : "Manual approval required for the service to be consumed",
+                        "Default" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "ConnectionAlerts",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Events",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Values" : [ "Accept", "Connect", "Delete", "Reject" ],
+                        "Default" : [ "Accept", "Reject" ]
+                    },
+                    {
+                        "Names" : "Links",
+                        "Description" : "Link to send alerts to",
+                        "Subobjects" : true,
+                        "Children" : linkChildrenConfiguration
+                    }
+                ]
+            }
+        ]
+/]


### PR DESCRIPTION
## Description
Adds a new component, private services 

## Motivation and Context
Private services are used to offer application services between two networks over a cloud providers private networking. This is commonly used for SaaS offerings in security sensitive areas where the service shouldn't be available over the internet 

From AWS this is know as PrivateLink

## How Has This Been Tested?
Tested on local deployment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
