### PR TITLE
Ecs container advanced configuration

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -43,18 +43,6 @@
 [/#function]
 
 [#-- Fragment List Macros --]
-
-[#macro Attributes name="" image="" version="" essential=true]
-    [#assign _context +=
-        {
-            "Essential" : essential
-        } +
-        attributeIfContent("Name", name) +
-        attributeIfContent("Image", image) +
-        attributeIfContent("ImageVersion", version)
-    ]
-[/#macro]
-
 [#macro lambdaAttributes
         imageBucket=""
         imagePrefix=""
@@ -258,6 +246,25 @@
             }
         ]
     [/#if]
+[/#macro]
+
+[#macro Hostname hostname ]
+    [#assign _context +=
+        {
+            "Hostname" : hostname
+        }
+    ]
+[/#macro]
+
+[#macro Attributes name="" image="" version="" essential=true]
+    [#assign _context +=
+        {
+            "Essential" : essential
+        } +
+        attributeIfContent("Name", name) +
+        attributeIfContent("Image", image) +
+        attributeIfContent("ImageVersion", version)
+    ]
 [/#macro]
 
 [#macro WorkingDirectory workingDirectory ]

--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -275,14 +275,13 @@
     ]
 [/#macro]
 
-[#macro Volume name="" containerPath="" hostPath="" readOnly=false persist=false volumeLinkId="" driverOpts={} autoProvision=false ]
+[#macro Volume name="" containerPath="" hostPath="" readOnly=false persist=false volumeLinkId="" driverOpts={} autoProvision=false scope="" volumeEngine="local" ]
 
     [#if volumeLinkId?has_content ]
         [#local volumeName = _context.DataVolumes[volumeLinkId].Name ]
         [#local volumeEngine = _context.DataVolumes[volumeLinkId].Engine ]
     [#else]
         [#local volumeName = name!"COTFatal: Volume Name or VolumeLinkId not provided" ]
-        [#local volumeEngine = "local"]
     [/#if]
 
     [#switch volumeEngine ]
@@ -309,9 +308,13 @@
                                             persist?boolean,
                                             persist),
                         "Driver" : volumeDriver,
-                        "DriverOptions" : driverOpts,
+                        "DriverOpts" : driverOpts,
                         "AutoProvision" : autoProvision
                     } +
+                    attributeIfContent(
+                        "Scope",
+                        scope
+                    ) +
                     (volumeDriver == "efs" )?then(
                         {
                             "EFS" : _context.DataVolumes[volumeLinkId].EFS

--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -789,23 +789,28 @@
         [#assign contextLinks = getLinkTargets(task, containerLinks) ]
         [#assign _context =
             {
-                "Id" : getContainerId(container),
+                "Id" : contentIfContent(
+                        container.Fragment,
+                        getContainerId(container)
+                ),
                 "Name" : getContainerName(container),
                 "Instance" : core.Instance.Id,
                 "Version" : core.Version.Id,
                 "Essential" : true,
                 "RegistryEndPoint" : getRegistryEndPoint("docker", task),
-                "Image" :
-                    formatRelativePath(
-                        formatName(
-                            productName,
-                            getOccurrenceBuildScopeExtension(task)
-                        ),
-                        formatName(
-                            getOccurrenceBuildUnit(task),
-                            getOccurrenceBuildReference(task)
-                        )
-                    ),
+                "Image" : container.Image?has_content?then(
+                            container.Image,
+                            formatRelativePath(
+                                formatName(
+                                    productName,
+                                    getOccurrenceBuildScopeExtension(task)
+                                ),
+                                formatName(
+                                    getOccurrenceBuildUnit(task),
+                                    getOccurrenceBuildReference(task)
+                                )
+                            )
+                ),
                 "MemoryReservation" : container.MemoryReservation,
                 "Mode" : getContainerMode(container),
                 "LogDriver" : logDriver,
@@ -920,7 +925,7 @@
         [#-- Add link based sec rules --]
         [#assign _context += { "EgressRules" : egressRules }]
         [#assign _context += { "LinkIngressRules" : linkIngressRules }]
-å
+
         [#-- Add in fragment specifics including override of defaults --]
         [#assign fragmentId = formatFragmentId(_context)]
         [#include fragmentList]

--- a/legacy/fragment/fragment_hamlet.ftl
+++ b/legacy/fragment/fragment_hamlet.ftl
@@ -195,7 +195,7 @@
 
     [#assign dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/home/jenkins"  ]
     [#assign dockerStageSize = settings["DOCKER_STAGE_SIZE_GB"]!"20"        ]
-    [#assign dockerLibSize = settings["DOCKER_LIB_VOLUME_SIZE]!"20"         ]
+    [#assign dockerLibSize = settings["DOCKER_LIB_VOLUME_SIZE"]!"20"         ]
     [#assign dindTLSVerify = settings["DIND_DOCKER_TLS_VERIFY"]!"true"      ]
 
 

--- a/legacy/fragment/fragment_jenkins.ftl
+++ b/legacy/fragment/fragment_jenkins.ftl
@@ -127,7 +127,7 @@
             [#assign JenkinsHomeFound = true]
             [@Volume
                 name="jenkinsdata"
-                containerPath"/var/jenkins_home"
+                containerPath="/var/jenkins_home"
                 hostPath=settings["JENKINSHOMEVOLUME"]
             /]
         [/#if]

--- a/providers/shared/components/ecs/id.ftl
+++ b/providers/shared/components/ecs/id.ftl
@@ -3,7 +3,8 @@
 [#assign
     containerChildrenConfiguration = [
         {
-            "Names" : ["Fragment", "Container"],
+            "Names" : "Fragment",
+            "Description" : "The fragment Id to use when evaluating component fragments - defaults to the container id",
             "Type" : "string",
             "Default" : ""
         },

--- a/providers/shared/components/ecs/id.ftl
+++ b/providers/shared/components/ecs/id.ftl
@@ -3,6 +3,11 @@
 [#assign
     containerChildrenConfiguration = [
         {
+            "Names" : ["Fragment", "Container"],
+            "Type" : "string",
+            "Default" : ""
+        },
+        {
             "Names" : "Cpu",
             "Type" : NUMBER_TYPE,
             "Default" : ""
@@ -84,8 +89,15 @@
             ]
         },
         {
+            "Names" : "Image",
+            "Type" : STRING_TYPE,
+            "Description" : "Overrides the image from the deployment unit",
+            "Default": ""
+        },
+        {
             "Names" : "Version",
             "Type" : STRING_TYPE,
+            "Description" : "Override the version from the deployment unit",
             "Default" : ""
         },
         {
@@ -247,6 +259,18 @@
                 "Description" : "The default compute provider for the cluster",
                 "Values" : [ "ec2", "ec2OnDemand" ],
                 "Default" : "ec2"
+            },
+            {
+                "Names" : "Monitoring",
+                "Description" : "Cluster level monitoring configuration",
+                "Children" : [
+                    {
+                        "Names" : "ContainerMetrics",
+                        "Description" : "Create detailed metrics on container lifecycle",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    }
+                ]
             }
         ]
 /]


### PR DESCRIPTION
## Description
Adds a collection of changes for ECS to allow for advanced configurations 
- Support setting the hostname for a container within a task
- Exposes volume driver configuration to users to use dynamic provisioning of volumes - mainly for the rexray/ebs volume 
- Support for overriding the container fragment Id when processing fragment files 
- Allows for override of the docker container image to align with the ability to override the image version 
- Adds support for placement constraints - Which allow you to restrict where a task is placed based on the labels assigned to either the ecs host or the task. For example attribute:ecs.availability-zone == ap-southeast-2a would only allow the task to be placed on an ec2 ecs host in ap-southeast-2a

This also adds support for [docker in docker](https://hub.docker.com/_/docker) when running Jenkins agents. While not always a recommend approach this PR covers off most of the concerns outlined in http://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/ 

## Motivation and Context
These changes have primarily been focussed on introducing the features required to make docker in docker work nicely on an ECS cluster for Jenkins agent hosting

## How Has This Been Tested?
Tested on codepublican testing environment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
