### PR TITLE
feat: Bucket cleanup optional when copying files

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -850,7 +850,7 @@ behaviour.
 
 [/#function]
 
-[#function syncFilesToBucketScript filesArrayName region bucket prefix]
+[#function syncFilesToBucketScript filesArrayName region bucket prefix cleanup=true]
     [#return
         [
             "case $\{STACK_OPERATION} in",
@@ -869,7 +869,8 @@ behaviour.
                    "\"" + bucket         + "\"" + " " +
                    "\"" + prefix         + "\"" + " " +
                    "\"" + filesArrayName + "\"" + " " +
-                   "--delete || return $?",
+                   valueIfTrue("--delete", cleanup, "") +
+                   " || return $?",
             "    ;;",
             " esac",
             "#"


### PR DESCRIPTION
## Description
Add the ability to control the --delete flag.

## Motivation and Context
To permit stacks to be rolled back, it needs to be possible to copy files to S3 without deleting existing files as part of a prologue script, and for the operation to be repeated after successful stack update but with unneeded files now deleted.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
