### PR TITLE
feat: manage one off instance failures

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -677,6 +677,12 @@
         "Description" : "The minimum number of instances which must be available during an update"
     },
     {
+        "Names" : "MinSuccessInstances",
+        "Type" : NUMBER_TYPE,
+        "Description" : "The minimum percantage of instances that must sucessfully update",
+        "Default" : 75
+    },
+    {
         "Names" : "ReplaceCluster",
         "Type" : BOOLEAN_TYPE,
         "Default" : false,


### PR DESCRIPTION
## Description
Adds the ability to configure the number of successful instances in an autoscaling replacement 

## Motivation and Context
When performing a rolling up date to instances, if any instance fails to update the whole update will be rolled back. This allows for the process to handle one off failures which will be resolved by a replacement of the instance without causing the whole update to fail

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
