### PR TITLE
feat(ecs): add lookup for ingress rules based on links for containers

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -778,6 +778,8 @@
             attributeIfContent("ContainerNetworkLinks", container.ContainerNetworkLinks)
         ]
 
+
+        [#local linkIngressRules = [] ]
         [#list _context.Links as linkId,linkTarget]
             [#assign linkTargetCore = linkTarget.Core ]
             [#assign linkTargetConfiguration = linkTarget.Configuration ]
@@ -787,6 +789,10 @@
 
             [#if (linkTargetRoles.Outbound["networkacl"]!{})?has_content ]
                 [#local egressRules += [ linkTargetRoles.Outbound["networkacl"] ]]
+            [/#if]
+
+            [#if linkTarget.Direction == "Inbound" && linkTarget.Role == "networkacl" ]
+                [#local linkIngressRules += [  mergeObjects( linkTargetRoles.Inbound["networkacl"],  { "Ports" : inboundPorts } ) ] ]]
             [/#if]
 
             [#switch linkTargetCore.Type]
@@ -816,9 +822,10 @@
             [/#switch]
         [/#list]
 
-        [#-- Add link based egress rules --]
+        [#-- Add link based sec rules --]
         [#assign _context += { "EgressRules" : egressRules }]
-
+        [#assign _context += { "LinkIngressRules" : linkIngressRules }]
+å
         [#-- Add in fragment specifics including override of defaults --]
         [#assign fragmentId = formatFragmentId(_context)]
         [#include fragmentList]


### PR DESCRIPTION
## Description
Adds ingress security group lookups for containers in ecs components

## Motivation and Context
Allows for direct inbound rules for containers to use links as well as subnet based rules

## How Has This Been Tested?
Tested on local template generation

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- engine: https://github.com/hamlet-io/engine/pull/1370
- engine-plugin-aws: https://github.com/hamlet-io/engine-plugin-aws/pull/110

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
