### PR TITLE
fix: parameter ordering for invokeViewMacro

### DIFF
--- a/providers/shared/flows/views/flow.ftl
+++ b/providers/shared/flows/views/flow.ftl
@@ -29,8 +29,8 @@
 
     [#if invokeViewMacro(
             primaryProvider,
-            commandLineOptions.Entrance.Type,
             commandLineOptions.Deployment.Framework.Name,
+            commandLineOptions.Entrance.Type,
             [
                 commandLineOptions.Deployment.Unit.Subset
             ])]

--- a/providers/shared/views/blueprint/setup.ftl
+++ b/providers/shared/views/blueprint/setup.ftl
@@ -108,11 +108,11 @@
     [#return result ]
 [/#function]
 
-[#macro shared_view_blueprint_default_generationcontract  ]
+[#macro shared_view_default_blueprint_generationcontract  ]
     [@addDefaultGenerationContract subsets="config" /]
 [/#macro]
 
-[#macro shared_view_blueprint_default_config ]
+[#macro shared_view_default_blueprint_config ]
     [@addToDefaultJsonOutput
         content=mergeObjects(getTenantBlueprint(), logMessages)
     /]

--- a/providers/shared/views/info/setup.ftl
+++ b/providers/shared/views/info/setup.ftl
@@ -1,10 +1,10 @@
 [#ftl]
 
-[#macro shared_view_info_default_generationcontract  ]
+[#macro shared_view_default_info_generationcontract  ]
     [@addDefaultGenerationContract subsets=[ "info" ] /]
 [/#macro]
 
-[#macro shared_view_info_default ]
+[#macro shared_view_default_info ]
 
     [#-- Load sections which are dynamically loaded through discovery --]
     [#local providersList = asFlattenedArray( [ SHARED_PROVIDER, commandLineOptions.Deployment.Provider.Names ] ) ]


### PR DESCRIPTION
## Description
Correct ordering of use to align to macro definition

## Motivation and Context
Any macros will need to have the deployment framework and entrance switched.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Merge https://github.com/hamlet-io/engine-plugin-diagrams/pull/6

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
