### PR TITLE
refactor: Generic check for type in authentication header

### DIFF
--- a/engine/openapi.ftl
+++ b/engine/openapi.ftl
@@ -179,7 +179,7 @@
                         {
                             "Names" : "ValidityExpression",
                             "Type" : STRING_TYPE,
-                            "Default" : r"^[ \t]*((?i)bearer)[ \t]+[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+[ \t]*$"
+                            "Default" : r"^[ \t]*[a-zA-Z0-9\-_]+[ \t]+[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+[ \t]*$"
                         },
                         {
                             "Names" : "Arns",


### PR DESCRIPTION
## Description
Make check for type in header look for a generic string.

## Motivation and Context
While the authorizer might want to enforce a stricter check on the authentication type, the API gateway should just enforce general HTTP syntax for this header.


## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
