### PR TITLE
fix(mock): set a fixed runId for mock

### DIFF
--- a/providers/shared/inputsources/mock/commandlineoption.ftl
+++ b/providers/shared/inputsources/mock/commandlineoption.ftl
@@ -15,4 +15,13 @@
             }
         }
     /]
+
+    [#-- RunId details --]
+    [@addCommandLineOption
+        option={
+            "Run" : {
+                "Id" : "runId098"
+            }
+        }
+    /]
 [/#macro]


### PR DESCRIPTION
## Description
Sets a fixed run Id for the mock input source overriding the shared runId which uses the randomly generated id

## Motivation and Context
When deploying some resources we use the runId as part of the resource name to ensure that they are replaced on each update. Setting a fixed runId for the mock input allows us to test for the existing of these resources 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
