### PR TITLE
fix(bastion): allow ssh when internet access disabled

### DIFF
--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -361,8 +361,7 @@
 
     [#assign rotateKeys = (segmentObject.RotateKeys)!true]
 
-    [#assign sshEnabled = internetAccess &&
-                            ((segmentObject.SSH.Enabled)!(segmentObject.Bastion.Enabled)!true)]
+    [#assign sshEnabled = ((segmentObject.SSH.Enabled)!(segmentObject.Bastion.Enabled)!true)]
     [#assign sshActive = sshEnabled &&
                             ((segmentObject.SSH.Active)!(segmentObject.Bastion.Active)!false)]
     [#if (commandLineOptions.Deployment.Provider.Names)?seq_contains("aws")]


### PR DESCRIPTION
## Description
Allow SSH bastion instances to be deployed regardless of internet status

## Motivation and Context
When deploying an SSH bastion instance with SSM Console access you can still enable access to the instance without enabling internet access

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
