### PR TITLE
feat: os patching in solution config

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -1279,7 +1279,7 @@ behaviour.
     [/#switch]
 [/#function]
 
-[#function getMonitoredResources coreId resources, resourceQualifier ]
+[#function getMonitoredResources coreId resources resourceQualifier ]
     [#local monitoredResources = {} ]
 
     [#-- allow for a none type which disables dimension lookup --]
@@ -1347,3 +1347,26 @@ behaviour.
     [/#if]
     [#return addIdNameToObject(result, default) ]
 [/#function]
+
+
+[#-- OS Patching Config --]
+[#assign osPatchingChildConfiguration = [
+    {
+        "Names" : "Enabled",
+        "Description" : "Enable automatic OS Patching",
+        "Type" : BOOLEAN_TYPE,
+        "Default" : true
+    },
+    {
+        "Names" : "Schedule",
+        "Description" : "UTC based cron schedule to apply updates",
+        "Type" : STRING_TYPE,
+        "Default" : "59 13 * * *"
+    },
+    {
+        "Names" : "SecurityOnly",
+        "Description" : "Only apply security updates",
+        "Type" : BOOLEAN_TYPE,
+        "Default" : false
+    }
+]]

--- a/providers/shared/components/bastion/id.ftl
+++ b/providers/shared/components/bastion/id.ftl
@@ -91,6 +91,10 @@
                 "Names" : "Role",
                 "Description" : "Server configuration role",
                 "Default" : ""
+            },
+            {
+                "Names" : "OSPatching",
+                "Children" : osPatchingChildConfiguration
             }
         ]
 /]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1302,6 +1302,10 @@
         "Names" : "Role",
         "Description" : "Server configuration role",
         "Default" : ""
+    },
+    {
+        "Names" : "OSPatching",
+        "Children" : osPatchingChildConfiguration
     }
 ]]
 

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -85,6 +85,10 @@
                 "Names" : "Role",
                 "Description" : "Server configuration role",
                 "Default" : ""
+            },
+            {
+                "Names" : "OSPatching",
+                "Children" : osPatchingChildConfiguration
             }
         ]
 /]

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -76,6 +76,10 @@
                 "Names" : "Role",
                 "Description" : "Server configuration role",
                 "Default" : ""
+            },
+            {
+                "Names" : "OSPatching",
+                "Children" : osPatchingChildConfiguration
             }
         ]
 /]

--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -145,6 +145,9 @@
             },
             "DomainBehaviours": {
               "Segment": "naked"
+            },
+            "OSPatching" : {
+              "SecurityOnly" : true
             }
           },
           "trn": {

--- a/providers/shared/layers/Environment/id.ftl
+++ b/providers/shared/layers/Environment/id.ftl
@@ -148,6 +148,10 @@
                     "Default" : 7
                 }
             ]
+        },
+        {
+            "Names" : "OSPatching",
+            "Children" : osPatchingChildConfiguration
         }
     ]
 /]


### PR DESCRIPTION
## Description
Adds support for controlling OS patching through solution and environment layer configuration. The environment layer configuration has been included to provide compatibility  with existing configuration

## Motivation and Context
In the AWS provider we currently have some hardcoded configuration which updates ec2 based instances on startup and creates a cron job for regular patching. This move allows for this to be configured and controlled by users. 

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
