### PR TITLE
feat(containers): ulimit configuration

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -864,7 +864,8 @@
             attributeIfContent("InboundPorts", inboundPorts) +
             attributeIfContent("RunCapabilities", container.RunCapabilities) +
             attributeIfContent("ContainerNetworkLinks", container.ContainerNetworkLinks) +
-            attributeIfContent("PlacementConstraints", container.PlacementConstraints![] )
+            attributeIfContent("PlacementConstraints", container.PlacementConstraints![] ) +
+            attributeIfContent("Ulimits", container.Ulimits )
         ]
 
 

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1109,6 +1109,31 @@
         "Description" : "A per container setting which can be used by the app to determine run mode for a container in a task - defaults to the second half of a dash separated id",
         "Type" : STRING_TYPE,
         "Default" : ""
+    },
+    {
+        "Names" : "Ulimits",
+        "Description" : "Linux OS based limits for the container",
+        "Subobjects" : true,
+        "Children" : [
+            {
+                "Names" : "Name",
+                "Description" : "The name of the ulimit to apply",
+                "Type" : STRING_TYPE,
+                "Mandatory" : true
+            },
+            {
+                "Names" : "HardLimit",
+                "Description" : "The OS level hard limit to apply",
+                "Type" : NUMBER_TYPE,
+                "Default" : 1024
+            },
+            {
+                "Names" : "SoftLimit",
+                "Description" : "The User level limit to apply",
+                "Type" : NUMBER_TYPE,
+                "Default" : 1024
+            }
+        ]
     }
 ]]
 


### PR DESCRIPTION
## Description
Adds support for configuring ulimits on containers hosted as part of services and tasks 

## Motivation and Context
For some applications the default ulimits applied to a container can restrict the performance of the service fileopen limits being a key ulimit here, this allows you to configure the ulimits for each container dependent on what is available from the container orchestrator

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
