### PR TITLE
fix(networkProfile): enable or disable egress rules

### DIFF
--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -621,6 +621,18 @@
             [/#if]
             [#break]
 
+        [#case "_localhost"]
+        [#case "_localhost_"]
+        [#case "__localhost__"]
+            [#return
+                {
+                    "Id" : groupId,
+                    "Name" : groupId,
+                    "IsOpen" : false,
+                    "CIDR" : [ "127.0.0.1/32" ]
+                } ]
+            [#break]
+
         [#default]
             [#if (ipAddressGroups[groupId]!{})?has_content ]
                 [#return ipAddressGroups[groupId] ]

--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -1623,9 +1623,8 @@
           "default" : {
             "BaseSecurityGroup" : {
               "Outbound" : {
-                "IPAddressGroups" : [ "_global" ],
-                "Ports" : [ "any" ],
-                "Description" : "Default Global outbound"
+                "GlobalAllow" : true,
+                "NetworkRules" : {}
               }
             }
           }

--- a/providers/shared/references/NetworkProfiles/id.ftl
+++ b/providers/shared/references/NetworkProfiles/id.ftl
@@ -21,8 +21,20 @@
                 },
                 {
                     "Names" : "Outbound",
-                    "Description" : "Network level Rules to apply",
-                    "Children" : networkRuleChildConfiguration
+                    "Description" : "Outbound security group rules",
+                    "Children" : [
+                        {
+                            "Names" : "GlobalAllow",
+                            "Description" : "Allow all outbound traffic",
+                            "Type" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Names" : "NetworkRules",
+                            "SubObjects" : true,
+                            "Children" : networkRuleChildConfiguration
+                        }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
## Description
Adds some fixes for network profile base security groups
- Allow for multiple rules to be defined 
- Provide a configuration option to enable/disable enabling egress rules through the GlobalAllow rule

## Motivation and Context
This allows for a simpler implementation approach where you can either allow Global access outbound from all services or chose to enable egress control


## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
