### PR TITLE
feat(apigw + waf): separate logging enabled from logging profiles

### DIFF
--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -79,17 +79,6 @@ object.
                 "Names" : "Logging",
                 "Children" : [
                     {
-                        "Names" : "Execution",
-                        "Children" : [
-                            {
-                                "Names" : "Enabled",
-                                "Description" : "Logging of the API Gateway Execution Logs.",
-                                "Type" : BOOLEAN_TYPE,
-                                "Default" : false
-                            }
-                        ]
-                    },
-                    {
                         "Names" : "Access",
                         "Children" : [
                             {

--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -76,18 +76,13 @@ object.
                 "Default" : ""
             },
             {
-                "Names" : "Logging",
+                "Names" : "AccessLogging",
                 "Children" : [
                     {
-                        "Names" : "Access",
-                        "Children" : [
-                            {
-                                "Names" : "Enabled",
-                                "Description" : "Logging of the API Gateway Access Logs.",
-                                "Type" : BOOLEAN_TYPE,
-                                "Default" : true
-                            }
-                        ]
+                        "Names" : "Enabled",
+                        "Description" : "Logging of the API Gateway Access Logs.",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
                     }
                 ]
             },

--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -76,6 +76,33 @@ object.
                 "Default" : ""
             },
             {
+                "Names" : "Logging",
+                "Children" : [
+                    {
+                        "Names" : "Execution",
+                        "Children" : [
+                            {
+                                "Names" : "Enabled",
+                                "Description" : "Logging of the API Gateway Execution Logs.",
+                                "Type" : BOOLEAN_TYPE,
+                                "Default" : false
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "Access",
+                        "Children" : [
+                            {
+                                "Names" : "Enabled",
+                                "Description" : "Logging of the API Gateway Access Logs.",
+                                "Type" : BOOLEAN_TYPE,
+                                "Default" : true
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
                 "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
@@ -221,12 +248,6 @@ object.
                 "Names" : "LogMetrics",
                 "Subobjects" : true,
                 "Children" : logMetricChildrenConfiguration
-            },
-            {
-                "Names" : "LogToOpsData",
-                "Description" : "Output APIGateway logs to the Baseline OpsData databucket.",
-                "Type" : BOOLEAN_TYPE,
-                "Default" : false
             },
             {
                 "Names" : "BasePathBehaviour",

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -593,10 +593,14 @@
             "Default" : false
         },
         {
-            "Names" : "EnableLogging",
-            "Description" : "WAF Logs in the OpsData DataBucket.",
-            "Type" : BOOLEAN_TYPE,
-            "Default" : true
+            "Names" : "Logging",
+            "Children" : [ 
+                {
+                    "Names" : "Enabled",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : true
+                }
+            ]
         },
         {
             "Names" : "Profiles",

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -593,10 +593,17 @@
             "Default" : false
         },
         {
+            "Names" : "EnableLogging",
+            "Description" : "WAF Logs in the OpsData DataBucket.",
+            "Type" : BOOLEAN_TYPE,
+            "Default" : true
+        },
+        {
             "Names" : "Profiles",
             "Children" : [
                 {
                     "Names" : "Logging",
+                    "Description" : "Logging profile to process WAF Logs that are stored in the OpsData DataBucket.",
                     "Type"  : STRING_TYPE,
                     "Default" : "waf"
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Separated out the enabling of logging from the logging profile for the `apigateway` component and `WAF` configurations.

Note: I've used objects for the `apigateway` attributes because the intent is for providers to provide any further control they require at the provider level. A bool would not have been sufficient control here but any further configuration here will be provider specific.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The APIGateway provides several kinds of logs - Access Logs, Execution Logs and also WAF Logs. However they are not always able to be configured the same way. Separating out the concerns of "do you want logs?" from "where do you want them?" (`LoggingProfiles`) and creating an attribute structure likes this allows providers to add further control should they wish through namespaced attributes, whilst remaining clear as to the intent of each attribute.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [ ] Schema regeneration will be required.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] None of the above.
