### PR TITLE
feat(lambda): pull images from external source

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -1140,6 +1140,37 @@ behaviour.
 
 [/#function]
 
+[#function getImageFromUrlScript region product environment segment occurrence sourceURL imageFormat registryFile expectedImageHash=""  ]
+
+    [#local registryBucket = getRegistryEndPoint(imageFormat, occurrence) ]
+    [#local registryPrefix =
+        formatRelativePath(
+            getRegistryPrefix(imageFormat, occurrence),
+            getOccurrenceBuildProduct(occurrence, product),
+            getOccurrenceBuildScopeExtension(occurrence),
+            getOccurrenceBuildUnit(occurrence)
+        )
+    ]
+    [#local buildUnit = getOccurrenceBuildUnit(occurrence) ]
+
+    [#return
+        [
+            r'get_url_image_to_registry ' +
+            r'   "' + sourceURL + r'" ' +
+            r'   "' + expectedImageHash + r'" ' +
+            r'   "' + imageFormat + r'" ' +
+            r'   "' + region + r'" ' +
+            r'   "' + registryBucket + r'" ' +
+            r'   "' + registryPrefix + r'" ' +
+            r'   "' + registryFile + r'" ' +
+            r'   "' + product + r'" ' +
+            r'   "' + environment + r'" ' +
+            r'   "' + segment + r'" ' +
+            r'   "' + buildUnit + r'" || exit $?'
+        ]
+    ]
+[/#function]
+
 [#function getResourceMetricDimensions resource resources]
     [#local resourceMetricAttributes = metricAttributes[resource.Type]!{} ]
 

--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -217,6 +217,37 @@
                 "Names" : "ReservedExecutions",
                 "Type" : NUMBER_TYPE,
                 "Default" : -1
+            },
+            {
+                "Names" : "Image",
+                "Description" : "Control the source of the image that is used for the function",
+                "Children" : [
+                    {
+                        "Names" : "Source",
+                        "Description" : "The source of the image - registry is the hamlet registry",
+                        "Type" : STRING_TYPE,
+                        "Mandatory" : true,
+                        "Values" : [ "registry", "url" ],
+                        "Default" : "registry"
+                    },
+                    {
+                        "Names" : "UrlSource",
+                        "Description" : "Url Source specific Configuration",
+                        "Children" : [
+                            {
+                                "Names" : "Url",
+                                "Description" : "The Url to the lambda zip file",
+                                "Type" : STRING_TYPE
+                            },
+                            {
+                                "Names" : "ImageHash",
+                                "Description" : "The expected sha1 hash of the Url if empty any will be accepted",
+                                "Type" : STRING_TYPE,
+                                "Default" : ""
+                            }
+                        ]
+                    }
+                ]
             }
         ]
     parent=LAMBDA_COMPONENT_TYPE


### PR DESCRIPTION
## Description
Adds supporting for loading an external zip file as an image for a lambda function

## Motivation and Context
The main motivation for this is to allow for images to be shared across multiple products without the need to rebuild the package each time. This is especially useful for utility lambda functions which are the same across multiple tenants and products

This concern was brought up as part of #1453 which outlines the need for this to support the portability of modules

## How Has This Been Tested?
tested locally and on testing deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Requires: https://github.com/hamlet-io/engine/pull/1456 
- [X] Requires: https://github.com/hamlet-io/executor-bash/pull/126
- [X] Requires: https://github.com/hamlet-io/engine-plugin-aws/pull/160

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
