### PR TITLE
feat: s3 sync exclude support

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -885,7 +885,13 @@ behaviour.
 
 [/#function]
 
-[#function syncFilesToBucketScript filesArrayName region bucket prefix cleanup=true]
+[#function syncFilesToBucketScript filesArrayName region bucket prefix cleanup=true excludes=[] ]
+
+    [#local excludeSwitches = ""]
+    [#list asArray(excludes) as exclude]
+        [#local excludeSwitches += " --exclude \"${exclude}\""]
+    [/#list]
+
     [#return
         [
             "case $\{STACK_OPERATION} in",
@@ -905,6 +911,7 @@ behaviour.
                    "\"" + prefix         + "\"" + " " +
                    "\"" + filesArrayName + "\"" + " " +
                    valueIfTrue("--delete", cleanup, "") +
+                   excludeSwitches +
                    " || return $?",
             "    ;;",
             " esac",


### PR DESCRIPTION
## Description
Add ability to specify file patterns to be excluded during a sync operation.

## Motivation and Context
Initial use case is for the lambda authorizer to be able to ignore the openapi.json file provided to it by the api gateway deployment.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
