### PR TITLE
Link Direction Made Case Insensitive

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -117,7 +117,7 @@
 [#function getDefaultLinkVariables links includeInbound=false]
     [#local result = {"Links" : links, "Environment": {} }]
     [#list links as name,value]
-        [#if (value.Direction != "inbound") || includeInbound]
+        [#if (value.Direction?lower_case != "inbound") || includeInbound]
             [#local result = addLinkVariablesToContext(result, name, name, value.IncludeInContext, false) ]
         [/#if]
     [/#list]
@@ -127,7 +127,7 @@
 [#function getDefaultBaselineVariables links ]
     [#local result = {"Links" : links, "Environment": {} }]
     [#list links as name,value]
-        [#if (value.Direction != "inbound") || includeInbound]
+        [#if (value.Direction?lower_case != "inbound") || includeInbound]
             [#local result = addLinkVariablesToContext(result, name, name, [], false, false, false) ]
         [/#if]
     [/#list]
@@ -868,7 +868,7 @@
                 [#local egressRules += [ linkTargetRoles.Outbound["networkacl"] ]]
             [/#if]
 
-            [#if linkTarget.Direction == "Inbound" && linkTarget.Role == "networkacl" ]
+            [#if linkTarget.Direction?lower_case == "Inbound" && linkTarget.Role == "networkacl" ]
                 [#local linkIngressRules += [  mergeObjects( linkTargetRoles.Inbound["networkacl"],  { "Ports" : inboundPorts } ) ] ]]
             [/#if]
 

--- a/engine/link.ftl
+++ b/engine/link.ftl
@@ -35,7 +35,7 @@
         [/#if]
         [#if linkTarget.Role != "networkacl" ]
             [#local role = getOccurrenceRole(linkTarget, "Outbound", linkTarget.Role) ]
-            [#if (linkTarget.Direction == "outbound") && role?has_content  ]
+            [#if (linkTarget.Direction?lower_case == "outbound") && role?has_content  ]
                 [#local roles += asArray(role![]) ]
             [/#if]
         [/#if]

--- a/providers/shared/deploymentframeworks/default/context.ftl
+++ b/providers/shared/deploymentframeworks/default/context.ftl
@@ -758,7 +758,7 @@ The roles available are defined as part of the state of the target component.
             "Name" : name,
             "Enabled" : enabled,
             "Filter" : filter,
-            "Direction" : direction,
+            "Direction" : direction?lower_case,
             "Attributes" : attributes
         } +
         attributeIfContent("Role", role)]
@@ -781,7 +781,7 @@ The roles available are defined as part of the state of the target component.
             link.Id!"COTFatal: Id not provided on link",
             link.Name!"COTFatal: Name not provided on link",
             removeObjectAttributes(link, ["Id", "Name", "Direction", "Role", "Attributes", "Enabled", "Type"]),
-            link.Direction!OUTBOUND_LINK_DIRECTION,
+            (link.Direction?lower_case)!OUTBOUND_LINK_DIRECTION,
             link.Role!"",
             link.Attributes!{},
             link.Enabled!true

--- a/providers/shared/deploymentframeworks/default/legacy.ftl
+++ b/providers/shared/deploymentframeworks/default/legacy.ftl
@@ -146,7 +146,7 @@
         [#return
             internalCreateOccurrenceFromExternalLink(occurrence, link) +
             {
-                "Direction" : link.Direction!"outbound",
+                "Direction" : (link.Direction?lower_case)!"outbound",
                 "Role" : link.Role!"external",
                 "IncludeInContext" : link.IncludeInContext![]
             }
@@ -233,7 +233,7 @@
             [/#if]
 
             [#-- Determine the role --]
-            [#local direction = link.Direction!"outbound"]
+            [#local direction = (link.Direction?lower_case)!"outbound"]
 
             [#local role =
                 link.Role!getOccurrenceDefaultRole(targetSubOccurrence, direction)]
@@ -241,7 +241,7 @@
             [#return
                 targetSubOccurrence +
                 {
-                    "Direction" : direction,
+                    "Direction" : direction?lower_case,
                     "Role" : role,
                     "IncludeInContext" : link.IncludeInContext![]
                 } ]

--- a/providers/shared/deploymentframeworks/default/legacy.ftl
+++ b/providers/shared/deploymentframeworks/default/legacy.ftl
@@ -241,7 +241,7 @@
             [#return
                 targetSubOccurrence +
                 {
-                    "Direction" : direction?lower_case,
+                    "Direction" : direction,
                     "Role" : role,
                     "IncludeInContext" : link.IncludeInContext![]
                 } ]

--- a/providers/shared/deploymentframeworks/default/model.ftl
+++ b/providers/shared/deploymentframeworks/default/model.ftl
@@ -74,7 +74,7 @@
         [#return
             internalCreateOccurrenceFromContextExternalLink(occurrence, link) +
             {
-                "Direction" : fullLink.Direction,
+                "Direction" : fullLink.Direction?lower_case,
                 "Role" : fullLink.Role,
                 "IncludeInContext" : fullLink.IncludeInContext![]
             }
@@ -126,12 +126,12 @@
 
         [#-- Determine the role --]
         [#local role =
-            fullLink.Role!getOccurrenceDefaultRole(targetOccurrence, fullLink.Direction)]
+            fullLink.Role!getOccurrenceDefaultRole(targetOccurrence, fullLink.Direction?lower_case)]
 
         [#return
             targetOccurrence +
             {
-                "Direction" : fullLink.Direction,
+                "Direction" : fullLink.Direction?lower_case,
                 "Role" : role,
                 "IncludeInContext" : fullLink.IncludeInContext![]
             } ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Link processing functions to force all values lower-case.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The requirement for lowercase is presently undocumented and unnecessary. Otherwise correctly-formatted links do not trigger errors, so template passes succeed, however they will be missing the intended permissions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation and deployment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
