### PR TITLE
fix(console): allow for psuedo s3 buckets

### DIFF
--- a/legacy/account/account_console.ftl
+++ b/legacy/account/account_console.ftl
@@ -77,7 +77,7 @@
                 [/#if]
 
                 [#assign SSMDocumentInput += {
-                    "s3BucketName": consoleLogBucketName,
+                    "s3BucketName": getReference(consoleLogBucketId),
                     "s3KeyPrefix" : consoleLogBucketPrefix,
                     "s3EncryptionEnabled" : true
                 }]


### PR DESCRIPTION
## Description
Fix issue with console buckets created outside of the console stack 

## Motivation and Context
Allows for buckets to be created outside of the account console deployment and instead referenced through a pseudo stack. This was supported in the rest of the template but not in this particular spot

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
