### PR TITLE
fix(reference): deployment mode default hanlding

### DIFF
--- a/providers/shared/references/DeploymentMode/id.ftl
+++ b/providers/shared/references/DeploymentMode/id.ftl
@@ -83,7 +83,8 @@
         [#local deploymentModeDetails = deploymentModes[deploymentMode]]
     [/#if]
 
-    [#if (deploymentModes["_default"]!{})?has_content && deploymentModes["_default"].Enabled  ]
+    [#if !(deploymentModeDetails?has_content) &&
+            (deploymentModes["_default"]!{})?has_content && deploymentModes["_default"].Enabled  ]
         [#local deploymentModeDetails = deploymentModes["_default"]]
     [/#if]
 


### PR DESCRIPTION
## Description
Minor fix to default configuration applied when a deployment mode could not be found

## Motivation and Context
Currently the default deployment mode is always applying which means that the deployment modes aren't being used

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
