### PR TITLE
feat(gateway): dns configuration support

### DIFF
--- a/providers/shared/components/gateway/id.ftl
+++ b/providers/shared/components/gateway/id.ftl
@@ -90,6 +90,13 @@
                         "Children" : linkChildrenConfiguration
                     }
                 ]
+            },
+            {
+                "Names" : "DNSSupport",
+                "Description" : "Configure a private DNS zone for the serivces offerred by the endpoint",
+                "Type" : [ STRING_TYPE, BOOLEAN_TYPE ],
+                "Values" : [ "UseNetworkConfig", "Disabled", "Enabled", true, false ],
+                "Default" : "UseNetworkConfig"
             }
         ]
 /]


### PR DESCRIPTION
## Description
Adds support on gateways to control the gateway DNS zone provisioning 

## Motivation and Context
When using vpcendpoint gateways which require acceptance you can only provision DNS zones when the endpoint has been accepted. The current configuration for the DNS zone determination was based on the network configuration, this is still the default, and this configuration just allows for overriding that.

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
