### PR TITLE
efs support for chroot and mount creation

### DIFF
--- a/providers/shared/components/efs/id.ftl
+++ b/providers/shared/components/efs/id.ftl
@@ -80,13 +80,13 @@
             {
                 "Names" : "Ownership",
                 "Description" : "Defines the ownerships of files created under this directory",
-                "Subobjects" : [
+                "Children" : [
                     {
                         "Names" : "Enforced",
                         "Description" : "Enforce these ownership details on all files",
                         "Type" : BOOLEAN_TYPE,
                         "Default" : false
-                    }
+                    },
                     {
                         "Names" : "UID",
                         "Description" : "The UID which owns the files",
@@ -100,7 +100,13 @@
                         "Default" : ""
                     },
                     {
-                        "Names" : "Permission",
+                        "Names" : "SecondaryGIDS",
+                        "Description" : "Secondary GIDS to apply to file ownership",
+                        "TYPE" : ARRAY_OF_NUMBER_TYPE,
+                        "Default" : []
+                    },
+                    {
+                        "Names" : "Permissions",
                         "Description" : "The unix file permissions ( in number format) to apply",
                         "TYPE" : NUMBER_TYPE,
                         "Default" : 755

--- a/providers/shared/components/efs/id.ftl
+++ b/providers/shared/components/efs/id.ftl
@@ -70,6 +70,42 @@
                 "Names" : "Directory",
                 "Type" : STRING_TYPE,
                 "Mandatory" : true
+            },
+            {
+                "Names" : "chroot",
+                "Description" : "Set this directory as the root for clients who connect to it",
+                "TYPE" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "Ownership",
+                "Description" : "Defines the ownerships of files created under this directory",
+                "Subobjects" : [
+                    {
+                        "Names" : "Enforced",
+                        "Description" : "Enforce these ownership details on all files",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    }
+                    {
+                        "Names" : "UID",
+                        "Description" : "The UID which owns the files",
+                        "TYPE" : NUMBER_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "GID",
+                        "Description" : "The GID which owns the files",
+                        "TYPE" : NUMBER_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "Permission",
+                        "Description" : "The unix file permissions ( in number format) to apply",
+                        "TYPE" : NUMBER_TYPE,
+                        "Default" : 755
+                    }
+                ]
             }
         ]
     parent=EFS_COMPONENT_TYPE


### PR DESCRIPTION
## Description
Adds configuration options for controlling chroot and mount folder creation for EFS mounts 

## Motivation and Context
Cloud providers have introduced tools to manage file share permissions and to add chroot based mounts at given paths

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
