### PR TITLE
feat(waf): add waf logging profiles

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -582,6 +582,16 @@
             "Names" : "OWASP",
             "Type" : BOOLEAN_TYPE,
             "Default" : false
+        },
+        {
+            "Names" : "Profiles",
+            "Children" : [
+                {
+                    "Names" : "Logging",
+                    "Type"  : STRING_TYPE,
+                    "Default" : "waf"
+                }
+            ]
         }
     ]
 ]

--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -1633,6 +1633,9 @@
         "LoggingProfiles" : {
           "default" : {
             "ForwardingRules" : {}
+          },
+          "waf" : {
+            "ForwardingRules" : {}
           }
         },
         "LogFilters": {


### PR DESCRIPTION
## Description
Adds logging profiles for WAF services to allow for log fowarding

## Motivation and Context
In AWS WAF logging has to be enabled and sent to a forwarding service to see how traffic is being handled. The logs generated by WAF are separate from the normal logs of a WAF enabled service. So to support setting up log forwarding we need to be able to control this independently from the standard component logging profile

## How Has This Been Tested?
Tested locally on active deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- Core - https://github.com/hamlet-io/engine/pull/1366
- AWS - https://github.com/hamlet-io/engine-plugin-aws/pull/105
- Bash Executor -  https://github.com/hamlet-io/executor-bash/pull/71

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
