### PR TITLE
fix(settings): evaluation preferences for setting namespaces

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -451,12 +451,13 @@
             []
         ) +
         [
-            {"Key" : deploymentUnit, "Match" : "exact"},
             {"Key" : occurrence.Core.Name, "Match" : "partial"},
             {"Key" : occurrence.Core.TypedName, "Match" : "partial"},
             {"Key" : occurrence.Core.ShortName, "Match" : "partial"},
-            {"Key" : occurrence.Core.ShortTypedName, "Match" : "partial"}
-        ] ]
+            {"Key" : occurrence.Core.ShortTypedName, "Match" : "partial"},
+            {"Key" : deploymentUnit, "Match" : "exact"}
+        ]
+    ]
 
     [#local occurrenceBuild =
         internalCreateOccurrenceSettings(
@@ -542,11 +543,11 @@
             []
         ) +
         [
-            {"Key" : deploymentUnit, "Match" : "exact"},
             {"Key" : occurrence.Core.Name, "Match" : "partial"},
             {"Key" : occurrence.Core.TypedName, "Match" : "partial"},
             {"Key" : occurrence.Core.ShortName, "Match" : "partial"},
-            {"Key" : occurrence.Core.ShortTypedName, "Match" : "partial"}
+            {"Key" : occurrence.Core.ShortTypedName, "Match" : "partial"},
+            {"Key" : deploymentUnit, "Match" : "exact"}
         ] ]
 
     [#return
@@ -567,11 +568,11 @@
             []
         ) +
         [
-            {"Key" : deploymentUnit, "Match" : "exact"},
             {"Key" : occurrence.Core.Name, "Match" : "partial"},
             {"Key" : occurrence.Core.TypedName, "Match" : "partial"},
             {"Key" : occurrence.Core.ShortName, "Match" : "partial"},
-            {"Key" : occurrence.Core.ShortTypedName, "Match" : "partial"}
+            {"Key" : occurrence.Core.ShortTypedName, "Match" : "partial"},
+            {"Key" : deploymentUnit, "Match" : "exact"}
         ] ]
 
     [#return


### PR DESCRIPTION
## Description
Sets an explicit preference on how setting name spaces should be evaluated based on their matching patterns

With the following rules: 
- When provided with a list of prefixes the settings from the last prefix will win 
- Within a prefix exact matches are preferred over partial matches

## Motivation and Context
This was found when trying to deploy a component that included a partial match to another component in the solution. As a result of this the exact setting defined on the deployment unit was being overridden by the partial match provided by the other component. 

While it was under a very weird context ( component deployment unit was the same as a tier Id ) this did highlight an assumed ordering of settings that wasn't implemented in the code.


## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
