### PR TITLE
fix: setup contract outputs in resourceset

### DIFF
--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -246,9 +246,16 @@
 [#assign CONTRACT_EXECUTION_MODE_PARALLEL = "parallel" ]
 [#assign CONTRACT_EXECUTION_MODE_PRIORITY = "priority" ]
 
+[#macro setupContractOutputs ]
+    [#if ! getOutputContent("stages")?has_content ]
+        [@initialiseJsonOutput name="stages" /]
+        [@initialiseJsonOutput name="steps" /]
+    [/#if]
+[/#macro]
+
 [#macro default_output_contract level="" include=""]
-    [@initialiseJsonOutput name="stages" /]
-    [@initialiseJsonOutput name="steps" /]
+
+    [@setupContractOutputs /]
 
     [#-- Resources --]
     [#if include?has_content]

--- a/providers/shared/entrances/deployment/entrance.ftl
+++ b/providers/shared/entrances/deployment/entrance.ftl
@@ -21,6 +21,9 @@
             [#if (commandLineOptions.Deployment.Unit.Subset!"") == "generationcontract"]
                 [#assign groupDeploymentUnits = false]
                 [#assign ignoreDeploymentUnitSubsetInOutputs = false]
+
+                [#-- We need to initialise the outputs here since we are adding to it out side of the component flow --]
+                [@setupContractOutputs /]
                 [@addDefaultGenerationContract subsets=contractSubsets /]
 
             [#else]


### PR DESCRIPTION
## Description
Fixes an issue where resource sets try to add to the generation contract but the outputs aren't available

## Motivation and Context
During the changes introduced in #1407 the initialisation of the contract outputs was moved to be done as part of the output macro. This is the recommended approach as it reduces the potential for overlaps in outputs, however this means that if an entrance tries to create an output it will fail.

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
