### PR TITLE
feat: aws ecs account settings

### DIFF
--- a/legacy/account/account_ecs.ftl
+++ b/legacy/account/account_ecs.ftl
@@ -1,0 +1,43 @@
+[#-- ECS Account Settings --]
+[#if getDeploymentUnit()?contains("ecs") || (allDeploymentUnits!false) ]
+    [#if deploymentSubsetRequired("generationcontract", false)]
+        [@addDefaultGenerationContract subsets="epilogue" /]
+    [/#if]
+
+    [@includeServicesConfiguration
+        provider=AWS_PROVIDER
+        services=[ ]
+        deploymentFramework=commandLineOptions.Deployment.Framework.Name
+    /]
+
+    [#assign ecsAccountSettings = {
+                "serviceLongArnFormat" : true,
+                "taskLongArnFormat" : true,
+                "containerInstanceLongArnFormat" : true,
+                "awsvpcTrunking" : true
+    }]
+
+    [#-- Allow of overriding the settings if required --]
+    [#assign ecsAccountSettings = mergeObjects( ecsAccountSettings, (accountObject["aws:ecsAccountSettings"])!{} )]
+
+    [#assign ecsAccountCommands = [] ]
+    [#list ecsAccountSettings as setting,state ]
+        [#assign ecsAccountCommands += [ r'manage_ecs_account_settings "' + region + r'" "' + setting + r'" "' + state?then("enabled", "disabled") + r'"' ]]
+    [/#list]
+
+    [#if deploymentSubsetRequired("epilogue", true)]
+        [@addToDefaultBashScriptOutput
+            content=
+                [
+                    r'case ${STACK_OPERATION} in',
+                    r'  create|update)',
+                    r'      info "Updating ECS Account Settings"'
+                ] +
+                ecsAccountCommands +
+                [
+                    r'      ;;',
+                    r'esac'
+                ]
+        /]
+    [/#if]
+[/#if]


### PR DESCRIPTION
## Description
Implements https://github.com/hamlet-io/engine-plugin-aws/issues/123

Provides support for setting ECS account level settings which control account ( region ) wide services

AWS Details on the available services are available here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html 

As the settings are reasonably safe in terms of hamlet deployments we have chosen to enable all settings with the exception of container Insights which has a cost implication and can be controlled at the cluster level. 

Names of the settings that we support are based on the AWS cli definition of the settings - https://docs.aws.amazon.com/cli/latest/reference/ecs/put-account-setting.html 

## Motivation and Context
AWS has had to introduce new functionality and potentially breaking changes to the ECS service. To ensure smooth transitions and minimal impact some of the changes have been introduced through an opt in/opt out process and this has been implemented as account settings. Managing these through hamlet allows us to assist with smooth transitions to these new services with minimal impact

## How Has This Been Tested?
Tested on an active deployment, locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- engine - https://github.com/hamlet-io/engine/pull/1393
- executor-bash - https://github.com/hamlet-io/executor-bash/pull/85

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
