### PR TITLE
Various changes for providers and entrance setup

### DIFF
--- a/client/invokeEntrance.ftl
+++ b/client/invokeEntrance.ftl
@@ -8,6 +8,11 @@
 [#-- Validate Command line options are right for the entrance --]
 [#assign validCommandLineOptions = getCompositeObject(entrance.Configuration, commandLineOptions) ]
 
+[#-- Setup the contract outputs before invoking the entrance to allow for errors to be caught --]
+[#if (commandLineOptions.Deployment.Unit.Subset!"") == "generationcontract" ]
+    [@setupContractOutputs /]
+[/#if]
+
 [#-- Find and invoke the Entrance Macro --]
 [#-- Entrances provided by explicit providers are preferred over the shared provider --]
 [@invokeEntranceMacro

--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -310,6 +310,7 @@
                     [
                         [ SHARED_PROVIDER, occurrence.Core.Type, resourceGroup, placement.DeploymentFramework, entrance ] + asFlattenedArray(qualifier, true),
                         [ SHARED_PROVIDER, occurrence.Core.Type, placement.DeploymentFramework, entrance ] + asFlattenedArray(qualifier, true),
+                        [ SHARED_PROVIDER, occurrence.Core.Type, commandLineOptions.Deployment.Framework.Name, entrance] + asFlattenedArray(qualifier, true),
                         [ SHARED_PROVIDER, resourceGroup, placement.DeploymentFramework, entrance ] + asFlattenedArray(qualifier, true),
                         [ SHARED_PROVIDER, placement.DeploymentFramework, entrance ] + asFlattenedArray(qualifier, true),
                         [ SHARED_PROVIDER, entrance ] + asFlattenedArray(qualifier, true)
@@ -319,6 +320,7 @@
             [#local macroOptions += [
                 [ SHARED_PROVIDER, occurrence.Core.Type, resourceGroup, placement.DeploymentFramework, entrance],
                 [ SHARED_PROVIDER, occurrence.Core.Type, placement.DeploymentFramework, entrance],
+                [ SHARED_PROVIDER, occurrence.Core.Type, commandLineOptions.Deployment.Framework.Name, entrance],
                 [ SHARED_PROVIDER, resourceGroup, placement.DeploymentFramework, entrance],
                 [ SHARED_PROVIDER, placement.DeploymentFramework, entrance ],
                 [ SHARED_PROVIDER, entrance ]

--- a/engine/provider.ftl
+++ b/engine/provider.ftl
@@ -527,7 +527,7 @@
     [/#list]
 [/#macro]
 
-[#macro includeAllComponentConfiguration providers... ]
+[#macro includeAllComponentDefinitionConfiguration providers... ]
 
     [#list asFlattenedArray(providers) as provider ]
 
@@ -564,6 +564,46 @@
         [/#list]
     [/#list]
 [/#macro]
+
+
+[#macro includeAllComponentConfiguration providers... ]
+
+    [#list asFlattenedArray(providers) as provider ]
+
+        [#-- Process each provider --]
+        [#list providerMarkers as providerMarker ]
+
+            [#if providerMarker.Path?keep_after_last("/") != provider]
+                [#continue]
+            [/#if]
+
+            [#-- Determine the components available from a provider --]
+            [#local directories =
+                internalGetPluginFiles(
+                    [providerMarker.Path, "components"],
+                    [
+                        ["[^/]+"]
+                    ]
+                )
+            ]
+
+            [#local providerComponents = []]
+            [#list directories as directory]
+                [#if directory.IsDirectory!false ]
+                    [#local providerComponents += [directory.Filename] ]
+                [/#if]
+            [/#list]
+
+            [#list providerComponents as providerComponent ]
+                [@includeProviderComponentConfiguration
+                    provider=provider
+                    component=providerComponent
+                /]
+            [/#list]
+        [/#list]
+    [/#list]
+[/#macro]
+
 
 [#--- Query Provider Dictionary --]
 [#function getProviderComponentNames provider ]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -577,6 +577,7 @@
                 {
                     "Id" : groupId,
                     "IsOpen" : true,
+                    "IsLocal" : false,
                     "CIDR" : []
                 }]
         [/#if]
@@ -592,7 +593,8 @@
                 {
                     "Id" : groupId,
                     "Name" : groupId,
-                    "IsOpen" : true
+                    "IsOpen" : true,
+                    "IsLocal" : false
                 } ]
             [#break]
 
@@ -615,6 +617,7 @@
                     "Id" : groupId,
                     "Name" : groupId,
                     "IsOpen" : false,
+                    "IsLocal" : true,
                     "CIDR" : segmentCIDR
                 } ]
             [#break]
@@ -643,6 +646,7 @@
                         "Id" : groupDetailId,
                         "Name" : groupDetailId,
                         "IsOpen" : false,
+                        "IsLocal" : true,
                         "CIDR" : tierSubnets
                     } ]
             [#else]
@@ -680,6 +684,7 @@
                     "Id" : groupId,
                     "Name" : groupId,
                     "IsOpen" : false,
+                    "IsLocal" : true,
                     "CIDR" : [ networkCIDR ]
                 } ]
             [#else]
@@ -706,6 +711,7 @@
                     "Id" : groupId,
                     "Name" : groupId,
                     "IsOpen" : false,
+                    "IsLocal" : true,
                     "CIDR" : [ "127.0.0.1/32" ]
                 } ]
             [#break]
@@ -722,6 +728,7 @@
                     {
                         "Id" : groupId,
                         "IsOpen" : true,
+                        "IsLocal" : false,
                         "CIDR" : []
                     } ]
             [/#if]

--- a/providers/shared/entrances/deployment/entrance.ftl
+++ b/providers/shared/entrances/deployment/entrance.ftl
@@ -23,7 +23,6 @@
                 [#assign ignoreDeploymentUnitSubsetInOutputs = false]
 
                 [#-- We need to initialise the outputs here since we are adding to it out side of the component flow --]
-                [@setupContractOutputs /]
                 [@addDefaultGenerationContract subsets=contractSubsets /]
 
             [#else]

--- a/providers/shared/views/info/setup.ftl
+++ b/providers/shared/views/info/setup.ftl
@@ -8,7 +8,7 @@
 
     [#-- Load sections which are dynamically loaded through discovery --]
     [#local providersList = asFlattenedArray( [ SHARED_PROVIDER, commandLineOptions.Deployment.Provider.Names ] ) ]
-    [@includeAllComponentConfiguration providersList /]
+    [@includeAllComponentDefinitionConfiguration providersList /]
     [@includeAllViewConfiguration providersList /]
 
     [#list providerDictionary as id,provider ]

--- a/providers/shared/views/schema/setup.ftl
+++ b/providers/shared/views/schema/setup.ftl
@@ -1,10 +1,10 @@
 [#ftl]
 
-[#macro shared_view_schema_default_generationcontract  ]
+[#macro shared_view_default_schema_generationcontract  ]
     [@addDefaultGenerationContract subsets="schema" /]
 [/#macro]
 
-[#macro shared_view_schema_default_schema ]
+[#macro shared_view_default_schema ]
 
     [#local section = commandLineOptions.Deployment.Unit.Name]
 
@@ -12,14 +12,14 @@
 
         [#case "component"]
 
-            [@includeAllComponentConfiguration
+            [@includeAllComponentDefinitionConfiguration
                 SHARED_PROVIDER
                 commandLineOptions.Deployment.Provider.Names
             /]
 
             [#list componentConfiguration as id,configuration]
                 [#assign schemaComponentAttributes = []]
-                
+
                 [#-- Construct Component Attributes --]
                 [#list providerDictionary?keys as provider]
 


### PR DESCRIPTION
## Description
A collection of updates to the engine with the following changes 

- Moves the initialisation of contract outputs in the generationcontract subset to the invokeEntrance file. This allows for debug and error messages as part of the flow and entrance processing stages to be included in the generation contract and provided to users 
- As part of the invokeComponent macro process include a lookup for the deploymentFramework set via the commandLineOptions. This allows you to use a deployment framework lookup which is independent from the placement of the component. This is useful when using the component state from one provider and using a deploymentFramework from a different provider.
- Adds an IsLocal flag to the IP Address Group lookup, the isLocal flag is used to show network CIDR ranges which are part of the segment network or not
- Refactors the all component discovery routines to handle loading both the definition configuration and the setup configuration independently 

## Motivation and Context

These changes are mostly to support requirements identified in the diagrams provider along with changes while debugging entrance generation

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
