### PR TITLE
feat: add operations and provider to mgmt contract

### DIFF
--- a/providers/shared/components/shared/setup.ftl
+++ b/providers/shared/components/shared/setup.ftl
@@ -23,6 +23,7 @@
 [/#macro]
 
 [#macro shared_unitlist_managementcontract occurrence ]
+
     [@createOccurrenceManagementContractStep
         occurrence=occurrence
     /]

--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -1710,8 +1710,16 @@
           }
         },
         "DeploymentModes" : {
+          "_default" : {
+            "Operations" : [ "update" ],
+            "Membership" : "priority",
+            "Priority" : {
+              "GroupFilter" : ".*",
+              "Order" : "LowestFirst"
+            }
+          },
           "update" : {
-            "Actions" : [ "update" ],
+            "Operations" : [ "update" ],
             "Membership" : "priority",
             "Priority" : {
               "GroupFilter" : ".*",
@@ -1719,7 +1727,7 @@
             }
           },
           "stop" : {
-            "Actions" : [ "delete" ],
+            "Operations" : [ "delete" ],
             "Membership" : "priority",
             "Priority" : {
               "GroupFilter" : ".*",
@@ -1727,7 +1735,7 @@
             }
           },
           "stopstart" : {
-            "Actions" : [ "delete", "update" ],
+            "Operations" : [ "delete", "update" ],
             "Membership" : "priority",
             "Priority" : {
               "GroupFilter" : ".*",

--- a/providers/shared/provider.ftl
+++ b/providers/shared/provider.ftl
@@ -4,7 +4,7 @@
 [#assign DEFAULT_DEPLOYMENT_FRAMEWORK = "default"]
 
 [#-- Management Contracts --]
-[#macro createManagementContractStage deploymentUnit deploymentPriority deploymentGroup deploymentMode=getDeploymentMode() ]
+[#macro createManagementContractStage deploymentUnit deploymentPriority deploymentGroup deploymentProvider deploymentMode=getDeploymentMode() ]
 
     [#local deploymentModeDetails = getDeploymentModeDetails(deploymentMode)]
     [#local deploymentGroupDetails = getDeploymentGroupDetails(deploymentGroup) ]
@@ -74,7 +74,9 @@
                 parameters=
                     {
                         "DeploymentUnit" : deploymentUnit,
-                        "DeploymentGroup" : deploymentGroupDetails.Name
+                        "DeploymentGroup" : deploymentGroupDetails.Name,
+                        "DeploymentProvider" : deploymentProvider,
+                        "Operations" : deploymentModeDetails.Operations
                     }
             /]
         [/#if]
@@ -83,11 +85,14 @@
 
 [#macro createOccurrenceManagementContractStep occurrence ]
     [#local solution = occurrence.Configuration.Solution ]
+    [#local resourceGroups = occurrence.State.ResourceGroups ]
+
     [#if ((solution["deployment:Group"])!"")?has_content ]
         [@createManagementContractStage
             deploymentUnit=getOccurrenceDeploymentUnit(occurrence)
             deploymentGroup=solution["deployment:Group"]
             deploymentPriority=solution["deployment:Priority"]
+            deploymentProvider=resourceGroups["default"].Placement.Provider
         /]
     [/#if]
 [/#macro]
@@ -98,6 +103,7 @@
             deploymentUnit=resourceSet["deployment:Unit"]
             deploymentGroup=deploymentGroupDetails.Name
             deploymentPriority=resourceSet["deployment:Priority"]
+            deploymentProvider=(commandLineOptions.Deployment.Provider.Names)[0]
         /]
     [/#list]
 [/#macro]

--- a/providers/shared/references/DeploymentMode/id.ftl
+++ b/providers/shared/references/DeploymentMode/id.ftl
@@ -16,6 +16,13 @@
             "Default" : true
         },
         {
+            "Names" : "Operations",
+            "Description" : "The deployment operations to complete for each deployment",
+            "Type" : ARRAY_OF_STRING_TYPE,
+            "Values" : [ "create", "update", "delete" ],
+            "Default" : [ "update" ]
+        },
+        {
             "Names" : "ExecutionPolicy",
             "Description" : "Defines how groups can be used in this deployment mode",
             "Type" : STRING_TYPE,
@@ -70,18 +77,28 @@
 
 [#function getDeploymentModeDetails deploymentMode  ]
     [#local deploymentModes = getReferenceData(DEPLOYMENTMODE_REFERENCE_TYPE)]
+    [#local deploymentModeDetails = {}]
 
-    [#if ! (deploymentModes[deploymentMode]!{})?has_content || ! ( deploymentModes[deploymentMode].Enabled )  ]
-        [#return {}]
+    [#if (deploymentModes[deploymentMode]!{})?has_content && deploymentModes[deploymentMode].Enabled ]
+        [#local deploymentModeDetails = deploymentModes[deploymentMode]]
     [/#if]
 
-    [#return
-        mergeObjects(
-            {
-                "Id" : deploymentMode,
-                "Name" : (deploymentModes[deploymentMode].Name)!deploymentMode
-            },
-            deploymentModes[deploymentMode]
-        )
-    ]
+    [#if (deploymentModes["_default"]!{})?has_content && deploymentModes["_default"].Enabled  ]
+        [#local deploymentModeDetails = deploymentModes["_default"]]
+    [/#if]
+
+    [#if deploymentModeDetails?has_content ]
+        [#return
+            mergeObjects(
+                {
+                    "Id" : deploymentMode,
+                    "Name" : (deploymentModeDetails.Name)!deploymentMode,
+                    "Enabled" : (deploymentModeDetails.Enabled)!false
+                },
+                deploymentModeDetails
+            )
+        ]
+    [#else]
+        [#return {}]
+    [/#if]
 [/#function]

--- a/providers/shared/tasks/manage_deployment/id.ftl
+++ b/providers/shared/tasks/manage_deployment/id.ftl
@@ -18,6 +18,16 @@
             "Names" : "DeploymentGroup",
             "Type" : STRING_TYPE,
             "Mandatory" : true
+        },
+        {
+            "Names" : "Operations",
+            "Type" : ARRAY_OF_STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "DeploymentProvider",
+            "Type" : STRING_TYPE,
+            "Mandatory" : true
         }
     ]
 /]


### PR DESCRIPTION
## Description
Some additional updates to the management contract and deployment configuration

- Adds Operations to the deployment mode which allows a mode to specify what operations ( create, update, delete ) should be performed as part of the management step. This allows the information to be passed to deployment tasks such as manage stack or manage deployment 
- Adds the deployment provider to the contract step so that the executors can call the appropriate step to mange the deployment 
- Adds a default deployment mode to handle modes provided by the command line which don't have an explicit configuration - this is mostly for backwards compatibility with existing deployments

## Motivation and Context

This allows for the management contract to be used to handle the generate and execution of deployments as part of the management contract. Future changes will implement a deployment contract that outlines these steps in greater detail. 

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
