### PR TITLE
fix: include int and version in occurrence caching

### DIFF
--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -358,8 +358,9 @@
 
                     [#-- check we don't already have this occurrence cached --]
                     [#-- if cached return it from cache and skip processing this occurrence --]
-                    [#if isOccurrenceCached(tierId, component.Id, ((formatId(subComponentId))!""), instanceKey, versionKey) ]
-                        [#local occurrences += [ getOccurrenceFromCache(tierId, component.Id, ((formatId(subComponentId))!""), instanceKey, versionKey) ]]
+                    [#if isOccurrenceCached( occurrence, parentOccurrence ) ]
+                        [#local occurrences += [
+                            getOccurrenceFromCache( occurrence, parentOccurrence ) ]]
                         [#continue]
                     [/#if]
 
@@ -535,12 +536,8 @@
                     [#local occurrence = occurrence + attributeIfContent("Occurrences", subOccurrences) ]
 
                     [@addOccurrenceToCache
-                        tierId=tierId
-                        componentId=component.Id
-                        subComponentId=(formatId(subComponentId))!""
-                        instanceId=instanceKey
-                        versionId=versionKey
                         occurrence=occurrence
+                        parentOccurrence=parentOccurrence
                     /]
 
                     [#local occurrences +=


### PR DESCRIPTION

## Description
fix to include the instance and version details for components and
subcomponents. The cache wasn't accounting for the isntances of
subcomponents and as a result if you had two instances of a component
only the first subcomponent was included

Also reworks the caching to use the occurrence details instead of the
sources of the occurrence details

## Motivation and Context
Caching was returning incorrect results for subcomponents where their parent component had multiple instances 

## How Has This Been Tested?
Tested locally and on active deployment 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
