### PR TITLE
fix(s3): adds migration for queue permissions config

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -840,6 +840,12 @@
         "Type" : ARRAY_OF_STRING_TYPE,
         "Default" : [ "create" ],
         "Values" : [ "create", "delete", "restore", "reducedredundancy" ]
+    },
+    {
+        "Names" : "aws:QueuePermissionMigration",
+        "Description" : "Deprecation alert: set to true once policy updated for queue",
+        "Type" : BOOLEAN_TYPE,
+        "Default" : false
     }
 ]]
 


### PR DESCRIPTION
## Description
Adds a configuration option to control error handling for the S3 Queue permissions migration requirements as part of https://github.com/hamlet-io/engine-plugin-aws/pull/98 

## Motivation and Context
Ensures we don't break deployments when the queue permissions haven't been updated

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
