### PR TITLE
fix: If no CIDRs defined, getGroupCIDRs should return false

### DIFF
--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -727,7 +727,7 @@
         [/#if]
         [#local cidrs += nextGroup.CIDR ]
     [/#list]
-    [#return valueIfTrue(true, asBoolean, cidrs) ]
+    [#return valueIfTrue(cidrs?has_content, asBoolean, cidrs) ]
 [/#function]
 
 [#function getGroupCountryCodes groups blacklist=false]


### PR DESCRIPTION
## Description
Correct logic for detecting if CIDRs are defined.

## Motivation and Context
Current logic returns true even if no CIDRs are found. This creates empty WAF rules which also changes the default rule.


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Local template creation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
