### PR TITLE
fix(account): only run cmk checks in specific units

### DIFF
--- a/legacy/account/account_console.ftl
+++ b/legacy/account/account_console.ftl
@@ -31,7 +31,9 @@
     [#assign consoleDocumentDependencies = []]
 
     [#assign accountCMKId = formatAccountCMKTemplateId()]
-    [#if ! getExistingReference(formatAccountCMKTemplateId())?has_content ]
+
+    [#if deploymentSubsetRequired("console", true) &&
+            ! getExistingReference(formatAccountCMKTemplateId())?has_content ]
         [@fatal
             message="Account CMK not found"
             detail="Run the cmk deployment at the account level to create the CMK"

--- a/legacy/account/account_volumeencrypt.ftl
+++ b/legacy/account/account_volumeencrypt.ftl
@@ -18,14 +18,15 @@
 
     [#assign kmsKeyArn = getExistingReference(formatAccountCMKTemplateId(), ARN_ATTRIBUTE_TYPE)]
 
-    [#if ! kmsKeyArn?has_content ]
-        [@fatal
-            message="Account CMK not found"
-            detail="Create account level CMK before enabling volume encryption"
-        /]
-    [/#if]
-
     [#if deploymentSubsetRequired("epilogue", false) ]
+
+        [#if ! kmsKeyArn?has_content ]
+            [@fatal
+                message="Account CMK not found"
+                detail="Create account level CMK before enabling volume encryption"
+            /]
+        [/#if]
+
         [@addToDefaultBashScriptOutput
             content=
                 [


### PR DESCRIPTION
## Description
Add deployment unit filter to cmk required checks to allow for subset passes to work

## Motivation and Context
if you choose not to use the encryption hardening account level units then the cmk isn't required. These checks should only be run if you have specified the use of the encryption units

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
