### PR TITLE
feat(ecs): placement constraint support

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -230,6 +230,8 @@
                 )]
 [/#macro]
 
+[#-- ECS Specific Macros --]
+
 [#macro Host name value]
     [#assign _context +=
         {
@@ -264,6 +266,15 @@
         attributeIfContent("Name", name) +
         attributeIfContent("Image", image) +
         attributeIfContent("ImageVersion", version)
+    ]
+[/#macro]
+
+
+[#macro taskPlacementConstraint expression ]
+    [#assign _context +=
+        {
+            "PlacementConstraints" : combineEntities( _context.PlacementConstraints![], [ expression ], UNIQUE_COMBINE_BEHAVIOUR)
+        }
     ]
 [/#macro]
 
@@ -852,7 +863,8 @@
             attributeIfContent("IngressRules", ingressRules) +
             attributeIfContent("InboundPorts", inboundPorts) +
             attributeIfContent("RunCapabilities", container.RunCapabilities) +
-            attributeIfContent("ContainerNetworkLinks", container.ContainerNetworkLinks)
+            attributeIfContent("ContainerNetworkLinks", container.ContainerNetworkLinks) +
+            attributeIfContent("PlacementConstraints", container.PlacementConstraints![] )
         ]
 
 


### PR DESCRIPTION
## Description
Adds support for configuring task placement constraints on ecs services 

## Motivation and Context
ECS allows you to use constraints and strategies to define where a container is placed in your ECS cluster. Constraints are requirements which must met for the container to be placed, this can include rules such as the availability zone of the ECS Instance must be ap-southeast-2a, only when an ecs instance is available within this az will the container be started 

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html 

This is useful when you have an Highly Available cluster of independent services which form a cluster and you want to ensure that they are placed specifically as requsted

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
