### PR TITLE
fix: Explicit mock API passthrough behaviour

### DIFF
--- a/engine/openapi.ftl
+++ b/engine/openapi.ftl
@@ -994,6 +994,7 @@ is useful to see what the global settings are from a debug perspective
                 {
                     "x-amazon-apigateway-integration" : {
                         "type": "mock",
+                        "passthroughBehavior" : "never",
                         "responses" :
                             {
                                 "default" : {


### PR DESCRIPTION


## Description
Add an explicit value for the passthroughBehaviour attribute of mock API AWS openapi extensions.
## Motivation and Context
Because of the way the mock request handling communicates with the response templates, we should never pass through a payload for a mock.

## How Has This Been Tested?
Customer deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
