### PR TITLE
feat(externalnetwork+gateway): vpn security profile

### DIFF
--- a/providers/shared/components/externalnetwork/id.ftl
+++ b/providers/shared/components/externalnetwork/id.ftl
@@ -82,6 +82,16 @@
                 "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : [
+                    {
+                        "Names" : "Security",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
             }
         ]
     parent=EXTERNALNETWORK_COMPONENT_TYPE

--- a/providers/shared/components/gateway/id.ftl
+++ b/providers/shared/components/gateway/id.ftl
@@ -153,6 +153,16 @@
                 "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : [
+                    {
+                        "Names" : "Security",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
             }
         ]
     parent=NETWORK_GATEWAY_COMPONENT_TYPE

--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -1584,6 +1584,27 @@
             },
             "es": {
               "ProtocolPolicy": "https-only"
+            },
+            "IPSecVPN" : {
+              "IKEVersions" : [ "ikev1", "ikev2" ],
+              "Rekey" : {
+                "MarginTime" : 540,
+                "FuzzPercentage" : 100
+              },
+              "ReplayWindowSize" : 1024,
+              "DeadPeerDetectionTimeout" : 30,
+              "Phase1" : {
+                "EncryptionAlgorithms" : [ "AES256" ],
+                "IntegrityAlgorithms" : [ "SHA2-256" ],
+                "DiffeHellmanGroups" : [ 18, 22, 23, 24 ],
+                "Lifetime" : 3600
+              },
+              "Phase2" : {
+                "EncryptionAlgorithms" : [ "AES256" ],
+                "IntegrityAlgorithms" : [ "SHA2-256" ],
+                "DiffeHellmanGroups" : [ 18, 22, 23, 24 ],
+                "Lifetime" : 3600
+              }
             }
           }
         },

--- a/providers/shared/references/SecurityProfile/id.ftl
+++ b/providers/shared/references/SecurityProfile/id.ftl
@@ -111,6 +111,82 @@
                     "Values" : [ "https-only", "http-https", "http-only" ]
                 }
             ]
+        },
+        {
+            "Names" : "IPSecVPN",
+            "Children" : [
+                {
+                    "Names" : "TunnelInsideCidr",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Names" : "IKEVersions",
+                    "Type" : ARRAY_OF_STRING_TYPE
+                },
+                {
+                    "Names" : "Rekey",
+                    "Children" : [
+                        {
+                            "Names" : "MarginTime",
+                            "Type" : NUMBER_TYPE
+                        },
+                        {
+                            "Names" : "FuzzPercentage",
+                            "Type" : NUMBER_TYPE
+                        }
+                    ]
+                },
+                {
+                    "Names" : "ReplayWindowSize",
+                    "Type" : NUMBER_TYPE
+                },
+                {
+                    "Names" : "DeadPeerDetectionTimeout",
+                    "Type" : NUMBER_TYPE
+                },
+                {
+                    "Names" : "Phase1",
+                    "Children" : [
+                        {
+                            "Names" : "EncryptionAlgorithms",
+                            "Type" : ARRAY_OF_STRING_TYPE
+                        },
+                        {
+                            "Names" : "IntegrityAlgorithms",
+                            "Type" : ARRAY_OF_STRING_TYPE
+                        },
+                        {
+                            "Names" : "DiffeHellmanGroups",
+                            "Type" : ARRAY_OF_NUMBER_TYPE
+                        }
+                        {
+                            "Names" : "Lifetime",
+                            "Type" : NUMBER_TYPE
+                        }
+                    ]
+                },
+                {
+                    "Names" : "Phase2",
+                    "Children" : [
+                        {
+                            "Names" : "EncryptionAlgorithms",
+                            "Type" : ARRAY_OF_STRING_TYPE
+                        },
+                        {
+                            "Names" : "IntegrityAlgorithms",
+                            "Type" : ARRAY_OF_STRING_TYPE
+                        },
+                        {
+                            "Names" : "DiffeHellmanGroups",
+                            "Type" : ARRAY_OF_NUMBER_TYPE
+                        }
+                        {
+                            "Names" : "Lifetime",
+                            "Type" : NUMBER_TYPE
+                        }
+                    ]
+                }
+            ]
         }
     ]
 /]


### PR DESCRIPTION
## Description
Adds support for configuring IPSec Site to Site VPN options using a security profile
adds a default IPSec profile based on high security standards

## Motivation and Context
To ensure compliance with other network devices and security requirements we need to be able to configure the IPSec security configuration. Making this a security profile allows for standardised configuration across a deployment as these options can be quite complicated

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
