### PR TITLE
fix: syntax and variable name updates for build scopes

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -957,7 +957,7 @@ behaviour.
               getRegistryEndPoint(registry, occurrence) + " " +
               formatRelativePath(
                 getRegistryPrefix(registry, occurrence),
-                getOccurrenceBuildScopeProduct(occurrence, product),
+                getOccurrenceBuildProduct(occurrence, product),
                 getOccurrenceBuildScopeExtension(occurrence),
                 getOccurrenceBuildUnit(occurrence),
                 getOccurrenceBuildReference(occurrence)) + " " +

--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -802,7 +802,7 @@
                             container.Image,
                             formatRelativePath(
                                 formatName(
-                                    getOccurrenceBuildScopeProduct(task, productName),
+                                    getOccurrenceBuildProduct(task, productName),
                                     getOccurrenceBuildScopeExtension(task)
                                 ),
                                 formatName(

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -34,7 +34,7 @@
 
 [#function getOccurrenceBuildScopeExtension occurrence ]
     [#local extension = ""]
-    [#local scope = getOccurrenceSettingValue(occurrence, "BUILD_SCOPE", true).trim() ]
+    [#local scope = getOccurrenceSettingValue(occurrence, "BUILD_SCOPE", true)?trim ]
     [#switch scope]
         [#case "account"]
             [#break]
@@ -51,7 +51,7 @@
 
 [#function getOccurrenceBuildProduct occurrence product]
     [#local result = product]
-    [#local scope = getOccurrenceSettingValue(occurrence, "BUILD_SCOPE", true).trim() ]
+    [#local scope = getOccurrenceSettingValue(occurrence, "BUILD_SCOPE", true)?trim ]
     [#switch scope]
         [#case "account"]
             [#local result = accountName]


### PR DESCRIPTION
## Description
Minor fixes for #1402 

- Align function name for product lookup 
- Syntax fixes for trim functions ( freemarker != groovy :) ) 

## Motivation and Context
Some minor fixes to existing changes which caused template generation to fail

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
