### PR TITLE
fix: better control over scope combination

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -998,7 +998,7 @@ behaviour.
         [
             "cp" + " " +
                "\"" + filepath                      + "\"" + " " +
-               "\"" + "$\{tmpdir}/$\{tmp_filename}" + "\"",
+               "\"" + "$\{tmpdir}/$\{tmp_filename}" + "\"" + " || return $?",
             "#",
             "addToArray" + " " +
                filesArrayName + " " +

--- a/engine/openapi.ftl
+++ b/engine/openapi.ftl
@@ -379,6 +379,12 @@
                     "Default" : true
                 },
                 {
+                    "Names" : ["ScopeBehaviour"],
+                    "Type" : STRING_TYPE,
+                    "Values" : [REPLACE_COMBINE_BEHAVIOUR, UNIQUE_COMBINE_BEHAVIOUR],
+                    "Default" : UNIQUE_COMBINE_BEHAVIOUR
+                },
+                {
                     "Names" : ["Scopes"],
                     "Type" : ARRAY_OF_STRING_TYPE,
                     "Default" : []
@@ -603,7 +609,7 @@ doesn't handle very well.
 
 The elements in the array are alternatives, while the attributes of each
 array object are ANDed. Configured schemes are added into each array object,
-thus adding o the requirements specified in the definition itself.
+thus adding to the requirements specified in the definition itself.
 
 A security attribute is explicitly written out every time so technically
 the method security attribute will always override the global one, but it
@@ -632,19 +638,20 @@ is useful to see what the global settings are from a debug perspective
             [#local option = definitionOption]
             [#list configuration as scheme,value]
                 [#if value.Enabled]
-                    [#-- Merge with any existing definition --]
+                    [#-- Combine scopes with any existing definition --]
                     [#local option +=
                         {
                             scheme :
-                                getUniqueArrayElements(
+                                combineEntities(
                                     (option[scheme])![],
-                                    value.Scopes
+                                    value.Scopes,
+                                    value.ScopeBehaviour
                                 )
                         }
                     ]
                 [/#if]
             [/#list]
-            [#local result = [option] ]
+            [#local result += [option] ]
         [/#list]
     [#else]
         [#-- Rely on the configured schemes alone --]


### PR DESCRIPTION
## Description
Add explicit control over scope combining behaviour.

Also improve error detection when generating script files.

## Motivation and Context
When combining openapi spec based security information with integration configuration security information, permit better control over the process used to combine scopes. The initial use case is for authorisers where scopes need to be removed to meet AWS constraints.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] None of the above.
