### PR TITLE
feat: support for centralised service resources

### DIFF
--- a/engine/bootstrap.ftl
+++ b/engine/bootstrap.ftl
@@ -35,6 +35,9 @@
 [#-- Component handling --]
 [#include "component.ftl" ]
 
+[#-- Service Handling --]
+[#include "services.ftl" ]
+
 [#-- View handling --]
 [#include "view.ftl" ]
 

--- a/engine/provider.ftl
+++ b/engine/provider.ftl
@@ -220,6 +220,41 @@
     [/#list]
 [/#macro]
 
+[#macro includeAllServicesConfiguration provider deploymentFramework="" ]
+
+    [#-- Process each provider --]
+    [#list providerMarkers as providerMarker ]
+
+        [#if providerMarker.Path?keep_after_last("/") != provider]
+            [#continue]
+        [/#if]
+
+        [#-- Determine the components available from a provider --]
+        [#local directories =
+            internalGetPluginFiles(
+                [providerMarker.Path, "services"],
+                [
+                    ["[^/]+"]
+                ]
+            )
+        ]
+
+        [#local providerServices = []]
+        [#list directories as directory]
+            [#if directory.IsDirectory!false ]
+                [#local providerServices += [directory.Filename] ]
+            [/#if]
+        [/#list]
+
+        [@includeServicesConfiguration
+            provider=provider
+            services=providerServices
+            deploymentFramework=deploymentFramework
+        /]
+
+    [/#list]
+[/#macro]
+
 [#macro includeServicesConfiguration provider services deploymentFramework]
     [#local templates = [] ]
 

--- a/engine/services.ftl
+++ b/engine/services.ftl
@@ -1,0 +1,119 @@
+[#ftl]
+
+[#-- Service Resource Configuration provides a lookup service for details about resources that have beeb loaded --]
+[#-- Resources are stored under a provider and service and allow for their own sections for different configuration groups --]
+[#-- These macros can be extended by other providers to add their own resource configuration --]
+
+[#assign serviceResourceConfiguration = {}]
+
+[#-- Query functions --]
+[#function getServiceResourceSection provider service resource section ]
+    [#return (serviceResourceConfiguration[provider][service]["resources"][resource][section])!{} ]
+[/#function]
+
+[#function getServiceSection provider service section ]
+    [#return (serviceResourceConfiguration[provider][service][section])!{} ]
+[/#function]
+
+[#function getServiceResources provider service  ]
+    [#return ((serviceResourceConfiguration[provider][service]["resources"])?keys)![] ]
+[/#function]
+
+[#function getServices provider ]
+    [#return ((serviceResourceConfiguration[provider])?keys)![]]
+[/#function]
+
+[#function getServiceFromResource provider resource ]
+    [#list getServices(provider) as service ]
+        [#list getServiceResources(provider, service) as svcResource ]
+            [#if svcResource ==  resource ]
+                [#return service ]
+            [/#if]
+        [/#list]
+    [/#list]
+    [#return ""]
+[/#function]
+
+[#-- resource --]
+[#macro addServiceResource provider service resource ]
+    [@addServiceResourceSection
+        provider=provider
+        service=service
+        resource=resource
+        section="present"
+        configuration={
+            "present" : true
+        }
+    /]
+[/#macro]
+
+[#macro addServiceResourceSection provider service resource section configuration ]
+    [@internalMergeServiceResourceConfiguration
+        provider=provider
+        service=service
+        resource=resource
+        section=section
+        configuration=configuration
+    /]
+[/#macro]
+
+[#-- service --]
+[#macro addService provider service ]
+    [@addServiceSection
+        provider=provider
+        service=service
+        section="present"
+        configuration={
+            "present" : true
+        }
+    /]
+[/#macro]
+
+[#macro addServiceSection provider service section configuration ]
+    [@internalMergeServiceConfiguration
+        provider=provider
+        service=service
+        section=section
+        configuration=configuration
+    /]
+[/#macro]
+
+
+[#-- Internal Macros for processing --]
+[#macro internalMergeServiceConfiguration provider service section configuration={} ]
+    [#if section == "resources" ]
+        [@fatal
+            message="Invalid Service Section Name"
+            detail="Provide another section heading name"
+        /]
+    [/#if]
+    [#assign serviceResourceConfiguration =
+        mergeObjects(
+            serviceResourceConfiguration,
+            {
+                provider : {
+                    service : {
+                        section : configuration
+                    }
+                }
+            }
+        )]
+[/#macro]
+
+[#macro internalMergeServiceResourceConfiguration provider service resource section configuration={} ]
+    [#assign serviceResourceConfiguration =
+        mergeObjects(
+            serviceResourceConfiguration,
+            {
+                provider : {
+                    service : {
+                        "resources" : {
+                            resource : {
+                                section : configuration
+                            }
+                        }
+                    }
+                }
+            }
+        )]
+[/#macro]


### PR DESCRIPTION
## Description
Adds support for a centralised definition of services and their resources configuration. The main functionality is the introduction of the `serviceResourceConfiguration` hash which accepts updates to sections of data within the structure based on the Provider, Service and Resource that you want to provide details about 

Sections allow for multiple sources of data to be added to a given resource, for example output mappings and diagram class mappings. This also allows for other providers to extend existing resources and services which might be implemented by another provider 

With the data in this structure it is also possible to search for the provider and service that a resource belongs to based on a first returned basis ( some resource names currently overlap within the same provider ). 

## Motivation and Context
Currently we implement some mappings for resources ( output mappings ) and we have defined that services belong to resources through our dynamic loading process, but once they have been loaded its not possible to determine a given resources service or its provider. This allows us to complete these kinds of queries and to also maintain a central point of resource and service configuration when multiple providers can offer configuration for a given resource 

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
