### PR TITLE
feat(ecs): add support for compute providers

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -419,6 +419,11 @@ behaviour.
     [#return (networkProfiles[profileName])!{} ]
 [/#function]
 
+[#function getComputeProviderProfile profileName  ]
+    [#local computeProviders = getReferenceData(COMPUTEPROVIDER_REFERENCE_TYPE)]
+    [#return (computeProviders[profileName])!{} ]
+[/#function]
+
 [#function getLoggingProfile profileName  ]
     [#local loggingProfiles = getReferenceData(LOGGINGPROFILE_REFERENCE_TYPE)]
     [#return (loggingProfiles[profileName])!{} ]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -53,6 +53,9 @@
 [@addReferenceData type=PROCESSOR_REFERENCE_TYPE base=blueprintObject /]
 [#assign processors = getReferenceData(PROCESSOR_REFERENCE_TYPE) ]
 
+[#-- ComputeProvider Profiles --]
+[@addReferenceData type=COMPUTEPROVIDER_REFERENCE_TYPE base=blueprintObject /]
+
 [#-- Ports --]
 [@addReferenceData type=PORT_REFERENCE_TYPE base=blueprintObject /]
 [#assign ports = getReferenceData(PORT_REFERENCE_TYPE) ]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -594,7 +594,7 @@
         },
         {
             "Names" : "Logging",
-            "Children" : [ 
+            "Children" : [
                 {
                     "Names" : "Enabled",
                     "Type" : BOOLEAN_TYPE,
@@ -1186,6 +1186,11 @@
         "Children" :
             [
                 {
+                    "Names" : "ComputeProvider",
+                    "Type" : STRING_TYPE,
+                    "Default" : "default"
+                },
+                {
                     "Names" : "Processor",
                     "Type" : STRING_TYPE,
                     "Default" : "default"
@@ -1214,7 +1219,43 @@
     {
         "Names" : "HostScalingPolicies",
         "Subobjects" : true,
-        "Children" : scalingPolicyChildrenConfiguration
+        "Children" : [
+            {
+                "Names" : "Type",
+                "Type" : STRING_TYPE,
+                "Values" : [ "Stepped", "Tracked", "Scheduled", "ComputeProvider" ],
+                "Default" : "ComputeProvider"
+            },
+            {
+                "Names" : "ComputeProvider",
+                "Children": [
+                    {
+                        "Names" : "MinAdjustment",
+                        "Description" : "The minimum instances to update during scaling activities",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 1
+                    },
+                    {
+                        "Names" : "MaxAdjustment",
+                        "Description" : "The maximum instances to  update during scaling activities",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 10000
+                    },
+                    {
+                        "Names" : "TargetCapacity",
+                        "Description" : "The target usage of the autoscale group to maintain as a percentage",
+                        "Type" : NUMBER_TYPE,
+                        "Default" : 90
+                    },
+                    {
+                        "Names" : "ManageTermination",
+                        "Description" : "Alow the computer provider to manage when instances will be terminated",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                ] + scalingPolicyChildrenConfiguration
+            }
+        ]
     },
     {
         "Names" : "DockerUsers",
@@ -1261,12 +1302,6 @@
         "Names" : "Role",
         "Description" : "Server configuration role",
         "Default" : ""
-    },
-    {
-        "Names" : "ComputeProvider",
-        "Description" : "The default compute provider for the cluster",
-        "Values" : [ "ec2", "ec2OnDemand" ],
-        "Default" : "ec2"
     }
 ]]
 

--- a/providers/shared/references/ComputeProvider/id.ftl
+++ b/providers/shared/references/ComputeProvider/id.ftl
@@ -1,0 +1,64 @@
+[#ftl]
+
+[@addReference
+    type=COMPUTEPROVIDER_REFERENCE_TYPE
+    pluralType="ComputeProviders"
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Policies to determine the compute services used to host a given resource"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "Containers",
+            "Description" : "Compute policy for container based resources",
+            "Children" : [
+                {
+                    "Names" : "Default",
+                    "Description" : "Sets the default computer provider which will meet base capacity",
+                    "Children" : [
+                        {
+                            "Names" : "Provider",
+                            "Description" : "The default container compute provider",
+                            "Type"  : STRING_TYPE,
+                            "Values" : [ "_autoscalegroup", "aws:fargate", "aws:fargatespot" ],
+                            "Default" : "_autoscalegroup"
+                        },
+                        {
+                            "Names" : "Weight",
+                            "Type" : NUMBER_TYPE,
+                            "Description" : "The ratio of containers allocated to the provider based on the configured providers",
+                            "Default" : 1
+                        },
+                        {
+                            "Names" : "RequiredCount",
+                            "Description" : "The minimum count of containers to run on the default provider",
+                            "Type" : NUMBER_TYPE,
+                            "Default" : 1
+                        }
+                    ]
+                },
+                {
+                    "Names" : "Additional",
+                    "Description" : "Providers who will meet the additonal compute capacity outside of the default",
+                    "Subobjects" : true,
+                    "Children" : [
+                        {
+                            "Names" : "Provider",
+                            "Type" : STRING_TYPE,
+                            "Values" : [ "_autoscalegroup", "aws:fargate", "aws:fargatespot" ],
+                            "Mandatory" : true
+                        },
+                        {
+                            "Names" : "Weight",
+                            "Type" : NUMBER_TYPE,
+                            "Description" : "The ratio of containers allocated to the provider based on the configured providers",
+                            "Default" : 1
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+/]

--- a/providers/shared/references/reference.ftl
+++ b/providers/shared/references/reference.ftl
@@ -24,6 +24,7 @@
 [#assign LOGFILEPROFILE_REFERENCE_TYPE = "LogFileProfile" ]
 
 [#-- Compute Reference Types --]
+[#assign COMPUTEPROVIDER_REFERENCE_TYPE = "ComputeProvider" ]
 [#assign PROCESSOR_REFERENCE_TYPE = "Processor" ]
 [#assign STORAGE_REFERENCE_TYPE = "Storage" ]
 


### PR DESCRIPTION
## Description
Adds support for defining compute providers as part of a solution deployment. While a processor profile defines the type of instance you want or how many, a compute profile defines how to source the processing/compute services to deliver the required resources 

The initial implementation for compute providers is on the ECS/ContainerHost component, on this component we can define the a compute provider and default strategy used when deploying containers onto this host 

A compute provider has two distinct configuration options 

* default provider - which offers the base level capacity and requires a minimum number of instances to be provisioned using this provider - this is used when you want to use a stable provider and a less stable provider 
* additional provider - Are weighted rules which define other providers to use once the default capacity requirements have been met

## Motivation and Context
Cloud providers now offer a collection of ways to use compute services to meet particular needs and requirements, this includes managed vs unmanaged hosting ( AWS ECS Ec2 vs ECS Fargate ) or cost based offerings ( AWS On-Demand vs Spot ). Compute Providers are the hamlet representation of defining the compute services you want to use

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [*] BREAKING CHANGE: this also removes the existing ComputeProvider option
on the ECS component in favour of a more configurable approach


## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
