### PR TITLE
feat: hamlet info view

### DIFF
--- a/engine/entrance.ftl
+++ b/engine/entrance.ftl
@@ -75,6 +75,9 @@
     /]
 [/#macro]
 
+[#function getEntranceTypes ]
+    [#return entranceConfiguration?keys ]
+[/#function]
 
 [#function getEntrance type ]
     [#if ((entranceConfiguration[type])!{})?has_content]
@@ -87,6 +90,14 @@
     [/#if]
 
     [#return entranceConfig!{} ]
+[/#function]
+
+[#function getEntranceProperties type ]
+    [#return (getEntrance(type).Properties)![] ]
+[/#function]
+
+[#function getEntranceCommandLineOptions type ]
+    [#return (getEntrance(type).CommandLineOptions)![] ]
 [/#function]
 
 [#macro invokeEntranceMacro type ]

--- a/engine/provider.ftl
+++ b/engine/provider.ftl
@@ -328,6 +328,43 @@
     [@includeTemplates templates=templates /]
 [/#macro]
 
+[#macro includeAllViewConfiguration providers... ]
+    [#list asFlattenedArray(providers) as provider ]
+
+        [#-- Process each provider --]
+        [#list providerMarkers as providerMarker ]
+
+            [#if providerMarker.Path?keep_after_last("/") != provider]
+                [#continue]
+            [/#if]
+
+            [#-- Determine the components available from a provider --]
+            [#local directories =
+                internalGetPluginFiles(
+                    [providerMarker.Path, "views"],
+                    [
+                        ["[^/]+"]
+                    ]
+                )
+            ]
+
+            [#local providerViews = []]
+            [#list directories as directory]
+                [#if directory.IsDirectory!false ]
+                    [#local providerViews += [directory.Filename] ]
+                [/#if]
+            [/#list]
+
+            [#list providerViews as providerView ]
+                [@includeProviderViewDefinitionConfiguration
+                    provider=provider
+                    view=providerView
+                /]
+            [/#list]
+        [/#list]
+    [/#list]
+[/#macro]
+
 [#macro includeSharedComponentConfiguration component ]
     [@includeProviderComponentDefinitionConfiguration SHARED_PROVIDER component /]
     [@includeProviderComponentConfiguration SHARED_PROVIDER component /]
@@ -455,6 +492,69 @@
     [/#list]
 [/#macro]
 
+[#macro includeAllComponentConfiguration providers... ]
+
+    [#list asFlattenedArray(providers) as provider ]
+
+        [#-- Process each provider --]
+        [#list providerMarkers as providerMarker ]
+
+            [#if providerMarker.Path?keep_after_last("/") != provider]
+                [#continue]
+            [/#if]
+
+            [#-- Determine the components available from a provider --]
+            [#local directories =
+                internalGetPluginFiles(
+                    [providerMarker.Path, "components"],
+                    [
+                        ["[^/]+"]
+                    ]
+                )
+            ]
+
+            [#local providerComponents = []]
+            [#list directories as directory]
+                [#if directory.IsDirectory!false ]
+                    [#local providerComponents += [directory.Filename] ]
+                [/#if]
+            [/#list]
+
+            [#list providerComponents as providerComponent ]
+                [@includeProviderComponentDefinitionConfiguration
+                    provider=provider
+                    component=providerComponent
+                /]
+            [/#list]
+        [/#list]
+    [/#list]
+[/#macro]
+
+[#--- Query Provider Dictionary --]
+[#function getProviderComponentNames provider ]
+    [#local providerComponents = getCacheSection(providerDictionary, [provider, "c"] ) ]
+
+    [#local providerComponentNames = []]
+    [#list providerComponents as id, component ]
+        [#if (component.id.Content.Present)!false ]
+            [#local providerComponentNames += [ id ]]
+        [/#if]
+    [/#list]
+    [#return providerComponentNames ]
+[/#function]
+
+
+[#function getProviderViewNames provider ]
+    [#local providerViews = getCacheSection(providerDictionary, [provider, "v"] ) ]
+
+    [#local providerViewNames = []]
+    [#list providerViews as id, view ]
+        [#if (view.id.Content.Present)!false ]
+            [#local providerViewNames += [ id ]]
+        [/#if]
+    [/#list]
+    [#return providerViewNames ]
+[/#function]
 [#------------------------------------------------------
 -- Internal support functions for provider processing --
 --------------------------------------------------------]

--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -174,8 +174,8 @@
                 "RequestReference" : commandLineOptions.References.Request,
                 "ConfigurationReference" : commandLineOptions.References.Configuration
             },
-            "Providers" : getOutputContent("providers"),
-            "Entrances" : getOutputContent("entrances")
+            "Providers" : getOutputContent("providers")?values,
+            "Entrances" : getOutputContent("entrances")?values
         } +
         attributeIfContent("COTMessages", logMessages)
     /]
@@ -194,7 +194,7 @@
     [@mergeWithJsonOutput
         name="entrances"
         content={
-            id : details
+            id :  details
         }
     /]
 [/#macro]

--- a/providers/shared/entrances/entrance.ftl
+++ b/providers/shared/entrances/entrance.ftl
@@ -7,3 +7,4 @@
 [#assign BUILDBLUEPRINT_ENTRANCE_TYPE    = "buildblueprint" ]
 [#assign UNITLIST_ENTRANCE_TYPE          = "unitlist" ]
 [#assign SCHEMA_ENTRANCE_TYPE            = "schema" ]
+[#assign INFO_ENTRANCE_TYPE               = "info" ]

--- a/providers/shared/entrances/info/entrance.ftl
+++ b/providers/shared/entrances/info/entrance.ftl
@@ -1,0 +1,28 @@
+[#ftl]
+
+[#macro shared_entrance_info ]
+
+  [#-- override the deployment group to get all deployment groups --]
+  [@addCommandLineOption
+      option={
+        "Deployment" : {
+          "Framework" : {
+              "Name" : DEFAULT_DEPLOYMENT_FRAMEWORK
+          }
+        },
+        "View" : {
+          "Name" : INFO_VIEW_TYPE
+        },
+        "Flow" : {
+          "Names" : [ "views" ]
+        }
+      }
+  /]
+
+  [@generateOutput
+    deploymentFramework=commandLineOptions.Deployment.Framework.Name
+    type=commandLineOptions.Deployment.Output.Type
+    format=commandLineOptions.Deployment.Output.Format
+  /]
+
+[/#macro]

--- a/providers/shared/entrances/info/id.ftl
+++ b/providers/shared/entrances/info/id.ftl
@@ -1,0 +1,18 @@
+[#ftl]
+
+[@addEntrance
+    type=INFO_ENTRANCE_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "Provides details on the hamlet engine and the avaiable entrances"
+            }
+        ]
+    commandlineoptions=[
+        {
+            "Names" : "*",
+            "Type" : ANY_TYPE
+        }
+    ]
+/]

--- a/providers/shared/views/info/setup.ftl
+++ b/providers/shared/views/info/setup.ftl
@@ -22,6 +22,7 @@
 
         [#local providerDetails =
             {
+                "Name" : id,
                 "Location" : providerLocation,
                 "Components" : getProviderComponentNames(id),
                 "Views" : getProviderViewNames(id)

--- a/providers/shared/views/info/setup.ftl
+++ b/providers/shared/views/info/setup.ftl
@@ -1,0 +1,52 @@
+[#ftl]
+
+[#macro shared_view_info_default_generationcontract  ]
+    [@addDefaultGenerationContract subsets=[ "info" ] /]
+[/#macro]
+
+[#macro shared_view_info_default ]
+
+    [#-- Load sections which are dynamically loaded through discovery --]
+    [#local providersList = asFlattenedArray( [ SHARED_PROVIDER, commandLineOptions.Deployment.Provider.Names ] ) ]
+    [@includeAllComponentConfiguration providersList /]
+    [@includeAllViewConfiguration providersList /]
+
+    [#list providerDictionary as id,provider ]
+        [#local providerLocation = ""]
+        [#list providerMarkers as providerMarker ]
+            [#if providerMarker.Path?keep_after_last("/") == id ]
+                [#local providerLocation = providerMarker.Path ]
+                [#break]
+            [/#if]
+        [/#list]
+
+        [#local providerDetails =
+            {
+                "Location" : providerLocation,
+                "Components" : getProviderComponentNames(id),
+                "Views" : getProviderViewNames(id)
+            }
+        ]
+
+        [@infoProvider
+            id=id
+            details=providerDetails
+        /]
+    [/#list]
+
+    [#list getEntranceTypes() as type ]
+        [#local entranceProperties = getEntranceProperties(type)]
+        [#local entranceDescription = entranceProperties?filter( prop -> prop.Type == "Description")?map( prop -> prop.Value )?join(' ') ]
+
+        [#local entranceDetails = {
+            "Type" : type,
+            "Description" : entranceDescription,
+            "CommandLineOptions" : getEntranceCommandLineOptions(type)
+        }]
+        [@infoEntrance
+            id=type
+            details=entranceDetails
+        /]
+
+    [/#list]
+[/#macro]

--- a/providers/shared/views/schema/setup.ftl
+++ b/providers/shared/views/schema/setup.ftl
@@ -12,20 +12,10 @@
 
         [#case "component"]
 
-            [#-- incl. provider configuration --]
-            [#list findProviderMarkers() as providerMarker]
-                [@internalIncludeProviderConfiguration
-                providerMarker=providerMarker
-                /]
-            [/#list]
-
-            [#-- incl. all component definitions --]
-            [#list findComponentMarkers() as component]
-            [@includeProviderComponentDefinitionConfiguration
-                provider=component.Path?split("/")[1]
-                component=component.Path?split("/")[3]
+            [@includeAllComponentConfiguration
+                SHARED_PROVIDER
+                commandLineOptions.Deployment.Provider.Names
             /]
-            [/#list]
 
             [#list componentConfiguration as id,configuration]
             [#assign schemaComponentAttributes = []]

--- a/providers/shared/views/view.ftl
+++ b/providers/shared/views/view.ftl
@@ -2,3 +2,4 @@
 
 [#assign BLUEPRINT_VIEW_TYPE = "blueprint" ]
 [#assign SCHEMA_VIEW_TYPE = "schema"]
+[#assign INFO_VIEW_TYPE = "info" ]


### PR DESCRIPTION
## Description
Adds a new info view which is intended to provide details on the hamlet engine and the providers which have been loaded

The initial implementation includes two sections 

- Providers - which shows all providers that have been found along with the components and views they offer 
- Entrances - which provides a list of all entrances, a description of them and their command line options

## Motivation and Context
The primary motivation behind this view is to be able to provide the available entrances to users either directly or through other tools so that they can find out entrances they can use to generate outputs

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
