### PR TITLE
Feature - APIGateway LogToOpsData

### DIFF
--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -225,7 +225,8 @@ object.
             {
                 "Names" : "LogStore",
                 "Description" : "The logging destination for the API Gateway.",
-                "Type" : STRING_TYPE
+                "Type" : STRING_TYPE,
+                "Values" : []
             },
             {
                 "Names" : "BasePathBehaviour",

--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -223,6 +223,11 @@ object.
                 "Children" : logMetricChildrenConfiguration
             },
             {
+                "Names" : "LogStore",
+                "Description" : "The logging destination for the API Gateway.",
+                "Type" : STRING_TYPE
+            },
+            {
                 "Names" : "BasePathBehaviour",
                 "Description" : "How to handle base paths provided in the spec",
                 "Type" : STRING_TYPE,

--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -223,10 +223,10 @@ object.
                 "Children" : logMetricChildrenConfiguration
             },
             {
-                "Names" : "LogStore",
-                "Description" : "The logging destination for the API Gateway.",
-                "Type" : STRING_TYPE,
-                "Values" : []
+                "Names" : "LogToOpsData",
+                "Description" : "Output APIGateway logs to the Baseline OpsData databucket.",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
             },
             {
                 "Names" : "BasePathBehaviour",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
New attribute on the `apigateway` component - LogToOpsData. A boolean value that defines whether logs are directed to the OpsData bucket or not.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Need to be able to consolidate logs somewhere. This allows the logs to be placed in a known location (ops data) where other profiles can handle the replication of data elsewhere if required.

* Ultimately the LogProfiles should be able to define such settings however currently they do not. Further discussion around how logging profiles should look need to be had before that could be implemented however, so this attribute is an interim measure.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation and deployment (alongside matching changes in the AWS provider plugin).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
