### PR TITLE
feat: S3 Bucket encryption

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -433,17 +433,35 @@
         ) +
         valueIfTrue(
             s3ReadPermission(baselineIds["OpsData"], getSettingsFilePrefix(occurrence)) +
-            s3ListPermission(baselineIds["OpsData"], getSettingsFilePrefix(occurrence)),
+            s3ListPermission(baselineIds["OpsData"], getSettingsFilePrefix(occurrence)) +
+            s3EncryptionReadPermission(
+                baselineIds["Encryption"],
+                getExistingReference(baselineIds["OpsData"], NAME_ATTRIBUTE_TYPE),
+                getSettingsFilePrefix(occurrence),
+                getExistingReference(baselineIds["OpsData"], REGION_ATTRIBUTE_TYPE)
+            ),
             permissions.AsFile,
             []
         ) +
         valueIfTrue(
-            s3AllPermission(baselineIds["AppData"], getAppDataFilePrefix(occurrence)),
+            s3AllPermission(baselineIds["AppData"], getAppDataFilePrefix(occurrence)) +
+            s3EncryptionAllPermission(
+                baselineIds["Encryption"],
+                getExistingReference(baselineIds["AppData"], NAME_ATTRIBUTE_TYPE),
+                getAppDataFilePrefix(occurrence),
+                getExistingReference(baselineIds["AppData"], REGION_ATTRIBUTE_TYPE)
+            ),
             permissions.AppData,
             []
         ) +
         valueIfTrue(
-            s3AllPermission(baselineIds["AppData"], getAppDataPublicFilePrefix(occurrence)),
+            s3AllPermission(baselineIds["AppData"], getAppDataPublicFilePrefix(occurrence)) +
+            s3EncryptionAllPermission(
+                baselineIds["Encryption"],
+                getExistingReference(baselineIds["AppData"], NAME_ATTRIBUTE_TYPE),
+                getAppDataPublicFilePrefix(occurrence),
+                getExistingReference(baselineIds["AppData"], REGION_ATTRIBUTE_TYPE)
+            ),
             permissions.AppPublic && getAppDataPublicFilePrefix(occurrence)?has_content,
             []
         )

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -166,8 +166,13 @@
 
     [#if (commandLineOptions.Deployment.Provider.Names)?seq_contains("aws")]
         [#assign credentialsBucket = getExistingReference(formatAccountS3Id("credentials"))]
+        [#assign credentialsBucketRegion = getExistingReference(formatAccountS3Id("credentials"), REGION_ATTRIBUTE_TYPE)]
+
         [#assign codeBucket = getExistingReference(formatAccountS3Id("code")) ]
+        [#assign codeBucketRegion = getExistingReference(formatAccountS3Id("code"), REGION_ATTRIBUTE_TYPE)]
+
         [#assign registryBucket = getExistingReference(formatAccountS3Id("registry")) ]
+        [#assign registryBucketRegion = getExistingReference(formatAccountS3Id("registry"), REGION_ATTRIBUTE_TYPE)]
     [/#if]
 
     [#assign categoryName = "account"]

--- a/legacy/account/account_audit.ftl
+++ b/legacy/account/account_audit.ftl
@@ -7,6 +7,8 @@
             [@addDefaultGenerationContract subsets="template" /]
         [/#if]
 
+        [#assign s3EncryptionEnabled = (accountObject.S3.Encryption.Enabled)!false ]
+
         [#if deploymentSubsetRequired("audit", true)]
             [#assign lifecycleRules = []]
 
@@ -20,31 +22,14 @@
 
             [#assign sqsNotifications = []]
 
-            [@cfResource
+            [@createS3Bucket
                 id=formatAccountS3Id("audit")
-                type="AWS::S3::Bucket"
-                properties=
-                    {
-                        "BucketName" : formatName("account", "audit", accountObject.Seed),
-                        "AccessControl" : "LogDeliveryWrite",
-                        "VersioningConfiguration" : {
-                            "Status" : "Enabled"
-                        }
-                    } +
-                    attributeIfContent(
-                        "LifecycleConfiguration",
-                        lifecycleRules,
-                        {
-                            "Rules" : lifecycleRules
-                        }) +
-                    attributeIfContent(
-                        "NotificationConfiguration",
-                        sqsNotifications,
-                        {
-                            "QueueConfigurations" : sqsNotifications
-                        })
-                tags=getCfTemplateCoreTags("", "", "", "", false, false, 7)
-                outputs=S3_OUTPUT_MAPPINGS
+                name=formatName("account", "audit", accountObject.Seed)
+                encrypted=s3EncryptionEnabled
+                encryptionSource="AES256"
+                lifecycleRules=lifecycleRules
+                versioning=true
+                cannedACL="LogDeliveryWrite"
             /]
         [/#if]
     [#else]

--- a/providers/shared/components/baseline/id.ftl
+++ b/providers/shared/components/baseline/id.ftl
@@ -216,6 +216,10 @@
                 "Names" : "Notifications",
                 "Subobjects" : true,
                 "Children" : s3NotificationChildConfiguration
+            },
+            {
+                "Names" : "Encryption",
+                "Children" : s3EncryptionChildConfiguration
             }
         ]
     parent=BASELINE_COMPONENT_TYPE

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -830,6 +830,22 @@
     }
 ]]
 
+[#assign s3EncryptionChildConfiguration = [
+    {
+        "Names" : "Enabled",
+        "Description" : "Enable at rest encryption",
+        "Type" : BOOLEAN_TYPE,
+        "Default" : false
+    },
+    {
+        "Names" : "EncryptionSource",
+        "Type" : STRING_TYPE,
+        "Description" : "The encryption service to use - LocalService = S3, EncryptionService = native encryption service (kms)",
+        "Values" : [ "EncryptionService", "LocalService" ],
+        "Default" : "EncryptionService"
+    }
+]]
+
 [#assign dynamoDbTableChildConfiguration = [
     {
         "Names" : "Billing",

--- a/providers/shared/components/s3/id.ftl
+++ b/providers/shared/components/s3/id.ftl
@@ -112,6 +112,10 @@
                 ]
             },
             {
+                "Names" : "Encryption",
+                "Children" : s3EncryptionChildConfiguration
+            },
+            {
                 "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration


### PR DESCRIPTION
## Description
Adds support for configuring S3 Bucket At rest default encryption. Any object can be uploaded to a bucket and the client can specify at rest encryption. Default encryption will apply to any object which hasn't been configured for at rest encryption. 

This is available on all S3 buckets - account, baseline and s3 component buckets  and has been disabled by default to ensure compatibility and migration 

When enabling Encryption the default method in this PR is to use the CMK encryption keys `EncryptionService` that we use for at rest encryption across other services. As a result of this extra policies have to be added to the S3 uploaders IAM policy which permit access to the encryption key. 

If this isn't possible or not supported by the client ( this includes other cloud provider services ) the `LocalService` option is available which will use a native encryption service to the client which doesn't require any permissions

## Motivation and Context
The main motivation for this is for security hardening accounts which require where possible all services are encrypted at rest

## How Has This Been Tested?
Tested on development deployment across all components

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
