### PR TITLE
Fix: Support legacy types in profiles

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1,5 +1,8 @@
 [#ftl]
 
+[#-- Legacy type mappings --]
+[#assign legacyTypeMapping = {} ]
+
 [#-- Known component types --]
 [#assign ADAPTOR_COMPONENT_TYPE = "adaptor"]
 
@@ -36,6 +39,7 @@
 
 [#assign DB_COMPONENT_TYPE = "db" ]
 [#assign DB_LEGACY_COMPONENT_TYPE = "rds" ]
+[#assign legacyTypeMapping += { DB_LEGACY_COMPONENT_TYPE : DB_COMPONENT_TYPE } ]
 
 [#assign EC2_COMPONENT_TYPE = "ec2"]
 
@@ -48,6 +52,7 @@
 
 [#assign ES_COMPONENT_TYPE = "es"]
 [#assign ES_LEGACY_COMPONENT_TYPE = "elasticsearch"]
+[#assign legacyTypeMapping += { ES_LEGACY_COMPONENT_TYPE : ES_COMPONENT_TYPE } ]
 
 [#assign EXTERNALNETWORK_COMPONENT_TYPE = "externalnetwork" ]
 [#assign EXTERNALNETWORK_CONNECTION_COMPONENT_TYPE = "externalnetworkconnection" ]
@@ -66,6 +71,7 @@
 [#assign LB_COMPONENT_TYPE = "lb" ]
 [#assign LB_PORT_COMPONENT_TYPE = "lbport" ]
 [#assign LB_LEGACY_COMPONENT_TYPE = "alb" ]
+[#assign legacyTypeMapping += { LB_LEGACY_COMPONENT_TYPE : LB_COMPONENT_TYPE } ]
 
 [#assign MOBILEAPP_COMPONENT_TYPE = "mobileapp"]
 


### PR DESCRIPTION
## Description
Capture the mapping between legacy types and their canonical equivalent.

Rework the component utility functions to drive off the legacy type mapping.

Rework the lookup of profiles during processing to support the use of legacy types. In the process, also make this logic case insensitive.

## Motivation and Context
Legacy types should work consistently across all aspects of hamlet operation. 

## How Has This Been Tested?
Local builds.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
