### PR TITLE
feat(network): flow log control

### DIFF
--- a/providers/shared/components/network/id.ftl
+++ b/providers/shared/components/network/id.ftl
@@ -28,8 +28,46 @@
                 "Children" : [
                     {
                         "Names" : "EnableFlowLogs",
+                        "Description" : "Deprecated: Please use FlowLogs",
                         "Type" : BOOLEAN_TYPE,
                         "Default" : true
+                    },
+                    {
+                        "Names" : "FlowLogs",
+                        "Description" : "Log flows across the network",
+                        "Subobjects" : true,
+                        "Children" : [
+                            {
+                                "Names" : "TrafficType",
+                                "Type" : STRING_TYPE,
+                                "Description" : "The type of traffic to capture in the flow log",
+                                "Values" : [ "accept", "reject", "all" ],
+                                "Mandatory" : true
+                            },
+                            {
+                                "Names" : "DestinationType",
+                                "Description" : "The destination type to send the logs to",
+                                "Values" : [ "log", "s3" ],
+                                "Default" : "s3"
+                            },
+                            {
+                                "Names" : "s3",
+                                "Description" : "s3 specific destination configuration",
+                                "Children" : [
+                                    {
+                                        "Names" : "Link",
+                                        "Description" : "A link to the s3 bucket destination",
+                                        "Children" : linkChildrenConfiguration
+                                    },
+                                    {
+                                        "Names" : "Prefix",
+                                        "Description" : "A prefix for the s3 bucket destination",
+                                        "Type" : STRING_TYPE,
+                                        "Default" : "FlowLogs/"
+                                    }
+                                ]
+                            }
+                        ]
                     }
                 ]
             },

--- a/providers/shared/components/network/id.ftl
+++ b/providers/shared/components/network/id.ftl
@@ -38,10 +38,10 @@
                         "Subobjects" : true,
                         "Children" : [
                             {
-                                "Names" : "TrafficType",
+                                "Names" : "Action",
                                 "Type" : STRING_TYPE,
-                                "Description" : "The type of traffic to capture in the flow log",
-                                "Values" : [ "accept", "reject", "all" ],
+                                "Description" : "The action to capture in the flow log",
+                                "Values" : [ "accept", "reject", "any" ],
                                 "Mandatory" : true
                             },
                             {


### PR DESCRIPTION
## Description
Adds the ability to define and create your own network flow logs. Logs can either be sent to s3 or a log, s3 being our current component type name for object store and log for the providers native logging service 

Users can create different flows for different actions which have been applied to the flow ( accept, reject, all ) and then route this to an appropriate destination. 

This deprecates the existing boolean flow logs configuration 

## Motivation and Context
Flow logs can be used for a number of different purposes so allowing for them to be controlled and managed by the user makes sense 

## How Has This Been Tested?
tested locally and on development deployment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
