### PR TITLE
feat(secretstore): update configuration and make it shareable

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -89,8 +89,10 @@
 
 [#assign NETWORK_ACL_COMPONENT_TYPE = "networkacl"]
 [#assign NETWORK_COMPONENT_TYPE = "network" ]
+
 [#assign NETWORK_GATEWAY_COMPONENT_TYPE = "gateway"]
 [#assign NETWORK_GATEWAY_DESTINATION_COMPONENT_TYPE = "gatewaydestination"]
+
 [#assign NETWORK_ROUTE_TABLE_COMPONENT_TYPE = "networkroute"]
 
 [#assign NETWORK_ROUTER_COMPONENT_TYPE = "router"]
@@ -977,6 +979,114 @@
         ]
     }
 ]]
+
+
+[#assign secretTemplateConfiguration = [
+    {
+        "Names" : "Generated",
+        "Children" : [
+            {
+                "Names" : "Content",
+                "Description" : "A JSON object which contains the nonsensitve parts of the secret",
+                "Type" : OBJECT_TYPE,
+                "Default" : {
+                    "username" : "admin"
+                }
+            },
+            {
+                "Names" : "SecretKey",
+                "Description" : "The key in the JSON secret to set the generated secret to",
+                "Type" : STRING_TYPE,
+                "Default" : "password"
+            }
+        ]
+    }
+]]
+
+[#assign secretRotationConfiguration = [
+    {
+        "Names" : "Lifecycle",
+        "Description" : "The lifecycle for a given Secret.",
+        "Children" : [
+            {
+                "Names" : "Rotation",
+                "Description" : "The Secret rotation schedule, in number of days - accepts rate() or cron() formats.",
+                "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Description" : "Enable Secret rotation.",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    }
+                ]
+            }
+        ]
+    }
+]]
+
+[#assign secretConfiguration = [
+    {
+        "Names" : "Source",
+        "Type" : STRING_TYPE,
+        "Values" : [ "user", "generated" ],
+        "Default" : "user"
+    },
+    {
+        "Names" : "Requirements",
+        "Description" : "Format requirements for the Secret",
+        "Children" : [
+            {
+                "Names" : "MinLength",
+                "Description" : "The minimum character length",
+                "Type" : NUMBER_TYPE,
+                "Default" : 20
+            },
+            {
+                "Names" : "MaxLength",
+                "Description" : "The maximum character length",
+                "Type" : NUMBER_TYPE,
+                "Default" : 30
+            },
+            {
+                "Names" : "IncludeUpper",
+                "Description" : "Include upper-case characters",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "IncludeLower",
+                "Description" : "Include lower-case characters",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "IncludeSpecial",
+                "Description" : "Include special characters",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "IncludeNumber",
+                "Description" : "Include numbers characters",
+                "Type" : BOOLEAN_TYPE,
+                "Default": true
+            },
+            {
+                "Names" : "ExcludedCharacters",
+                "Description" : "Characters that must be excluded",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : [ r'"', r"'", r'$', r'@', r'/', r'\' ]
+            },
+            {
+                "Names" : "RequireAllIncludedTypes",
+                "Description" : "Require at least one of each included type",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            }
+        ]
+    }
+    ]
+]
 
 [#assign networkRuleChildConfiguration = [
     {

--- a/providers/shared/components/secretstore/id.ftl
+++ b/providers/shared/components/secretstore/id.ftl
@@ -14,6 +14,12 @@
             }
         ]
     attributes=[
+        {
+            "Names" : "Engine",
+            "Description" : "The type of secret store",
+            "Values" : [],
+            "Mandatory" : true
+        }
     ]
 /]
 
@@ -22,76 +28,13 @@
     properties=[
             {
                 "Type"  : "Description",
-                "Value" : "A Secret stored within a given SecretStore."
+                "Value" : "A manually defined secret"
             }
         ]
-    attributes=[
-            {
-                "Names" : "Source",
-                "Type" : STRING_TYPE,
-                "Values" : [ "user", "generated" ],
-                "Default" : "user"
-            },
-            {
-                "Names" : "Lifecycle",
-                "Description" : "The lifecycle for a given Secret.",
-                "Children" : [
-                    {
-                        "Names" : "Rotation",
-                        "Description" : "The Secret rotation schedule, in number of days - accepts rate() or cron() formats.",
-                        "Children" : [
-                            {
-                                "Names" : "Enabled",
-                                "Description" : "Enable Secret rotation.",
-                                "Type" : BOOLEAN_TYPE,
-                                "Default" : false
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "Names" : "Requirements",
-                "Description" : "Format requirements for the Secret.",
-                "Children" : [
-                    {
-                        "Names" : "MinLength",
-                        "Description" : "The minimum character length for the Secret.",
-                        "Type" : NUMBER_TYPE,
-                        "Default" : 20
-                    },
-                    {
-                        "Names" : "MaxLength",
-                        "Description" : "The maximum character length for the Secret.",
-                        "Type" : NUMBER_TYPE,
-                        "Default" : 30
-                    },
-                    {
-                        "Names" : "IncludeUpper",
-                        "Description" : "Include upper-case characters in Secret.",
-                        "Type" : BOOLEAN_TYPE,
-                        "Mandatory" : true
-                    },
-                    {
-                        "Names" : "IncludeLower",
-                        "Description" : "Include lower-case characters in Secret.",
-                        "Type" : BOOLEAN_TYPE,
-                        "Mandatory" : true
-                    },
-                    {
-                        "Names" : "IncludeSpecial",
-                        "Description" : "Include special characters in Secret.",
-                        "Type" : BOOLEAN_TYPE,
-                        "Mandatory" : false
-                    },
-                    {
-                        "Names" : "ExcludedCharacters",
-                        "Description" : "Characters that must be excluded from Secret.",
-                        "Type" : ARRAY_OF_STRING_TYPE
-                    }
-                ]
-            }
-        ]
+    attributes=
+        secretConfiguration +
+        secretTemplateConfiguration +
+        secretRotationConfiguration
     parent=SECRETSTORE_COMPONENT_TYPE
     childAttribute="Secrets"
     linkAttributes="Secret"


### PR DESCRIPTION
## Description

Some refactors and updates to the secretstore configuration
- Breakout the configuration into sections which can be used on other components - ideally this would be metaparameters in the future 
     - A template section which allows for the creation of a json based secret with extra parameters ( username etc ) along with specifying a key where a generated secret would be stored 
     - Rotation for components which handle secret rotation 
     - The secret definition which defines the secret source and the policy required for the secret 
- Adds some extra policy conditions which were missed originally 

## Motivation and Context

Some components require secrets to be provided as part of their deployment, they are also locked to the component so instead of making them subcomponents of the secret store it makes more sense to establish standard configuration for components which need secrets to be defined.

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
