### PR TITLE
fix(openapi): quota throttling only exists on a usage plan

### DIFF
--- a/engine/openapi.ftl
+++ b/engine/openapi.ftl
@@ -355,21 +355,6 @@
                     "Names" : "RateLimit",
                     "Description" : "The request limit per second.",
                     "Type" : NUMBER_TYPE
-                },
-                {
-                    "Names" : "Quota",
-                    "Description" : "",
-                    "Children" : [
-                        {
-                            "Names" : "Limit",
-                            "Type" : NUMBER_TYPE
-                        },
-                        {
-                            "Names" : "Period",
-                            "Type" : STRING_TYPE,
-                            "Values" : [ "DAY", "WEEK", "MONTH" ]
-                        }
-                    ]
                 }
             ]
         }
@@ -1048,23 +1033,6 @@ is useful to see what the global settings are from a debug perspective
             ]
             [#break]
     [/#switch]
-    [#return result]
-[/#function]
-
-[#function getApiThrottlingSettings occurrence]
-
-    [#local occurrenceSettings = 
-        getOccurrenceSettingValue(occurrence, [["apigw"]], true)]
-
-    [#local result = mergeObjects(
-        {
-            "BurstLimit" : "",
-            "RateLimit" : "",
-            "Quota" : ""
-        },
-        occurrenceSettings.Throttling!{},
-        { "Patterns" : occurrenceSettings.Patterns![] }
-    )]
     [#return result]
 [/#function]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remote quota throttling as only exists on a usage plan

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Quota throttling is a client-side throttle, whereas component configuration is for server-side only.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
As-yet untested, requires reimplementation of aws provider updates.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
