### PR TITLE
feat(alerts): get metric dimensions from blueprint

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -1187,6 +1187,35 @@ behaviour.
     ]
 [/#function]
 
+
+[#function getMetricDimensions alert monitoredResource resources environment={}]
+    [#switch alert.DimensionSource]
+        [#case "Resource" ]
+            [#return getResourceMetricDimensions(monitoredResource, resources)]
+            [#break]
+
+        [#case "Configured" ]
+            [#local dimensions = [] ]
+            [#list alert.Dimensions as id, dimension ]
+                [#local value = ""]
+                [#if ((dimension.SettingEnvName)!"")?has_content ]
+                    [#local value = (environment["Environment"][dimension.SettingEnvName])!"" ]
+                [#else]
+                    [#local value = (dimension.Value)!"" ]
+                [/#if]
+
+                [#local dimensions += [ {
+                    "Name" : dimension.Key,
+                    "Value" : value
+                }]]
+            [/#list]
+            [#return dimensions]
+            [#break]
+    [/#switch]
+
+    [#return []]
+[/#function]
+
 [#function getResourceMetricDimensions resource resources]
     [#local resourceMetricAttributes = metricAttributes[resource.Type]!{} ]
 

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -313,7 +313,15 @@
             "Default" : ""
         },
         {
+            "Names" : "DimensionSource",
+            "Description" : "The source of the alert dimensions - resource lookup or explicit configuration",
+            "Type" : STRING_TYPE,
+            "Values" : [ "Resouce", "Configured" ],
+            "Default" : "Resource"
+        },
+        {
             "Names" : "Resource",
+            "Description" : "Provide a component resource to determine the dimensions of the metric",
             "Children" : [
                 {
                     "Names" : "Id",
@@ -322,6 +330,28 @@
                 {
                     "Names" : "Type",
                     "Type" : STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : "Dimensions",
+            "Description" : "Explicit configured dimensions",
+            "Subobjects" : true,
+            "Children" : [
+                {
+                    "Names" : "Key",
+                    "Description" : "The Key of the dimension",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Names" : "Value",
+                    "Description" : "The value of the dimension to match",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Names" : "SettingEnvName",
+                    "Description" : "A setting name as env that will provide the dimension value",
+                    "Type": STRING_TYPE
                 }
             ]
         },

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -316,7 +316,7 @@
             "Names" : "DimensionSource",
             "Description" : "The source of the alert dimensions - resource lookup or explicit configuration",
             "Type" : STRING_TYPE,
-            "Values" : [ "Resouce", "Configured" ],
+            "Values" : [ "Resource", "Configured" ],
             "Default" : "Resource"
         },
         {


### PR DESCRIPTION
## Description
Adds support for explicit alert metric dimensions defined as part of settings or solution configuration

## Motivation and Context
When monitoring systems its common to create your own metrics based on business data which are stored in your monitoring system. This allows you to generate alarms on system infrastructure and business related events. Currently our alert support would only allow for defining metric dimensions based on component resources. As a result of this you couldn't create alerts based on business metrics which don't map to resources

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
