### PR TITLE
fix: handle no deploymentunit

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -5,7 +5,7 @@
     [#if obj["deployment:Unit"]?has_content ]
         [#return obj["deployment:Unit"]]
     [#else]
-        [#return ((obj.DeploymentUnits)![])[0] ]
+        [#return (((obj.DeploymentUnits)![])[0])!"" ]
     [/#if]
 [/#function]
 


### PR DESCRIPTION
## Description
Minor fix to handle a deployment unit not being found

## Motivation and Context
Not all occurrences require deployment units so should return an empty string if it is not found. This also helps with troubleshooting misconfigured occurrences where the configuration hasn't been loaded or couldn't be found

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
