### PR TITLE
feat(ecs): add healthcheck support

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -342,7 +342,7 @@
     ]
 [/#macro]
 
-[#macro HealthCheck command useShell=true interval=30 retries=3 startWait=0 timeout=5  ]
+[#macro HealthCheck command useShell=true interval=30 retries=3 startPeriod=0 timeout=5  ]
 
     [#local command = asArray(command) ]
 
@@ -360,8 +360,8 @@
             } +
             attributeIfTrue(
                 "StartPeriod",
-                ( startWait > 0 ),
-                startWait
+                ( startPeriod > 0 ),
+                startPeriod
             )
         }
     ]

--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -342,6 +342,32 @@
     ]
 [/#macro]
 
+[#macro HealthCheck command useShell=true interval=30 retries=3 startWait=0 timeout=5  ]
+
+    [#local command = asArray(command) ]
+
+    [#if  !(command[0] == "CMD") && !(command[0] == "CMD-SHELL") ]
+        [#local command = [ useShell?then( "CMD-SHELL", "CMD") ] + command ]
+    [/#if]
+
+    [#assign _context +=
+        {
+            "HealthCheck" : {
+                "Command" : command,
+                "Interval" : interval,
+                "Retries" : retries,
+                "Timeout" : timeout
+            } +
+            attributeIfTrue(
+                "StartPeriod",
+                ( startWait > 0 ),
+                startWait
+            )
+        }
+    ]
+
+[/#macro]
+
 [#macro Policy statements...]
     [#assign _context +=
         {


### PR DESCRIPTION
## Description
Adds support for [docker based health checks](https://docs.docker.com/engine/reference/builder/#healthcheck) for tasks and services in the ECS component

## Motivation and Context
This allows for an out of band process to evaluate the health of a container. ECS will use this information to determine if the task container is healthy or not. If it is not healthy then ECS will replace it. This is useful for tasks which aren't part of a load balancer or will always respond to TCP based health checks

## How Has This Been Tested?
Tested on an active deployment using a local install of hamlet

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
