### PR TITLE
feat(console): add dedicated cmk option for console sessions

### DIFF
--- a/legacy/account/account_cmk.ftl
+++ b/legacy/account/account_cmk.ftl
@@ -6,7 +6,10 @@
 
     [@includeServicesConfiguration
         provider=AWS_PROVIDER
-        services=AWS_KEY_MANAGEMENT_SERVICE
+        services=[
+            AWS_KEY_MANAGEMENT_SERVICE,
+            AWS_SYSTEMS_MANAGER_SERVICE
+        ]
         deploymentFramework=CLOUD_FORMATION_DEPLOYMENT_FRAMEWORK
     /]
 
@@ -16,70 +19,103 @@
     [#assign cmkKeyAliasId = formatDependentResourceId(AWS_CMK_ALIAS_RESOURCE_TYPE, cmkKeyId)]
     [#assign cmkKeyAliasName = formatRelativePath( "alias", formatName("account", "cmk")) ]
 
-    [#if deploymentSubsetRequired("cmk", true) && isPartOfCurrentDeploymentUnit(cmkKeyId)]
+    [#if deploymentSubsetRequired("cmk", true) ]
 
-        [@createCMK
-            id=cmkKeyId
-            description=cmkKeyName
-            statements=
-                [
-                    getPolicyStatement(
-                        "kms:*",
-                        "*",
-                        {
-                            "AWS": formatAccountPrincipalArn()
-                        }
-                    ),
-                    getPolicyStatement(
-                        [
-                            "kms:Encrypt",
-                            "kms:Decrypt",
-                            "kms:ReEncrypt*",
-                            "kms:GenerateDataKey*",
-                            "kms:DescribeKey"
-                        ],
-                        "*",
-                        {
-                            "AWS": [
-                                formatGlobalArn(
-                                    "iam",
-                                    "role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
-                                )
-                            ]
-                        },
-                        {},
-                        true,
-                        "AutoScale Service Linked Role"
-                    ),
-                    getPolicyStatement(
-                        [
-                            "kms:CreateGrant"
-                        ],
-                        "*",
-                        {
-                            "AWS": [
-                                formatGlobalArn(
-                                    "iam",
-                                    "role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
-                                )
-                            ]
-                        },
-                        {
-                            "Bool": {
-                                "kms:GrantIsForAWSResource": true
+        [#if isPartOfCurrentDeploymentUnit(cmkKeyId)]
+
+            [@createCMK
+                id=cmkKeyId
+                description=cmkKeyName
+                statements=
+                    [
+                        getPolicyStatement(
+                            "kms:*",
+                            "*",
+                            {
+                                "AWS": formatAccountPrincipalArn()
                             }
-                        },
-                        true,
-                        "AutoScale Attachment of persistent resources"
-                    )
-                ]
-        /]
+                        ),
+                        getPolicyStatement(
+                            [
+                                "kms:Encrypt",
+                                "kms:Decrypt",
+                                "kms:ReEncrypt*",
+                                "kms:GenerateDataKey*",
+                                "kms:DescribeKey"
+                            ],
+                            "*",
+                            {
+                                "AWS": [
+                                    formatGlobalArn(
+                                        "iam",
+                                        "role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+                                    )
+                                ]
+                            },
+                            {},
+                            true,
+                            "AutoScale Service Linked Role"
+                        ),
+                        getPolicyStatement(
+                            [
+                                "kms:CreateGrant"
+                            ],
+                            "*",
+                            {
+                                "AWS": [
+                                    formatGlobalArn(
+                                        "iam",
+                                        "role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+                                    )
+                                ]
+                            },
+                            {
+                                "Bool": {
+                                    "kms:GrantIsForAWSResource": true
+                                }
+                            },
+                            true,
+                            "AutoScale Attachment of persistent resources"
+                        )
+                    ]
+            /]
 
-        [@createCMKAlias
-            id=cmkKeyAliasId
-            name=cmkKeyAliasName
-            cmkId=cmkKeyId
-        /]
+            [@createCMKAlias
+                id=cmkKeyAliasId
+                name=cmkKeyAliasName
+                cmkId=cmkKeyId
+            /]
+        [/#if]
 
+        [#if (accountObject.Console.Encryption.DedicatedKey)!false ]
+
+            [#assign consoleKeyId = formatAccountSSMSessionManagerKMSKeyId() ]
+            [#assign consoleKeyName = formatName("account", "cmk", "console")]
+            [#assign consoleKeyAliasId = formatDependentResourceId(AWS_CMK_ALIAS_RESOURCE_TYPE, consoleKeyId)]
+            [#assign consoleKeyAliasName = formatRelativePath( "alias", consoleKeyName) ]
+
+            [#if isPartOfCurrentDeploymentUnit(consoleKeyId)]
+                [@createCMK
+                    id=consoleKeyId
+                    description=consoleKeyName
+                    statements=
+                        [
+                            getPolicyStatement(
+                                "kms:*",
+                                "*",
+                                {
+                                    "AWS": formatAccountPrincipalArn()
+                                }
+                            )
+                        ]
+                /]
+
+                [@createCMKAlias
+                    id=consoleKeyAliasId
+                    name=consoleKeyAliasName
+                    cmkId=consoleKeyId
+                /]
+            [/#if]
+        [/#if]
     [/#if]
 [/#if]

--- a/legacy/account/account_console.ftl
+++ b/legacy/account/account_console.ftl
@@ -30,10 +30,10 @@
 
     [#assign consoleDocumentDependencies = []]
 
-    [#assign accountCMKId = formatAccountCMKTemplateId()]
+    [#assign consoleCMKId = getAccountSSMSessionManagerKMSKeyId()]
 
     [#if deploymentSubsetRequired("console", true) &&
-            ! getExistingReference(formatAccountCMKTemplateId())?has_content ]
+            ! getExistingReference(consoleCMKId)?has_content ]
         [@fatal
             message="Account CMK not found"
             detail="Run the cmk deployment at the account level to create the CMK"
@@ -41,7 +41,7 @@
     [/#if]
 
     [#assign SSMDocumentInput = {
-        "kmsKeyId" : getExistingReference(accountCMKId)
+        "kmsKeyId" : getExistingReference(consoleCMKId)
     }]
 
     [#list consoleLoggingDestinations as loggingDestination ]
@@ -69,7 +69,7 @@
                         id=consoleLogBucketId
                         name=consoleLogBucketName
                         encrypted=true
-                        kmsKeyId=accountCMKId
+                        kmsKeyId=consoleCMKId
                         versioning=true
                     /]
                 [/#if]


### PR DESCRIPTION
## Description
Adds support for configuring a dedicated KMS CMK for ssm console access. 

## Motivation and Context
This is mostly to support cases when this has been configured by other hardening services that are outside of hamlet. Uses the account level cmk by default

## How Has This Been Tested?
Tested on local deployment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
