### PR TITLE
fix(apigateway): do not attempt eval if definitions full is null

### DIFF
--- a/providers/shared/inputsources/composite/commandlineoption.ftl
+++ b/providers/shared/inputsources/composite/commandlineoption.ftl
@@ -25,7 +25,7 @@
                                     settings?eval,
                                     {}
                 ),
-                "Definitions" : (definitions!"")?has_content?then(
+                "Definitions" : ((definitions!"")?has_content && (!definitions?contains("null")))?then(
                                     definitions?eval,
                                     {}
                 ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a secondary measure to determining if a definitions object should be `?eval`'d or not.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In a scenario where a Solution includes an `apigateway` for which the spec has not yet been built/deployed, template generation on the component can create a composite object for the "definitions" object that is not valid JSON but a string of the word `null`. This passes the initial check for string content but cannot be evaluated. It provides a particularly unhelpful error message that does not put the user on the right track to fixing the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation prior to the build/deployment of an API spec.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
