### PR TITLE
Network Profiles and Security Group Control

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -392,6 +392,10 @@ behaviour.
 
 [/#function]
 
+[#function getNetworkProfile profileName  ]
+    [#return (networkProfiles[profileName])!{} ]
+[/#function]
+
 [#function getNetworkEndpoints endpointGroups zone region ]
     [#local services = []]
     [#local networkEndpoints = {}]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -89,6 +89,10 @@
 [@addReferenceData type=SECURITYPROFILE_REFERENCE_TYPE base=blueprintObject /]
 [#assign securityProfiles = getReferenceData(SECURITYPROFILE_REFERENCE_TYPE) ]
 
+[#-- Network Profiles --]
+[@addReferenceData type=NETWORKPROFILE_REFERENCE_TYPE base=blueprintObject /]
+[#assign networkProfiles = getReferenceData(NETWORKPROFILE_REFERENCE_TYPE) ]
+
 [#-- Baseline Profiles --]
 [@addReferenceData type=BASELINEPROFILE_REFERENCE_TYPE base=blueprintObject /]
 [#assign baselineProfiles = getReferenceData(BASELINEPROFILE_REFERENCE_TYPE) ]
@@ -367,8 +371,6 @@
     [#if (commandLineOptions.Deployment.Provider.Names)?seq_contains("aws")]
         [#assign sshFromProxySecurityGroup = getExistingReference(formatSSHFromProxySecurityGroupId())]
     [/#if]
-
-    [#assign consoleOnly = (segmentObject.ConsoleOnly)!false]
 
     [#assign operationsExpiration =
         (segmentObject.Operations.Expiration)!

--- a/providers/shared/components/bastion/id.ftl
+++ b/providers/shared/components/bastion/id.ftl
@@ -48,6 +48,11 @@
                             "Names" : "Processor",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Network",
+                            "Type":  STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },

--- a/providers/shared/components/cache/id.ftl
+++ b/providers/shared/components/cache/id.ftl
@@ -33,6 +33,16 @@
                 "Type" : STRING_TYPE
             },
             {
+                "Names" : "IPAddressGroups",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : [ "_localnet" ]
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
                 "Names" : "Backup",
                 "Children" : [
                     {
@@ -53,6 +63,11 @@
                         },
                         {
                             "Names" : "Alert",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
+                            "Names" : "Network",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
                         }

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -891,6 +891,33 @@
     }
 ]]
 
+[#assign networkRuleChildConfiguration = [
+    {
+        "Names" : "Ports",
+        "Description" : "A list of port ids from the Ports reference",
+        "Type" : ARRAY_OF_STRING_TYPE,
+        "Default" : []
+    },
+    {
+        "Names" : "IPAddressGroups",
+        "Description" : "A list of IP Address groups ids from the IPAddressGroups reference",
+        "Type" : ARRAY_OF_STRING_TYPE,
+        "Default" : []
+    },
+    {
+        "Names" : "SecurityGroups",
+        "Description" : "A list of security groups or ids - for internal use only",
+        "Type" : ARRAY_OF_STRING_TYPE,
+        "Default" : []
+    },
+    {
+        "Names" : "Description",
+        "Description" : "A description that will be applied to the rule",
+        "Type" : STRING_TYPE,
+        "Default" : ""
+    }
+]]
+
 [#-- Not for general use - framework only --]
 [#assign coreProfileChildConfiguration = [
     {

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -37,6 +37,11 @@
                             "Names" : "Processor",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Network",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },

--- a/providers/shared/components/configstore/id.ftl
+++ b/providers/shared/components/configstore/id.ftl
@@ -63,7 +63,7 @@
             },
             {
                 "Names" : "States",
-                "Descrption" : "A writable attribute in the config branch",
+                "Description" : "A writable attribute in the config branch",
                 "Subobjects" : true,
                 "Children" : [
                     {

--- a/providers/shared/components/datapipeline/id.ftl
+++ b/providers/shared/components/datapipeline/id.ftl
@@ -62,6 +62,11 @@
                             "Names" : "Processor",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Network",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             }

--- a/providers/shared/components/db/id.ftl
+++ b/providers/shared/components/db/id.ftl
@@ -47,6 +47,11 @@
                 "Type" : STRING_TYPE
             },
             {
+                "Names" : "IPAddressGroups",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : [ "_localnet" ]
+            },
+            {
                 "Names" : "Encrypted",
                 "Type" : BOOLEAN_TYPE,
                 "Default" : false
@@ -150,6 +155,11 @@
                         },
                         {
                             "Names" : "Security",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
+                            "Names" : "Network",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
                         }

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -47,6 +47,11 @@
                             "Names" : "Processor",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Network",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },

--- a/providers/shared/components/ecs/id.ftl
+++ b/providers/shared/components/ecs/id.ftl
@@ -177,6 +177,11 @@
                             "Names" : "Alert",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Network",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },
@@ -373,6 +378,11 @@
                             "Names" : "Processor",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Network",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },
@@ -496,6 +506,11 @@
                     [
                         {
                             "Names" : "Alert",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
+                            "Names" : "Network",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
                         }

--- a/providers/shared/components/efs/id.ftl
+++ b/providers/shared/components/efs/id.ftl
@@ -23,6 +23,26 @@
                 "Names" : "Encrypted",
                 "Type" : BOOLEAN_TYPE,
                 "Default" : true
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : [
+                    {
+                        "Names" : "Network",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
+            },
+            {
+                "Names" : "IPAddressGroups",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : [ "_localnet" ]
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
             }
         ]
 /]

--- a/providers/shared/components/es/id.ftl
+++ b/providers/shared/components/es/id.ftl
@@ -88,6 +88,11 @@
                             "Names" : "Security",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Network",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },

--- a/providers/shared/components/externalnetwork/id.ftl
+++ b/providers/shared/components/externalnetwork/id.ftl
@@ -25,6 +25,11 @@
                 "Default" : []
             },
             {
+                "Names" : "Ports",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : [ "any" ]
+            },
+            {
                 "Names" : "BGP",
                 "Children" : [
                     {

--- a/providers/shared/components/externalservice/state.ftl
+++ b/providers/shared/components/externalservice/state.ftl
@@ -91,8 +91,19 @@
                 "PROTOCOL" : port.Protocol
             },
             "Roles" : {
-                "Inbound" : {},
-                "Outbound" : {}
+                "Inbound" : {
+                    "networkacl" : {
+                        "IPAddressGroups" : solution.IPAddressGroups,
+                        "Description" : core.FullName
+                    }
+                },
+                "Outbound" : {
+                    "networkacl" : {
+                        "Ports" : solution.Port,
+                        "IPAddressGroups" : solution.IPAddressGroups,
+                        "Description" : core.FullName
+                    }
+                }
             }
         }
     ]

--- a/providers/shared/components/gateway/id.ftl
+++ b/providers/shared/components/gateway/id.ftl
@@ -103,6 +103,16 @@
                 "Type" : [ STRING_TYPE, BOOLEAN_TYPE ],
                 "Values" : [ "UseNetworkConfig", "Disabled", "Enabled", true, false ],
                 "Default" : "UseNetworkConfig"
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : [
+                    {
+                        "Names" : "Network",
+                        "Description" : "The network profile for the gateway",
+                        "Default" : "default"
+                    }
+                ]
             }
         ]
 /]

--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -199,6 +199,11 @@
                             "Names" : "Alert",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Network",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },

--- a/providers/shared/components/lb/id.ftl
+++ b/providers/shared/components/lb/id.ftl
@@ -99,7 +99,7 @@
             {
                 "Names" : "IPAddressGroups",
                 "Type" : ARRAY_OF_STRING_TYPE,
-                "Default" : []
+                "Default" : [ "_localnet" ]
             },
             {
                 "Names" : "Certificate",
@@ -128,6 +128,16 @@
                 "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : [
+                    {
+                        "Names" : "Network",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
             },
             {
                 "Names" : "Authentication",

--- a/providers/shared/inputsources/mock/blueprint.ftl
+++ b/providers/shared/inputsources/mock/blueprint.ftl
@@ -39,7 +39,6 @@
                 "Bastion": {
                     "Active": false
                 },
-                "ConsoleOnly": true,
                 "multiAZ": true
             },
             "IPAddressGroups": {},

--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -669,6 +669,17 @@
               "Timeout": "5"
             }
           },
+          "nfs": {
+            "Port": 2049,
+            "Protocol": "TCP",
+            "IPProtocol": "tcp",
+            "HealthCheck": {
+              "HealthyThreshold": "3",
+              "UnhealthyThreshold": "5",
+              "Interval": "30",
+              "Timeout": "5"
+            }
+          },
           "hsmtp": {
             "Port": 2025,
             "Protocol": "TCP",
@@ -1604,6 +1615,16 @@
                 "IntegrityAlgorithms" : [ "SHA2-256" ],
                 "DiffeHellmanGroups" : [ 18, 22, 23, 24 ],
                 "Lifetime" : 3600
+              }
+            }
+          }
+        },
+        "NetworkProfiles" :{
+          "default" : {
+            "BaseSecurityGroup" : {
+              "Outbound" : {
+                "IPAddressGroups" : [ "_global" ],
+                "Ports" : [ "any" ]
               }
             }
           }

--- a/providers/shared/references/NetworkProfiles/id.ftl
+++ b/providers/shared/references/NetworkProfiles/id.ftl
@@ -1,0 +1,30 @@
+[#ftl]
+
+[@addReference
+    type=NETWORKPROFILE_REFERENCE_TYPE
+    pluralType="NetworkProfiles"
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "A profile to desribe network level controls"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "BaseSecurityGroup",
+            "Children" : [
+                {
+                    "Names" : "Links",
+                    "Description" : "Apply network security rules based on links",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                },
+                {
+                    "Names" : "Outbound",
+                    "Description" : "Network level Rules to apply",
+                    "Children" : networkRuleChildConfiguration
+                }
+            ]
+        }
+    ]
+/]

--- a/providers/shared/references/reference.ftl
+++ b/providers/shared/references/reference.ftl
@@ -38,6 +38,7 @@
 [#assign CORSPROFILE_REFERENCE_TYPE = "CORSProfile" ]
 [#assign SCRIPTSTORE_REFERENCE_TYPE = "ScriptStore" ]
 [#assign SECURITYPROFILE_REFERENCE_TYPE = "SecurityProfile" ]
+[#assign NETWORKPROFILE_REFERENCE_TYPE = "NetworkProfile" ]
 
 [#assign TESTCASE_REFERENCE_TYPE = "TestCase" ]
 [#assign TESTPROFILE_REFERENCE_TYPE = "TestProfile" ]


### PR DESCRIPTION
## Description
Adds support for Network Profiles as part of adding support  fine grained security group management 
Network Profiles move control over the default security group rules from hard-coded values in component implementations into the solution itself. 

The Network profile offers an initial list set of security group rules which will be applied to a component. Currently it supports two ways of specifying rules, through links to components or through network Rules which list port and IP Address combinations. 

Only outbound rules are controlled through the network profile and the default outbound rule is currently set to allow all outbound access, inline with cloud provider defaults and with the current configuration.

Ingress rules are still maintained on each component using the IPAddressGroups and Ports properties, this is to maintain compatibility and it is not easy to define global rules for inbound access while maintaining good security practice. Some components which had implied rules for the IPAddressGroups and Ports have now been made available in the component configuration

Links used in the Network Profile can control either inbound or outbound access based on how the link is configured. 

## Motivation and Context
Our current network security policy is to restrict inbound network access and allow all outbound network access. For services which can not route via the internet we also allow full inbound access from within the VPC. This stance is useful from a usability and quick deployment perspective but doesn't meet the requirements of highly secure environments. 

This PR allows for the network security policy to be controlled by the user rather than defined in our component code

## How Has This Been Tested?
Tested on all components which have been updated including deployments of each component 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
