### PR TITLE
Service roles and volumeencrypt fixes

### DIFF
--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -112,6 +112,9 @@
 [@addReferenceData type=NETWORKENDPOINTGROUP_REFERENCE_TYPE base=blueprintObject /]
 [#assign networkEndpointGroups = getReferenceData(NETWORKENDPOINTGROUP_REFERENCE_TYPE) ]
 
+[#-- Service Roles --]
+[@addReferenceData type=SERVICEROLE_REFERENCE_TYPE base=blueprintObject /]
+
 [#-- WAF --]
 [@addReferenceData type=WAFPROFILE_REFERENCE_TYPE base=blueprintObject /]
 [@addReferenceData type=WAFRULEGROUP_REFERENCE_TYPE base=blueprintObject /]

--- a/legacy/account/account_cmk.ftl
+++ b/legacy/account/account_cmk.ftl
@@ -62,17 +62,10 @@
             [#assign volumeEncryptionKmsKeyAliasId = formatDependentResourceId(AWS_CMK_ALIAS_RESOURCE_TYPE, volumeEncryptionKmsKeyId)]
 
             [#-- Check that service linked role exists --]
-            [#assign autoScaleRoleDeployed = false ]
-            [#list getReferenceData(SERVICEROLE_REFERENCE_TYPE) as id,ServiceRole ]
-                [#if ServiceRole.ServiceName == "autoscaling.amazonaws.com" ]
-                    [#assign autoScaleRoleDeployed = getExistingReference( formatAccountServiceLinkedRoleId(id) )?has_content ]
-                [/#if]
-            [/#list]
-
-            [#if ! autoScaleRoleDeployed ]
+            [#if ! isSerivceLinkedRoleDeployed("autoscaling.amazonaws.com" ) ]
                 [@fatal
                     message="autoscaling.amazonaws.com service linked role not deployed"
-                    detail="Check ServiceRoles reference data and run account level IAM deployment"
+                    detail="Run an account level iam deployment to enable the service"
                 /]
             [/#if]
 

--- a/legacy/account/account_cmk.ftl
+++ b/legacy/account/account_cmk.ftl
@@ -61,10 +61,6 @@
             [#assign volumeEncryptionKmsKeyName = formatName("account", "cmk", "volume", "encrypt")]
             [#assign volumeEncryptionKmsKeyAliasId = formatDependentResourceId(AWS_CMK_ALIAS_RESOURCE_TYPE, volumeEncryptionKmsKeyId)]
 
-            [#assign volumeEncryptResourceId = formatEC2AccountVolumeEncryptionId() ]
-            [#assign volumeEncryptionEnabled = true ]
-
-
             [#-- Check that service linked role exists --]
             [#assign autoScaleRoleDeployed = false ]
             [#list getReferenceData(SERVICEROLE_REFERENCE_TYPE) as id,ServiceRole ]

--- a/legacy/account/account_iam.ftl
+++ b/legacy/account/account_iam.ftl
@@ -1,0 +1,28 @@
+[#if getDeploymentUnit()?contains("iam") ]
+    [#if deploymentSubsetRequired("generationcontract", false)]
+        [@addDefaultGenerationContract subsets="template" /]
+    [/#if]
+
+    [@includeServicesConfiguration
+        provider=AWS_PROVIDER
+        services=[
+            AWS_IDENTITY_SERVICE
+        ]
+        deploymentFramework=CLOUD_FORMATION_DEPLOYMENT_FRAMEWORK
+    /]
+
+    [#list getReferenceData(SERVICEROLE_REFERENCE_TYPE) as id,serviceRole ]
+        [#assign serviceLinkedRoleId = formatAccountServiceLinkedRoleId(id) ]
+
+        [#if deploymentSubsetRequired("iam", true) &&
+                (serviceRole.Enabled)!true &&
+                isPartOfCurrentDeploymentUnit(serviceLinkedRoleId)]
+
+            [@createServiceLinkedRole
+                id=serviceLinkedRoleId
+                serviceName=serviceRole.ServiceName
+            /]
+
+        [/#if]
+    [/#list]
+[/#if]

--- a/providers/shared/references/ServiceRoles/id.ftl
+++ b/providers/shared/references/ServiceRoles/id.ftl
@@ -1,0 +1,29 @@
+[#ftl]
+
+[@addReference
+    type=SERVICEROLE_REFERENCE_TYPE
+    pluralType="ServiceRoles"
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Security Roles assigned to cloud services"
+            },
+            {
+                "Type" : "Note",
+                "Value" : "AWS - See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html for supported services"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "Enabled",
+            "Type" : BOOLEAN_TYPE,
+            "Default" : true
+        },
+        {
+            "Names" : "ServiceName",
+            "Description" : "The Service domain name for the service you want to create the role for",
+            "Type" : STRING_TYPE,
+            "Mandatory": true
+        }
+    ]
+/]

--- a/providers/shared/references/reference.ftl
+++ b/providers/shared/references/reference.ftl
@@ -42,6 +42,7 @@
 [#assign SCRIPTSTORE_REFERENCE_TYPE = "ScriptStore" ]
 [#assign SECURITYPROFILE_REFERENCE_TYPE = "SecurityProfile" ]
 [#assign NETWORKPROFILE_REFERENCE_TYPE = "NetworkProfile" ]
+[#assign SERVICEROLE_REFERENCE_TYPE = "ServiceRole" ]
 
 [#assign TESTCASE_REFERENCE_TYPE = "TestCase" ]
 [#assign TESTPROFILE_REFERENCE_TYPE = "TestProfile" ]


### PR DESCRIPTION
## Description
A collection of changes to make volume encryption easier to support
- Adds a new reference component Service Roles which allow for account level provisioning of service linked roles - These provide permissions for cloud provider services to access other services 
- Refactors the volume encryption process to check for service roles and to also use a dedicated CMK for encryption. This allows for simpler management of KMS key policy 

## Motivation and Context
When adding policies to a KMS key the principals listed in the key policy have to actually exist. This is different to IAM policies which don't require this 
So in order to provide the autoscaling service with KMS access for volume encryption we need to create the autoscaling service linked role before creating the KMS key and before enabling default volume encryption 

Some other services also require the existing of the default service linked role before certain deployments so making it a reference data controlled thing seemed useful

## How Has This Been Tested?
Tested on active deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [ ] engine - https://github.com/hamlet-io/engine/pull/1368
- [ ] engine-plugin-aws - https://github.com/hamlet-io/engine-plugin-aws/pull/107
- [ ] executor-bash - https://github.com/hamlet-io/executor-bash/pull/75

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
