### PR TITLE
fix: use all units by default on resource lables

### DIFF
--- a/client/createDeployment.ftl
+++ b/client/createDeployment.ftl
@@ -10,6 +10,9 @@
 [#list ((deploymentGroup.Deployment.ResourceSets)!{})?values?filter(s -> s.Enabled ) as resourceSet ]
     [#if getDeploymentUnit() == resourceSet.DeploymentUnit ]
 
+        [#assign allDeploymentUnits = true]
+        [#assign ignoreDeploymentUnitSubsetInOutputs = true]
+
         [#assign contractSubsets = []]
         [#list resourceSet.ResourceLabels as label ]
             [#assign resourceLabel = getResourceLabel(label, level) ]
@@ -17,11 +20,14 @@
         [/#list]
 
         [#if (commandLineOptions.Deployment.Unit.Subset!"") == "generationcontract"]
+            [#assign allDeploymentUnits = false]
+            [#assign ignoreDeploymentUnitSubsetInOutputs = false]
+
             [@initialiseDefaultScriptOutput format=commandLineOptions.Deployment.Output.Format /]
             [@addDefaultGenerationContract subsets=contractSubsets /]
+
         [#else]
             [#if !(commandLineOptions.Deployment.Unit.Subset?has_content)]
-                [#assign allDeploymentUnits = true]
                 [#assign commandLineOptions =
                     mergeObjects(
                         commandLineOptions,
@@ -33,7 +39,6 @@
                             }
                         }
                     ) ]
-                [#assign ignoreDeploymentUnitSubsetInOutputs = true]
             [/#if]
         [/#if]
     [/#if]


### PR DESCRIPTION
## Description
Set all subsets generated as part of resource labels to use all units. Disable this for generation contracts as each label sets the expected subsets

## Motivation and Context
When generating any document using a resource label all deployment units configuration should be included in the template document generation process. Currently they are being skipped and while the resource label subset is finding the document in the generation contract its currently generating an empty file

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
