### PR TITLE
Data feed deployment specific prefixes

### DIFF
--- a/providers/shared/components/datafeed/id.ftl
+++ b/providers/shared/components/datafeed/id.ftl
@@ -56,6 +56,24 @@
                         "Type" : STRING_TYPE,
                         "Description" : "The prefix appeneded to the object name when processing failed",
                         "Default" : "error/"
+                    },
+                    {
+                        "Names" : "Include",
+                        "Description" : "Details to add to prefix",
+                        "Children" : [
+                            {
+                                "Names" : "Order",
+                                "Description" : "The order of the included prefixes",
+                                "Type" : ARRAY_OF_STRING_TYPE,
+                                "Default" : [ "AccountId" ]
+                            }
+                            {
+                                "Names" : "AccountId",
+                                "Description" : "The deployment account id",
+                                "Type" : BOOLEAN_TYPE,
+                                "Default" : false
+                            }
+                        ]
                     }
                 ]
             },

--- a/providers/shared/components/datafeed/id.ftl
+++ b/providers/shared/components/datafeed/id.ftl
@@ -65,12 +65,18 @@
                                 "Names" : "Order",
                                 "Description" : "The order of the included prefixes",
                                 "Type" : ARRAY_OF_STRING_TYPE,
-                                "Default" : [ "AccountId" ]
+                                "Default" : [ "AccountId", "ComponentPath" ]
                             }
                             {
                                 "Names" : "AccountId",
                                 "Description" : "The deployment account id",
                                 "Type" : BOOLEAN_TYPE,
+                                "Default" : false
+                            },
+                            {
+                                "Names" : "ComponentPath",
+                                "Description" : "The full component path defaults",
+                                "Type": BOOLEAN_TYPE,
                                 "Default" : false
                             }
                         ]

--- a/providers/shared/components/datafeed/id.ftl
+++ b/providers/shared/components/datafeed/id.ftl
@@ -59,7 +59,7 @@
                     },
                     {
                         "Names" : "Include",
-                        "Description" : "Details to add to prefix",
+                        "Description" : "Deployment specific details to add to prefix",
                         "Children" : [
                             {
                                 "Names" : "Order",


### PR DESCRIPTION
## Description
Adds support for including deployment specific prefixes to the user defined prefix

## Motivation and Context
Making paths globally unique for datafeeds is a requirement when creating consolidated data stores or having a path with identifiable details in it. This allows for these details to be injected in the datafeed deployment based on where the datafeed has been deployed

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
