### PR TITLE
feat(account): allow unique cmk aliases

### DIFF
--- a/legacy/account/account_cmk.ftl
+++ b/legacy/account/account_cmk.ftl
@@ -13,11 +13,18 @@
         deploymentFramework=CLOUD_FORMATION_DEPLOYMENT_FRAMEWORK
     /]
 
+    [#if accountObject.Encryption.Alias.IncludeSeed!false ]
+        [#assign cmkKeyAliasName = formatRelativePath( "alias", formatName("account", "cmk", accountObject.Seed)) ]
+        [#assign consoleKeyAliasName = formatRelativePath( "alias", formatName("account", "cmk", "console", accountObject.Seed)) ]
+    [#else]
+        [#assign cmkKeyAliasName = formatRelativePath( "alias", formatName("account", "cmk")) ]
+        [#assign consoleKeyAliasName = formatRelativePath( "alias", formatName("account", "cmk", "console")) ]
+    [/#if]
+
     [#assign cmkKeyId = formatAccountCMKTemplateId()]
     [#assign cmkKeyName = formatName("account", "cmk")]
 
     [#assign cmkKeyAliasId = formatDependentResourceId(AWS_CMK_ALIAS_RESOURCE_TYPE, cmkKeyId)]
-    [#assign cmkKeyAliasName = formatRelativePath( "alias", formatName("account", "cmk")) ]
 
     [#if deploymentSubsetRequired("cmk", true) ]
 
@@ -92,7 +99,6 @@
             [#assign consoleKeyId = formatAccountSSMSessionManagerKMSKeyId() ]
             [#assign consoleKeyName = formatName("account", "cmk", "console")]
             [#assign consoleKeyAliasId = formatDependentResourceId(AWS_CMK_ALIAS_RESOURCE_TYPE, consoleKeyId)]
-            [#assign consoleKeyAliasName = formatRelativePath( "alias", consoleKeyName) ]
 
             [#if isPartOfCurrentDeploymentUnit(consoleKeyId)]
                 [@createCMK


### PR DESCRIPTION
## Description
Allows for creating unique aliases for CMK keys created at the account level

## Motivation and Context
Ensures that there aren't collisions with other hardening applied to the AWS account 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
