### PR TITLE
External Service Endpoint attributes

### DIFF
--- a/providers/shared/components/externalservice/state.ftl
+++ b/providers/shared/components/externalservice/state.ftl
@@ -64,16 +64,32 @@
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
+    [#local cidrs = getGroupCIDRs(solution.IPAddressGroups, true, occurrence)]
+    [#local hosts = []]
+    [#list cidrs as cidr ]
+        [#local hosts = combineEntities(hosts, getHostsFromNetwork(cidr), UNIQUE_COMBINE_BEHAVIOUR) ]
+    [/#list]
+
+    [#local port = ports[solution.Port]]
+
+    [#local parentAttributes = parent.State.Attributes ]
+
     [#assign componentState =
         {
             "Resources" : {
                 "externalEndpoint" : {
                     "Id" : formatId(SHARED_EXTERNAL_RESOURCE_TYPE, core.Id),
                     "Name" : core.FullName,
-                    "Type" : SHARED_EXTERNAL_RESOURCE_TYPE
+                    "Type" : SHARED_EXTERNAL_RESOURCE_TYPE,
+                    "Deployed" : true
                 }
             },
-            "Attributes" : {},
+            "Attributes" : parentAttributes +
+            {
+                "HOST" : hosts?join(","),
+                "PORT" : port.Port,
+                "PROTOCOL" : port.Protocol
+            },
             "Roles" : {
                 "Inbound" : {},
                 "Outbound" : {}

--- a/providers/shared/components/externalservice/state.ftl
+++ b/providers/shared/components/externalservice/state.ftl
@@ -65,9 +65,9 @@
     [#local solution = occurrence.Configuration.Solution]
 
     [#local cidrs = getGroupCIDRs(solution.IPAddressGroups, true, occurrence)]
-    [#local hosts = []]
+    [#local hostIPs = []]
     [#list cidrs as cidr ]
-        [#local hosts = combineEntities(hosts, getHostsFromNetwork(cidr), UNIQUE_COMBINE_BEHAVIOUR) ]
+        [#local hostIPs = combineEntities(hosts, getHostsFromNetwork(cidr), UNIQUE_COMBINE_BEHAVIOUR) ]
     [/#list]
 
     [#local port = ports[solution.Port]]
@@ -86,7 +86,7 @@
             },
             "Attributes" : parentAttributes +
             {
-                "IP" : hosts?join(","),
+                "IP" : hostIPs?join(","),
                 "PORT" : port.Port,
                 "PROTOCOL" : port.Protocol
             },

--- a/providers/shared/components/externalservice/state.ftl
+++ b/providers/shared/components/externalservice/state.ftl
@@ -86,7 +86,7 @@
             },
             "Attributes" : parentAttributes +
             {
-                "HOST" : hosts?join(","),
+                "IP" : hosts?join(","),
                 "PORT" : port.Port,
                 "PROTOCOL" : port.Protocol
             },


### PR DESCRIPTION
## Description
- Set attributes for external service endpoints based on the IP Address Group and Port configuration 
- Minor fix to mark external service endpoints as deployed

## Motivation and Context
When linking to an endpoint it would be useful to get this information as attributes inline with our other components

## How Has This Been Tested?
tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
