### PR TITLE
Queuehost component

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -102,6 +102,8 @@
 
 [#assign PRIVATE_SERVICE_COMPONENT_TYPE = "privateservice" ]
 
+[#assign QUEUEHOST_COMPONENT_TYPE = "queuehost" ]
+
 [#assign S3_COMPONENT_TYPE = "s3" ]
 
 [#assign SECRETSTORE_COMPONENT_TYPE = "secretstore" ]

--- a/providers/shared/components/id.ftl
+++ b/providers/shared/components/id.ftl
@@ -122,6 +122,7 @@
 [#assign LASTRESTORE_ATTRIBUTE_TYPE = "lastrestore" ]
 [#assign REGION_ATTRIBUTE_TYPE = "region"]
 [#assign EVENTSTREAM_ATTRIBUTE_TYPE = "stream"]
+[#assign SECRET_ATTRIBUTE_TYPE = "secret"]
 
 [#-- special attribute type to handle references --]
 [#assign REFERENCE_ATTRIBUTE_TYPE = "ref" ]
@@ -146,4 +147,3 @@
             resourceId,
             QUALIFIER_ATTRIBUTE_TYPE) ]
 [/#function]
-

--- a/providers/shared/components/queuehost/id.ftl
+++ b/providers/shared/components/queuehost/id.ftl
@@ -133,6 +133,12 @@
                         "Default" : "root"
                     },
                     {
+                        "Names" : "EncryptionScheme",
+                        "Type" : STRING_TYPE,
+                        "Description" : "A prefix appended to link attributes to show encryption status",
+                        "Default" : ""
+                    },
+                    {
                         "Names" : "Secret",
                         "Children" : secretConfiguration
                     },

--- a/providers/shared/components/queuehost/id.ftl
+++ b/providers/shared/components/queuehost/id.ftl
@@ -1,0 +1,147 @@
+[#ftl]
+
+[@addComponentDeployment
+    type=QUEUEHOST_COMPONENT_TYPE
+    defaultGroup="solution"
+/]
+
+[@addComponent
+    type=QUEUEHOST_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "Managed message queue hosting"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Type" : STRING_TYPE,
+                "Values" : [ "rabbitmq" ],
+                "Mandatory" : true
+            },
+            {
+                "Names" : "EngineVersion",
+                "Type" : STRING_TYPE,
+                "Mandatory" : true
+            },
+            {
+                "Names" : "IPAddressGroups",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : [ "_localnet" ]
+            },
+            {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Profiles",
+                "Children" :
+                    [
+                        {
+                            "Names" : "Alert",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
+                            "Names" : "Network",
+                            "Type" : STRING_TYPE,
+                            "Default" : "default"
+                        }
+                    ]
+            },
+            {
+                "Names" : "Processor",
+                "Children" : [
+                    {
+                        "Names" : "Type",
+                        "Type" : STRING_TYPE,
+                        "Mandatory" : true
+                    }
+                ]
+            },
+            {
+                "Names" : "Hibernate",
+                "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "StartUpMode",
+                        "Type" : STRING_TYPE,
+                        "Values" : ["replace"],
+                        "Default" : "replace"
+                    }
+                ]
+            },
+            {
+                "Names" : "Alerts",
+                "Subobjects" : true,
+                "Children" : alertChildrenConfiguration
+            },
+            {
+                "Names" : "Encrypted",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "MaintenanceWindow",
+                "Children" : [
+                    {
+                        "Names" : "DayOfTheWeek",
+                        "Type" : STRING_TYPE,
+                        "Values" : [
+                            "Sunday",
+                            "Monday",
+                            "Tuesday",
+                            "Wednesday",
+                            "Thursday",
+                            "Friday",
+                            "Saturday"
+                        ],
+                        "Default" : "Sunday"
+                    },
+                    {
+                        "Names" : "TimeOfDay",
+                        "Type" : STRING_TYPE,
+                        "Default" : "00:00"
+                    },
+                    {
+                        "Names" : "TimeZone",
+                        "Type" : STRING_TYPE,
+                        "Default" : "UTC"
+                    }
+                ]
+            },
+            {
+                "Names" : "AutoMinorUpgrade",
+                "Type" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "RootCredentials",
+                "Description" : "Secret store configuration for the root credentials",
+                "Children" : [
+                    {
+                        "Names" : "Username",
+                        "Type" : STRING_TYPE,
+                        "Default" : "root"
+                    },
+                    {
+                        "Names" : "Secret",
+                        "Children" : secretConfiguration
+                    },
+                    {
+                        "Names" : "SecretStore",
+                        "Description" : "A link to the certificate store which will keep the secret",
+                        "Children"  : linkChildrenConfiguration
+                    }
+                ]
+            }
+        ]
+/]

--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -650,6 +650,28 @@
               "Timeout": "5"
             }
           },
+          "rabbitmq": {
+            "Port": 5671,
+            "IPProtocol": "tcp",
+            "HealthCheck": {
+              "HealthyThreshold": "3",
+              "UnhealthyThreshold": "5",
+              "Interval": "30",
+              "Timeout": "5"
+            }
+          },
+          "rabbitmq-ui": {
+            "Port": 15671,
+            "Protocol": "HTTP",
+            "IPProtocol": "tcp",
+            "HealthCheck": {
+              "Path": "/",
+              "HealthyThreshold": "2",
+              "UnhealthyThreshold": "3",
+              "Interval": "30",
+              "Timeout": "5"
+            }
+          },
           "redis": {
             "Port": 6379,
             "Protocol": "TCP",


### PR DESCRIPTION
## Description
initial definition of the queuehost component which is aimed to support managed queue broker services such as AmazonMq from AWS. The initial implementation focuses on a rabbitmq broker which requires a single admin user and is managed as a dedicated instance of the broker

## Motivation and Context
Queuehosts differ from a managed queue in that they are actually offering the hosting services to create any number of queues or associated services which can be defined as part of an application 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
