### PR TITLE
Feat - ResourceGroup Attribute Extensions

### DIFF
--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -137,7 +137,7 @@
     }
 ] ]
 
-[#macro addResourceGroupInformationExtensions type extensions provider]
+[#macro addResourceGroupAttributeValues type extensions provider]
 
     [@internalMergeComponentConfiguration
         type=type

--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -152,7 +152,7 @@
                                     profileAttribute.Children +
                                     attribute.Children
                             }
-                        ] ]
+                        ]
                 [#else]
                     [#local providerAttributes += [attribute] ]
                 [/#if]

--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -137,6 +137,25 @@
     }
 ] ]
 
+[#macro addResourceGroupInformationExtensions type extensions provider]
+
+    [@internalMergeComponentConfiguration
+        type=type
+        configuration=
+            {
+                "ResourceGroups" : {
+                    DEFAULT_RESOURCE_GROUP : {
+                        "Extensions" : {
+                            provider :
+                                extensions
+                        }
+                    }
+                }
+            }
+    /]
+
+[/#macro]
+
 [#macro addResourceGroupInformation type attributes provider resourceGroup services=[] prefixed=true ]
     [#if provider == SHARED_ATTRIBUTES ]
         [#-- Special processing for profiles --]

--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -137,14 +137,14 @@
     }
 ] ]
 
-[#macro addResourceGroupAttributeValues type extensions provider]
+[#macro addResourceGroupAttributeValues type extensions provider resourceGroup=DEFAULT_RESOURCE_GROUP]
 
     [@internalMergeComponentConfiguration
         type=type
         configuration=
             {
                 "ResourceGroups" : {
-                    DEFAULT_RESOURCE_GROUP : {
+                    resourceGroup : {
                         "Extensions" : {
                             provider :
                                 extensions

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -209,15 +209,27 @@
         [#local providerExtensions = extensions[provider]![]]
         [#list attributes as attribute]
 
-            [#local attributeExtension = providerExtensions?filter(e -> asArray(attribute.Names)?seq_contains(e.Names))]
-            [#if attributeExtension?has_content]
-  
-                [#local extendedValues = combineEntities(
-                    attribute.Values,
-                    attributeExtension[0].Values,
-                    ADD_COMBINE_BEHAVIOUR) ]
+            [#local attributeExtension = 
+                providerExtensions
+                ?filter(e -> asArray(attribute.Names)
+                    ?seq_contains(e.Names))]
 
-                [#local result += [mergeObjects(attribute, { "Values" : extendedValues })] ]
+            [#if attributeExtension?has_content]
+
+                [#local extendedValues = attribute.Values]
+  
+                [#list attributeExtension[0].Values as extensionValue]
+                    [#local extendedValues +=
+                        [extensionValue?ensure_starts_with(provider + ":")] ]
+                [/#list]
+
+                [#local result += [
+                    mergeObjects(
+                        attribute,
+                        {
+                            "Values" : getUniqueArrayElements(extendedValues)
+                        }
+                    )]]
             [#else]
                 [#local result += [attribute]]
             [/#if]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Extends the global `componentConfiguration` object to allow for "Extensions". Extensions provide additional valid values to an existing shared provider attribute. 

Extensions are not merged into the current structure but remain separate until after the placement is determined for the current occurrence, and the correct extensions to use for a given occurrence is determined by the placement.

<details>
<summary>Testing Extending the Value Sets for the DB Component</summary>
<br>

```
[@addResourceGroupAttributeValues
    type=DB_COMPONENT_TYPE
    provider=AZURE_PROVIDER
    extensions=[
        {
            "Names" : "Backup",
            "Children" : [
                {
                    "Names" : "DeletionPolicy",
                    "Values" : [ "notadeletionpolicy", "notreal"]
                }
            ]            
        },
        {
            "Names" : "Cluster",
            "Children" : [
                {
                    "Names" : "ScalingPolicies",
                    "Children" : [
                        {
                            "Names" : "Type",
                            "Values" : [ "Slippery-Dip" ]
                        }
                    ]
                }
            ]
        }
    ]
/]
```

</details>


<details>
<summary>Results for Backup.DeletionPolicy (direct children)</summary>
<br>

```
       {
          "Names": "Backup",
          "Children": [
            ...
            {
              "Names": "DeletionPolicy",
              "Type": "string",
              "Values": [
                "Snapshot",
                "Delete",
                "Retain",
                "azure:notadeletionpolicy",
                "azure:notreal"
              ],
              "Default": "Snapshot"
            }
            ...
          ]
        }
```

</details>

<details>
<summary>Results for Cluster.ScalingPolicies.Type (SubObjects = true) with </summary>
<br>

```
        {
          "Names": "Cluster",
          "Description": "Cluster specific configuration when using a clustered database engine",
          "Children": [
            {
              "Names": "ScalingPolicies",
              "Subobjects": true,
              "Children": [
                {
                  "Names": "Type",
                  "Type": "string",
                  "Values": [
                    "Stepped",
                    "Tracked",
                    "Scheduled",
                    "azure:Slippery-Dip"
                  ],
                  "Default": "Stepped"
                }
               ...
```

</details>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A number of shared provider attributes such as "Engine" are common in their usage across providers, but the set of valid values for that attribute can change per provider. 

It's currently necessary for the plugins to use namespaced attributes to accommodate for this, however this causes some unnecessary duplication of attributes - a namespaced attribute would appear as `"provider:Attribute" : value` alongside the shared `"Attribute" : value` in documentation and could cause confusion as to which one should be used.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
