### PR TITLE
fix(ecs): add fragment and instance back to container props

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -987,6 +987,12 @@
 
 [#assign containerChildrenConfiguration = [
     {
+        "Names" : "Fragment",
+        "Description" : "The fragment Id to use when evaluating component fragments - defaults to the container id",
+        "Type" : "string",
+        "Default" : ""
+    },
+    {
         "Names" : "Cpu",
         "Type" : NUMBER_TYPE,
         "Default" : ""
@@ -1068,8 +1074,15 @@
         ]
     },
     {
+        "Names" : "Image",
+        "Type" : STRING_TYPE,
+        "Description" : "Overrides the image from the deployment unit",
+        "Default": ""
+    },
+    {
         "Names" : "Version",
         "Type" : STRING_TYPE,
+        "Description" : "Override the version from the deployment unit",
         "Default" : ""
     },
     {


### PR DESCRIPTION
## Description
Minor regression fix to align the changes in #1388  with the changes added in #1396 

## Motivation and Context
New attributes added in one PR that wern't covered in a PR to move the container configuration to a new location 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
