### PR TITLE
feat(core): extend policy profiles to occurence level control

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -453,11 +453,14 @@ behaviour.
     [#return mergeObjects( (deploymentProfile.Modes["*"])!{}, (deploymentProfile.Modes[deploymentMode])!{})  ]
 [/#function]
 
-[#function getPolicyProfile deploymentMode ]
+[#function getPolicyProfile occurrencePolicies deploymentMode ]
 
     [#-- Get the total list of deployment profiles --]
     [#local policyProfileNames =
         getUniqueArrayElements(
+            occurrencePolicies,
+            (segmentObject.Profiles.Policy)![],
+            (environmentObject.Profiles.Policy)![],
             (productObject.Profiles.Policy)![],
             (accountObject.Profiles.Policy)![],
             (tenantObject.Profiles.Policy)![]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -283,6 +283,7 @@
     forceProfileComponentTypesToLowerCase(
         mergeObjects(
             blueprintObject.DeploymentProfiles!{},
+            productObject.DeploymentProfiles!{},
             tenantObject.DeploymentProfiles!{},
             accountObject.DeploymentProfiles!{}
         )
@@ -293,6 +294,7 @@
 [#assign policyProfiles =
     forceProfileComponentTypesToLowerCase(
         mergeObjects(
+            blueprintObject.PolicyProfiles!{},
             productObject.PolicyProfiles!{},
             accountObject.PolicyProfiles!{},
             tenantObject.PolicyProfiles!{}

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -974,6 +974,11 @@
                 "Default" : []
             },
             {
+                "Names" : "Policy",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
                 "Names" : "Placement",
                 "Type" : STRING_TYPE,
                 "Default" : "default"

--- a/providers/shared/deploymentframeworks/default/legacy.ftl
+++ b/providers/shared/deploymentframeworks/default/legacy.ftl
@@ -409,7 +409,7 @@
 
                     [#-- Apply deployment and policy profile overrides                  --]
                     [#local deploymentProfile = getDeploymentProfile(profiles.Deployment, commandLineOptions.Deployment.Mode) ]
-                    [#local policyProfile = getPolicyProfile(commandLineOptions.Deployment.Mode) ]
+                    [#local policyProfile = getPolicyProfile(profiles.Policy, commandLineOptions.Deployment.Mode) ]
 
                     [#-- Assemble the profile objects allowing for legacy types --]
                     [#local deploymentProfileObjects = [(deploymentProfile["*"])!{}] ]


### PR DESCRIPTION
## Description
extends policy profile support to align with the configuration options for deployment profiles

## Motivation and Context
when deployment profiles apply before the blueprint configuration you need to replicate the configuration you want to apply from the occurrence into the deployment profile and have to ensure that its not listed in the occurrence configuration. Extending policy profiles, which are applied after the blueprint configuration allows you to override a value in the occurrence configuration

The ordering of policy profile application is reversed from deployment profiles to ensure that higher level ( tenant, account ) policies are applied last to ensure they are still the preferred configuration

## How Has This Been Tested?
Tested locally on active deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
