### PR TITLE
Various fixes - Resource Sets, openapi

### DIFF
--- a/client/createDeployment.ftl
+++ b/client/createDeployment.ftl
@@ -6,7 +6,7 @@
 
 [#-- ResourceSets  --]
 [#-- Seperates resources from their component templates in to their own deployment --]
-[#list ((deploymentGroupDetails.Deployment.ResourceSets)!{})?values?filter(s -> s.Enabled ) as resourceSet ]
+[#list ((deploymentGroupDetails.ResourceSets)!{})?values?filter(s -> s.Enabled ) as resourceSet ]
     [#if getDeploymentUnit() == resourceSet["deployment:Unit"] ]
 
         [#assign allDeploymentUnits = true]
@@ -14,7 +14,7 @@
 
         [#assign contractSubsets = []]
         [#list resourceSet.ResourceLabels as label ]
-            [#assign resourceLabel = getResourceLabel(label, level) ]
+            [#assign resourceLabel = getResourceLabel(label, getDeploymentLevel()) ]
             [#assign contractSubsets = combineEntities( contractSubsets, (resourceLabel.Subsets)![], UNIQUE_COMBINE_BEHAVIOUR ) ]
         [/#list]
 

--- a/engine/openapi.ftl
+++ b/engine/openapi.ftl
@@ -1188,7 +1188,7 @@ is useful to see what the global settings are from a debug perspective
                     valueIfTrue(
                         optionsSecurity,
                         globalConfiguration.OptionsSecurity == "UseVerb",
-                        {}
+                        { "security" : [ {} ] }
                     )
                 }
             ]


### PR DESCRIPTION
## Description
A couple of minor fixes 
- Align the resource sets configuration with the updates made to the deployment group changes in #1149 
- When using the `disable` option for OptionsSecurity in the apigateway extensions add an explicit security object so that it doesn't inherit the default security configuration for the API

## Motivation and Context
These fixes we found while working through a new deployment 

## How Has This Been Tested?
Tested on an active deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
