### PR TITLE
feat(router): static route support

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -78,6 +78,7 @@
 [#assign NETWORK_ROUTE_TABLE_COMPONENT_TYPE = "networkroute"]
 
 [#assign NETWORK_ROUTER_COMPONENT_TYPE = "router"]
+[#assign NETWORK_ROUTER_STATIC_ROUTE_COMPONENT_TYPE = "routerstaticroute" ]
 
 [#assign OBJECTSQL_COMPONENT_TYPE = "objectsql"]
 

--- a/providers/shared/components/router/id.ftl
+++ b/providers/shared/components/router/id.ftl
@@ -48,3 +48,47 @@
             }
         ]
 /]
+
+[@addChildComponent
+    type=NETWORK_ROUTER_STATIC_ROUTE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A Static route defined on the router"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "IPAddressGroups",
+                "Description" : "The Destinations of the static route",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Mandatory" : true
+            },
+            {
+                "Names" : "Action",
+                "Description" : "How to handle the route",
+                "Type" : STRING_TYPE,
+                "Values" : [ "forward", "blackhole" ],
+                "Default" : "forward"
+            },
+            {
+                "Names" : "Links",
+                "Description" : "Links to the routing destination",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            }
+        ]
+    parent=NETWORK_ROUTER_COMPONENT_TYPE
+    childAttribute="StaticRoutes"
+    linkAttributes="StaticRoute"
+/]


### PR DESCRIPTION
## Description
Adds support for the router component to define its own static routes. Other components can still define their own routes if that is supported

## Motivation and Context
This was motivated by a couple of things 
- When using a shared AWS transit Gateway routing cannot be defined in the AWS account that the transit gateway is shared with it can only be managed from the account which owns the transit gateway. So in this scenario the router needs to control where to forward traffic 
- Allow for configuring blackhole routes on the router to drop traffic destined to locations it shouldn't go 

## How Has This Been Tested?
Tested in local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
