### PR TITLE
fix: semver supports asterisk in range indicator

### DIFF
--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -1225,17 +1225,16 @@ are added.
 
 [#--
 Strip any leading "v" (note we handle leading = in semver_satisfies)
-Convert any range indicators ("x" or "X") to 0
-* not supported as substitute for x
+Convert any range indicators ("x" or "X" or "*") to 0
 --]
 
 [#function semverClean version]
     [#-- Handle the full format --]
     [#local match = version?matches(r"^v?(0|[1-9][0-9]*|x|X)\.(0|[1-9][0-9]*|x|X)\.(0|[1-9][0-9]*|x|X)(\-([^+]+))?(\+(.*))?$") ]
     [#if match]
-        [#local major = match?groups[1]?replace("x", "0", "i")?number ]
-        [#local minor = match?groups[2]?replace("x", "0", "i")?number ]
-        [#local patch = match?groups[3]?replace("x", "0", "i")?number ]
+        [#local major = match?groups[1]?replace("[x*]", "0", "ir")?number ]
+        [#local minor = match?groups[2]?replace("[x*]", "0", "ir")?number ]
+        [#local patch = match?groups[3]?replace("[x*]", "0", "ir")?number ]
         [#local pre   = match?groups[5] ]
         [#local build = match?groups[7] ]
 
@@ -1264,8 +1263,8 @@ Convert any range indicators ("x" or "X") to 0
     [#-- Handle major.minor --]
     [#local match = version?matches(r"^v?(0|[1-9][0-9]*|x|X)\.(0|[1-9][0-9]*|x|X)$") ]
     [#if match]
-        [#local major = match?groups[1]?replace("x", "0", "i")?number ]
-        [#local minor = match?groups[2]?replace("x", "0", "i")?number ]
+        [#local major = match?groups[1]?replace("[x*]", "0", "ir")?number ]
+        [#local minor = match?groups[2]?replace("[x*]", "0", "ir")?number ]
         [#local patch = 0 ]
         [#return
             [
@@ -1282,7 +1281,7 @@ Convert any range indicators ("x" or "X") to 0
     [#-- Handle major --]
     [#local match = version?matches(r"^v?(0|[1-9][0-9]*|x|X)$") ]
     [#if match]
-        [#local major = match?groups[1]?replace("x", "0", "i")?number ]
+        [#local major = match?groups[1]?replace("[x*]", "0", "ir")?number ]
         [#local minor = 0 ]
         [#local patch = 0 ]
         [#return


### PR DESCRIPTION
## Description
Add support for the asterisk character as a substitute for 0.

## Motivation and Context
Better aligns semver support to the equivalent node library.

## How Has This Been Tested?
Local testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
