### PR TITLE
fix: allow for undefined networkendpoints on a region

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -429,7 +429,7 @@ behaviour.
     [#local networkEndpoints = {}]
 
     [#local regionObject = regions[region]]
-    [#local zoneNetworkEndpoints = regionObject.Zones[zone].NetworkEndpoints ]
+    [#local zoneNetworkEndpoints = (regionObject.Zones[zone].NetworkEndpoints)![] ]
 
     [#list endpointGroups as endpointGroup ]
         [#if networkEndpointGroups[endpointGroup]?? ]


### PR DESCRIPTION
## Description
Minor fix to allow for network processing to continue when network endpoints aren't defined for a region 

## Motivation and Context
Was currently stopping template generation when they couldn't be found

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
