### PR TITLE
fix(externalservice): fix var name for ip listing

### DIFF
--- a/providers/shared/components/externalservice/state.ftl
+++ b/providers/shared/components/externalservice/state.ftl
@@ -67,7 +67,7 @@
     [#local cidrs = getGroupCIDRs(solution.IPAddressGroups, true, occurrence)]
     [#local hostIPs = []]
     [#list cidrs as cidr ]
-        [#local hostIPs = combineEntities(hosts, getHostsFromNetwork(cidr), UNIQUE_COMBINE_BEHAVIOUR) ]
+        [#local hostIPs = combineEntities(hostIPs, getHostsFromNetwork(cidr), UNIQUE_COMBINE_BEHAVIOUR) ]
     [/#list]
 
     [#local port = ports[solution.Port]]


### PR DESCRIPTION
## Description
Minor fix to align with the variable used for host IP's. Was originally set to hosts but changed at the end of development

## Motivation and Context
Broken

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
