### PR TITLE
Gateway Destination ports

### DIFF
--- a/providers/shared/components/gateway/id.ftl
+++ b/providers/shared/components/gateway/id.ftl
@@ -27,7 +27,7 @@
             {
                 "Names" : "Engine",
                 "Type" : STRING_TYPE,
-                "Values" : [ "natgw", "igw", "vpcendpoint", "endpoint", "router", "private" ],
+                "Values" : [ "natgw", "igw", "vpcendpoint", "privateservice", "endpoint", "router", "private" ],
                 "Required" : true
             },
             {
@@ -50,7 +50,7 @@
             {
                 "Names" : "EndpointType",
                 "Description" : "The type of the route resource",
-                "Values" : [ "Peering", "Transit", "NetworkInterface", "Instance" ]
+                "Values" : [ "Peering", "NetworkInterface", "Instance" ]
             },
             {
                 "Names" : "BGP",
@@ -88,6 +88,17 @@
                         "Names" : "Link",
                         "Description" : "The link to the component",
                         "Children" : linkChildrenConfiguration
+                    }
+                ]
+            },
+            {
+                "Names" : "PrivateServices",
+                "Children" : [
+                    {
+                        "Names" : "DestinationPorts",
+                        "Description" : "The ports of services avaialble from the private service",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Default" : [ "https" ]
                     }
                 ]
             },

--- a/providers/shared/components/gateway/id.ftl
+++ b/providers/shared/components/gateway/id.ftl
@@ -92,15 +92,10 @@
                 ]
             },
             {
-                "Names" : "PrivateServices",
-                "Children" : [
-                    {
-                        "Names" : "DestinationPorts",
-                        "Description" : "The ports of services avaialble from the private service",
-                        "Type" : ARRAY_OF_STRING_TYPE,
-                        "Default" : [ "https" ]
-                    }
-                ]
+                "Names" : "DestinationPorts",
+                "Description" : "The ports of services avaialble from the private service",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : [ "any" ]
             },
             {
                 "Names" : "DNSSupport",


### PR DESCRIPTION
## Description

1.  Adds support for setting the destination ports on a gateway, defaulting to any. 
2. Adds a new engine type, privateservice which is intended to replace the existing vpcendpoint engine. 
  - Component developers should support both engines for the time being but treat them as the same gateway engine
3. Removes transit gateway as a endpoint engine gateway type 

## Motivation and Context
1. This allows for fine grain access control to be applied on gateways if required for security purposes 
2. This aligns with the name of the new private service component which is the other half of the of the vpc endpoint implementation  and also makes the naming more vendor agnostic 
3. This now has its own engine as part of the router engine 

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
