### PR TITLE
External endpoints

### DIFF
--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -487,7 +487,14 @@ are added.
 
 [#function getHostsFromNetwork networkCIDR ]
     [#local networkIPs = getSubnetsFromNetwork(networkCIDR, 32)?map(cidr -> (cidr?split("/"))[0] )]
-    [#return networkIPs[1..(networkIPs?size - 2)]]
+
+    [#-- networks with greater than 2 hosts ( i.e. above /31 ) --]
+    [#-- reserve the first and last address and can't be used for hosts --]
+    [#if networkIPs?size - 2 > 1 ]
+        [#return networkIPs[1..(networkIPs?size - 2)]]
+    [#else]
+        [#return networkIPs]
+    [/#if]
 [/#function]
 
 [#----------------------------

--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -485,6 +485,11 @@ are added.
     [#return IPAddress__getSubNetworks(networkCIDR, subnetCIDRMask )?eval ]
 [/#function]
 
+[#function getHostsFromNetwork networkCIDR ]
+    [#local networkIPs = getSubnetsFromNetwork(networkCIDR, 32)?map(cidr -> (cidr?split("/"))[0] )]
+    [#return networkIPs[1..(networkIPs?size - 2)]]
+[/#function]
+
 [#----------------------------
 -- Dynamic template loading --
 ------------------------------]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -53,6 +53,7 @@
 [#assign EXTERNALNETWORK_CONNECTION_COMPONENT_TYPE = "externalnetworkconnection" ]
 
 [#assign EXTERNALSERVICE_COMPONENT_TYPE = "externalservice" ]
+[#assign EXTERNALSERVICE_ENDPOINT_COMPONENT_TYPE = "externalserviceendpoint" ]
 
 [#assign FEDERATEDROLE_COMPONENT_TYPE = "federatedrole" ]
 [#assign FEDERATEDROLE_ASSIGNMENT_COMPONENT_TYPE = "federatedroleassignment" ]
@@ -211,6 +212,10 @@
         },
         {
             "Names" : [ "Route" ],
+            "Type"  : STRING_TYPE
+        },
+        {
+            "Names" : [ "Endpoint" ],
             "Type"  : STRING_TYPE
         },
         {

--- a/providers/shared/components/externalservice/id.ftl
+++ b/providers/shared/components/externalservice/id.ftl
@@ -17,11 +17,6 @@
                 "Value" : "solution"
             }
         ]
-    attributes=[]
-/]
-
-[@addResourceGroupInformation
-    type=EXTERNALSERVICE_COMPONENT_TYPE
     attributes=[
         {
             "Names" : "Properties",
@@ -50,6 +45,46 @@
             "Children" : linkChildrenConfiguration
         }
     ]
+/]
+
+[@addChildComponent
+    type=EXTERNALSERVICE_ENDPOINT_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "An endpoint of an external serivce normally an IP address or collection"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "shared" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "solution"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "IPAddressGroups",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
+                "Names" : "Port",
+                "Type" : STRING_TYPE,
+                "Default" : ""
+            }
+        ]
+    parent=EXTERNALSERVICE_COMPONENT_TYPE
+    childAttribute="Endpoints"
+    linkAttributes="Endpoint"
+/]
+
+[@addResourceGroupInformation
+    type=EXTERNALSERVICE_COMPONENT_TYPE
+    attributes=[]
     provider=SHARED_PROVIDER
     resourceGroup=DEFAULT_RESOURCE_GROUP
     services=[

--- a/providers/shared/components/externalservice/state.ftl
+++ b/providers/shared/components/externalservice/state.ftl
@@ -59,3 +59,25 @@
         }
     ]
 [/#macro]
+
+[#macro shared_externalserviceendpoint_default_state occurrence parent={} ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#assign componentState =
+        {
+            "Resources" : {
+                "externalEndpoint" : {
+                    "Id" : formatId(SHARED_EXTERNAL_RESOURCE_TYPE, core.Id),
+                    "Name" : core.FullName,
+                    "Type" : SHARED_EXTERNAL_RESOURCE_TYPE
+                }
+            },
+            "Attributes" : {},
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#macro]

--- a/providers/shared/components/lb/id.ftl
+++ b/providers/shared/components/lb/id.ftl
@@ -219,6 +219,17 @@
                         "Names" : "DeregistrationTimeout",
                         "Type" : NUMBER_TYPE,
                         "Default" : 30
+                    },
+                    {
+                        "Names" : "StaticEndpoints",
+                        "Description" : "Static endpoints for the load balancing port",
+                        "Children"  : [
+                            {
+                                "Names" : "Links",
+                                "Subobjects" : true,
+                                "Children" : linkChildrenConfiguration
+                            }
+                        ]
                     }
                 ]
             }


### PR DESCRIPTION
## Description
- Adds support for external endpoints, endpoints represent the IP/port of an external service and the ability to set static endpoints for load balancing
- Also adds a utility to provide the usable hosts in a given network 

## Motivation and Context
The intention here is to use external service endpoints in network access control or routing. For example you might want to proxy traffic to an external endpoint through a cloud hosted load balancer. In this case you can use a link from the Load balancer using the StaticEndpoints Links also introduced in this PR to route traffic to this external endpoint. 

 In future work this can also be used to control Egress Security group access so that you can link to an external service and these endpoints will be used for the Access control rules  

## How Has This Been Tested?
Tested on local deployment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
