### PR TITLE
fix: determine a primary provider to use for views

### DIFF
--- a/providers/shared/flows/views/flow.ftl
+++ b/providers/shared/flows/views/flow.ftl
@@ -15,18 +15,20 @@
         view=commandLineOptions.View.Name
     /]
 
+    [#local primaryProvider = ((commandLineOptions.Deployment.Provider.Names)[0])!SHARED_PROVIDER ]
+
     [@includeProviderViewDefinitionConfiguration
-        provider=(commandLineOptions.Deployment.Provider.Names)[0]
+        provider=primaryProvider
         view=commandLineOptions.View.Name
     /]
 
     [@includeProviderViewConfiguration
-        provider=(commandLineOptions.Deployment.Provider.Names)[0]
+        provider=primaryProvider
         view=commandLineOptions.View.Name
     /]
 
     [#if invokeViewMacro(
-            (commandLineOptions.Deployment.Provider.Names)![0],
+            primaryProvider,
             commandLineOptions.Entrance.Type,
             commandLineOptions.Deployment.Framework.Name,
             [


### PR DESCRIPTION
## Description
A minor fix to define a primary Provider ( the first provider ) for looking up setup macros for views

## Motivation and Context
A typo in the loading process would provide an array to lookups, this fixes this and makes it easier to understand

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
