### PR TITLE
fix(externalservice): Apply solution config on the resource group

### DIFF
--- a/providers/shared/components/externalservice/id.ftl
+++ b/providers/shared/components/externalservice/id.ftl
@@ -7,16 +7,28 @@
             {
                 "Type" : "Description",
                 "Value" : "An external component which is not part of codeontap"
-            },
-            {
-                "Type" : "Providers",
-                "Value" : [ "shared" ]
-            },
-            {
-                "Type" : "ComponentLevel",
-                "Value" : "solution"
             }
         ]
+    attributes=[]
+/]
+
+[@addChildComponent
+    type=EXTERNALSERVICE_ENDPOINT_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "An endpoint of an external serivce normally an IP address or collection"
+            }
+        ]
+    attributes=[]
+    parent=EXTERNALSERVICE_COMPONENT_TYPE
+    childAttribute="Endpoints"
+    linkAttributes="Endpoint"
+/]
+
+[@addResourceGroupInformation
+    type=EXTERNALSERVICE_COMPONENT_TYPE
     attributes=[
         {
             "Names" : "Properties",
@@ -45,27 +57,17 @@
             "Children" : linkChildrenConfiguration
         }
     ]
+    provider=SHARED_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=[
+        SHARED_EXTERNAL_SERVICE
+    ]
 /]
 
-[@addChildComponent
+
+[@addResourceGroupInformation
     type=EXTERNALSERVICE_ENDPOINT_COMPONENT_TYPE
-    properties=
-        [
-            {
-                "Type"  : "Description",
-                "Value" : "An endpoint of an external serivce normally an IP address or collection"
-            },
-            {
-                "Type" : "Providers",
-                "Value" : [ "shared" ]
-            },
-            {
-                "Type" : "ComponentLevel",
-                "Value" : "solution"
-            }
-        ]
-    attributes=
-        [
+    attributes=[
             {
                 "Names" : "IPAddressGroups",
                 "Type" : ARRAY_OF_STRING_TYPE,
@@ -77,14 +79,6 @@
                 "Default" : ""
             }
         ]
-    parent=EXTERNALSERVICE_COMPONENT_TYPE
-    childAttribute="Endpoints"
-    linkAttributes="Endpoint"
-/]
-
-[@addResourceGroupInformation
-    type=EXTERNALSERVICE_COMPONENT_TYPE
-    attributes=[]
     provider=SHARED_PROVIDER
     resourceGroup=DEFAULT_RESOURCE_GROUP
     services=[


### PR DESCRIPTION
## Description
Apply solution configuration for shared serivces as part of the resource group attributes

## Motivation and Context
This fixes a bug where the shared provider resource group were overriding the default configuration applied to exteranl service components. 
Not sure if this is a bug or not but I think this is a right approach

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
