### PR TITLE
feat(userpool): control oauth on clients

### DIFF
--- a/providers/shared/components/userpool/id.ftl
+++ b/providers/shared/components/userpool/id.ftl
@@ -232,6 +232,11 @@
                         "Type" : ARRAY_OF_STRING_TYPE,
                         "Values" : [ "code", "implicit", "client_credentials" ],
                         "Default" : [ "code" ]
+                    },
+                    {
+                        "Names" : "Enabled",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
                     }
                 ]
             },


### PR DESCRIPTION
## Description
Allow for OAuth to be disable on userpool clients

## Motivation and Context
In some cases, such as aws identity pools you might want to create a cilent but not include the oAuth configuration. This allows for this to be controlled on a client by client basis.

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
