### PR TITLE
feat(ec2): volume encryption

### DIFF
--- a/legacy/account/account_cmk.ftl
+++ b/legacy/account/account_cmk.ftl
@@ -1,0 +1,85 @@
+[#-- Account level CMK --]
+[#if getDeploymentUnit()?contains("cmk") || (allDeploymentUnits!false) ]
+    [#if deploymentSubsetRequired("generationcontract", false)]
+        [@addDefaultGenerationContract subsets="template" /]
+    [/#if]
+
+    [@includeServicesConfiguration
+        provider=AWS_PROVIDER
+        services=AWS_KEY_MANAGEMENT_SERVICE
+        deploymentFramework=CLOUD_FORMATION_DEPLOYMENT_FRAMEWORK
+    /]
+
+    [#assign cmkKeyId = formatAccountCMKTemplateId()]
+    [#assign cmkKeyName = formatName("account", "cmk")]
+
+    [#assign cmkKeyAliasId = formatDependentResourceId(AWS_CMK_ALIAS_RESOURCE_TYPE, cmkKeyId)]
+    [#assign cmkKeyAliasName = formatRelativePath( "alias", formatName("account", "cmk")) ]
+
+    [#if deploymentSubsetRequired("cmk", true) && isPartOfCurrentDeploymentUnit(cmkKeyId)]
+
+        [@createCMK
+            id=cmkKeyId
+            description=cmkKeyName
+            statements=
+                [
+                    getPolicyStatement(
+                        "kms:*",
+                        "*",
+                        {
+                            "AWS": formatAccountPrincipalArn()
+                        }
+                    ),
+                    getPolicyStatement(
+                        [
+                            "kms:Encrypt",
+                            "kms:Decrypt",
+                            "kms:ReEncrypt*",
+                            "kms:GenerateDataKey*",
+                            "kms:DescribeKey"
+                        ],
+                        "*",
+                        {
+                            "AWS": [
+                                formatGlobalArn(
+                                    "iam",
+                                    "role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+                                )
+                            ]
+                        },
+                        {},
+                        true,
+                        "AutoScale Service Linked Role"
+                    ),
+                    getPolicyStatement(
+                        [
+                            "kms:CreateGrant"
+                        ],
+                        "*",
+                        {
+                            "AWS": [
+                                formatGlobalArn(
+                                    "iam",
+                                    "role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+                                )
+                            ]
+                        },
+                        {
+                            "Bool": {
+                                "kms:GrantIsForAWSResource": true
+                            }
+                        },
+                        true,
+                        "AutoScale Attachment of persistent resources"
+                    )
+                ]
+        /]
+
+        [@createCMKAlias
+            id=cmkKeyAliasId
+            name=cmkKeyAliasName
+            cmkId=cmkKeyId
+        /]
+
+    [/#if]
+[/#if]

--- a/legacy/account/account_volumeencrypt.ftl
+++ b/legacy/account/account_volumeencrypt.ftl
@@ -1,0 +1,59 @@
+[#-- Volume Encryption --]
+[#if getDeploymentUnit()?contains("volumeencrypt") || (allDeploymentUnits!false) ]
+    [#if deploymentSubsetRequired("generationcontract", false)]
+        [@addDefaultGenerationContract subsets="epilogue" /]
+    [/#if]
+
+    [@includeServicesConfiguration
+        provider=AWS_PROVIDER
+        services=[
+            AWS_KEY_MANAGEMENT_SERVICE,
+            AWS_ELASTIC_COMPUTE_SERVICE
+        ]
+        deploymentFramework=CLOUD_FORMATION_DEPLOYMENT_FRAMEWORK
+    /]
+
+    [#assign volumeEncryptResourceId = formatEC2AccountVolumeEncryptionId() ]
+    [#assign volumeEncryptionEnabled = true ]
+
+    [#assign kmsKeyArn = getExistingReference(formatAccountCMKTemplateId(), ARN_ATTRIBUTE_TYPE)]
+
+    [#if ! kmsKeyArn?has_content ]
+        [@fatal
+            message="Account CMK not found"
+            detail="Create account level CMK before enabling volume encryption"
+        /]
+    [/#if]
+
+    [#if deploymentSubsetRequired("epilogue", false) ]
+        [@addToDefaultBashScriptOutput
+            content=
+                [
+                    r'case ${STACK_OPERATION} in',
+                    r'  create|update)',
+                    r'      info "Managing EBS Volume Encryption state..."',
+                    r'      manage_ec2_volume_encryption' +
+                    r'      "' + region + r'" ' +
+                    r'      "true"' +
+                    r'      "' + kmsKeyArn + r'"'
+                ] +
+                pseudoStackOutputScript(
+                    "Volume Encryption",
+                    {
+                        volumeEncryptResourceId : volumeEncryptionEnabled?c
+                    }
+                ) +
+                [
+                    r'      ;;',
+                    r' delete)',
+                    r'      info "Managing EBS Volume Encryption state..."',
+                    r'      manage_ec2_volume_encryption' +
+                    r'      "' + region + r'" ' +
+                    r'      "false"' +
+                    r'      "alias/aws/ebs"'
+                    r'      ;;',
+                    r'esac'
+                ]
+        /]
+    [/#if]
+[/#if]


### PR DESCRIPTION
## Description
Adds account level units to support enabling region wide ebs volume encryption 
This is implemented as two new account level deployment units 
- cmk - which creates an account level CMK
- volumeencrypt - which enables or disables default volume encryption if the CMK is available 

## Motivation and Context
AWS has introduced a global encryption setting for EBS volumes in a region which allows you to automatically encrypt all volumes at rest

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
