### PR TITLE
Loggging Profile

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -396,6 +396,11 @@ behaviour.
     [#return (networkProfiles[profileName])!{} ]
 [/#function]
 
+[#function getLoggingProfile profileName  ]
+    [#local loggingProfiles = getReferenceData(LOGGINGPROFILE_REFERENCE_TYPE)]
+    [#return (loggingProfiles[profileName])!{} ]
+[/#function]
+
 [#function getNetworkEndpoints endpointGroups zone region ]
     [#local services = []]
     [#local networkEndpoints = {}]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -57,6 +57,9 @@
 [@addReferenceData type=PORTMAPPING_REFERENCE_TYPE base=blueprintObject /]
 [#assign portMappings = getReferenceData(PORTMAPPING_REFERENCE_TYPE) ]
 
+[#-- Logging Profiles --]
+[@addReferenceData type=LOGGINGPROFILE_REFERENCE_TYPE base=blueprintObject /]
+
 [#-- Log Files --]
 [@addReferenceData type=LOGFILE_REFERENCE_TYPE base=blueprintObject /]
 [#assign logFiles = getReferenceData(LOGFILE_REFERENCE_TYPE) ]

--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -202,6 +202,11 @@ object.
                         "Names" : "Alert",
                         "Type" : STRING_TYPE,
                         "Default" : "default"
+                    },
+                    {
+                        "Names" : "Logging",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
                     }
                 ]
             },

--- a/providers/shared/components/bastion/id.ftl
+++ b/providers/shared/components/bastion/id.ftl
@@ -53,6 +53,11 @@
                             "Names" : "Network",
                             "Type":  STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Logging",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -42,6 +42,11 @@
                             "Names" : "Network",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Logging",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },

--- a/providers/shared/components/datafeed/id.ftl
+++ b/providers/shared/components/datafeed/id.ftl
@@ -43,7 +43,7 @@
             },
             {
                 "Names" : "Bucket",
-                "Children" : [ 
+                "Children" : [
                     {
                         "Names" : "Prefix",
                         "Type" : STRING_TYPE,
@@ -85,7 +85,17 @@
                 "Names" : "Encrypted",
                 "Type" : BOOLEAN_TYPE,
                 "Default" : false
-            }
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : [
+                    {
+                        "Names" : "Logging",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
+            },
             {
                 "Names" : "Backup",
                 "Children" : [

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -52,6 +52,11 @@
                             "Names" : "Network",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Logging",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },

--- a/providers/shared/components/ecs/id.ftl
+++ b/providers/shared/components/ecs/id.ftl
@@ -182,6 +182,11 @@
                             "Names" : "Network",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Logging",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },
@@ -383,6 +388,11 @@
                             "Names" : "Network",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Logging",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },
@@ -511,6 +521,11 @@
                         },
                         {
                             "Names" : "Network",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
+                            "Names" : "Logging",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
                         }

--- a/providers/shared/components/es/id.ftl
+++ b/providers/shared/components/es/id.ftl
@@ -93,6 +93,11 @@
                             "Names" : "Network",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Logging",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },

--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -204,6 +204,11 @@
                             "Names" : "Network",
                             "Type" : STRING_TYPE,
                             "Default" : "default"
+                        },
+                        {
+                            "Names" : "Logging",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
                         }
                     ]
             },

--- a/providers/shared/components/mobilenotifier/id.ftl
+++ b/providers/shared/components/mobilenotifier/id.ftl
@@ -42,6 +42,16 @@
                         "Default" : "base64"
                     }
                 ]
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : [
+                    {
+                        "Names" : "Logging",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
             }
         ]
 /]
@@ -113,6 +123,11 @@
                 "Children" : [
                     {
                         "Names" : "Alert",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
+                    },
+                    {
+                        "Names" : "Logging",
                         "Type" : STRING_TYPE,
                         "Default" : "default"
                     }

--- a/providers/shared/components/network/id.ftl
+++ b/providers/shared/components/network/id.ftl
@@ -58,11 +58,21 @@
                         "Default" : "10.0.0.0/16"
                     }
                 ]
-            },            
+            },
             {
                 "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : [
+                    {
+                        "Names" : "Logging",
+                        "Type" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
             }
         ]
 /]

--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -1630,6 +1630,11 @@
           }
         },
         "Bootstraps": {},
+        "LoggingProfiles" : {
+          "default" : {
+            "ForwardingRules" : {}
+          }
+        },
         "LogFilters": {
           "_all": {
             "Pattern": ""

--- a/providers/shared/references/LogFilter/id.ftl
+++ b/providers/shared/references/LogFilter/id.ftl
@@ -1,12 +1,12 @@
 [#ftl]
 
-[@addReference 
+[@addReference
     type=LOGFILTER_REFERENCE_TYPE
     pluralType="LogFilters"
     properties=[
             {
                 "Type"  : "Description",
-                "Value" : "A filter to apply when searching log files" 
+                "Value" : "A filter to apply when searching log files"
             }
         ]
     attributes=[
@@ -17,3 +17,7 @@
         }
     ]
 /]
+
+[#function getLogFilterPattern logFilterId ]
+    [#return (logFilters[logFilterId].Pattern)!"" ]
+[/#function]

--- a/providers/shared/references/LoggingProfile/id.ftl
+++ b/providers/shared/references/LoggingProfile/id.ftl
@@ -1,0 +1,33 @@
+[#ftl]
+
+[@addReference
+    type=LOGGINGPROFILE_REFERENCE_TYPE
+    pluralType="LoggingProfiles"
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "A profile to describe logging rules for a component"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "ForwardingRules",
+            "Description" : "Controls the forwarding of logs after they have landed in their initial logging location",
+            "Subobjects" : true,
+            "Children" : [
+                {
+                    "Names" : "Filter",
+                    "Description" : "The name of a Logfilter to apply to the forwarding rule",
+                    "Type" : STRING_TYPE,
+                    "Mandatory" : true
+                }
+                {
+                    "Names" : "Links",
+                    "Description" : "The links of components which will accept fowarded logs",
+                    "Subobjects" : true,
+                    "Children" : linkChildrenConfiguration
+                }
+            ]
+        }
+    ]
+/]

--- a/providers/shared/references/reference.ftl
+++ b/providers/shared/references/reference.ftl
@@ -13,10 +13,11 @@
 [#assign PORTMAPPING_REFERENCE_TYPE = "PortMapping" ]
 
 [#-- Logging Reference Types --]
+[#assign LOGGINGPROFILE_REFERENCE_TYPE = "LoggingProfile" ]
+[#assign LOGFILTER_REFERENCE_TYPE = "LogFilter" ]
 [#assign LOGFILE_REFERENCE_TYPE = "LogFile" ]
 [#assign LOGFILEGROUP_REFERENCE_TYPE = "LogFileGroup" ]
 [#assign LOGFILEPROFILE_REFERENCE_TYPE = "LogFileProfile" ]
-[#assign LOGFILTER_REFERENCE_TYPE = "LogFilter" ]
 
 [#-- Compute Reference Types --]
 [#assign PROCESSOR_REFERENCE_TYPE = "Processor" ]


### PR DESCRIPTION
## Description
Adds support for configuring a logging profile and creating forwarding rules to other components within this profile 

## Motivation and Context
For security or monitoring purposes you might want to forward logs to another monitoring service for enhanced logging performance or access control. 

The logging profile allows for these forwarding rules to be configured at the profile level allowing them to be applied across a whole solution or a select group of components

Implementation is modelled on the network profile configuration which uses a similar approach for egress and ingress network security control 

## How Has This Been Tested?
Tested on local deployment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
