### PR TITLE
feat(ecs): support container image sourcing

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -1187,6 +1187,35 @@ behaviour.
     ]
 [/#function]
 
+[#function getImageFromContainerRegistryScript
+        product
+        environment
+        segment
+        occurrence
+        sourceImage
+        imageFormat
+        registryHost
+        registryProvider
+        region=""
+    ]
+
+    [#local buildUnit = getOccurrenceBuildUnit(occurrence) ]
+
+    [#return
+        [
+            r'get_image_from_container_registry' +
+            r'   "' + sourceImage + r'" ' +
+            r'   "' + imageFormat + r'" ' +
+            r'   "' + product + r'" ' +
+            r'   "' + environment + r'" ' +
+            r'   "' + segment + r'" ' +
+            r'   "' + buildUnit + r'" ' +
+            r'   "' + registryHost + r'" ' +
+            r'   "' + registryProvider + r'" ' +
+            r'   "' + region + r'" || exit $? '
+        ]
+    ]
+[/#function]
 
 [#function getMetricDimensions alert monitoredResource resources environment={}]
     [#switch alert.DimensionSource]

--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -813,18 +813,15 @@
                 "Version" : core.Version.Id,
                 "Essential" : true,
                 "RegistryEndPoint" : getRegistryEndPoint("docker", task),
-                "Image" : container.Image?has_content?then(
-                            container.Image,
-                            formatRelativePath(
-                                formatName(
-                                    getOccurrenceBuildProduct(task, productName),
-                                    getOccurrenceBuildScopeExtension(task)
-                                ),
-                                formatName(
-                                    getOccurrenceBuildUnit(task),
-                                    getOccurrenceBuildReference(task)
-                                )
-                            )
+                "Image" : formatRelativePath(
+                    formatName(
+                        getOccurrenceBuildProduct(task, productName),
+                        getOccurrenceBuildScopeExtension(task)
+                    ),
+                    formatName(
+                        getOccurrenceBuildUnit(task),
+                        getOccurrenceBuildReference(task)
+                    )
                 ),
                 "MemoryReservation" : container.MemoryReservation,
                 "Mode" : getContainerMode(container),
@@ -872,6 +869,9 @@
             attributeIfContent("Ulimits", container.Ulimits )
         ]
 
+        [#if container.Image.Source == "containerregistry" ]
+            [#assign _context += { "Image" : container.Image["Source:containerregistry"].Image }]
+        [/#if]
 
         [#local linkIngressRules = [] ]
         [#list _context.Links as linkId,linkTarget]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1235,9 +1235,28 @@
     },
     {
         "Names" : "Image",
-        "Type" : STRING_TYPE,
-        "Description" : "Overrides the image from the deployment unit",
-        "Default": ""
+        "Description" : "Set the source of the components image",
+        "Children" : [
+            {
+                "Names" : "Source",
+                "Description" : "The source of the image",
+                "Type" : STRING_TYPE,
+                "Mandatory" : true,
+                "Values" : [ "registry", "containerregistry" ],
+                "Default" : "Registry"
+            },
+            {
+                "Names" : "Source:containerregistry",
+                "Description" : "A docker container registry to source the image from",
+                "Children" : [
+                    {
+                        "Names" : "Image",
+                        "Description" : "The docker image that you want to use",
+                        "Type" : STRING_TYPE
+                    }
+                ]
+            }
+        ]
     },
     {
         "Names" : "Version",


### PR DESCRIPTION
## Description
service/task/containerservice/containertask implementation of https://github.com/hamlet-io/engine/issues/1486 

Allows for containers in tasks and services to specify a public docker image to use. On template generation the image will be pulled from the public registry and copied to the hamlet account docker registry. The image reference for the task is then updated to use this image

## Motivation and Context
Simplifies the use of public container images which used to be pulled in via the manageDocker script and didn't specifically align with the public image ( we no store the digests of the images for traceability ) 
Also allows for container deployments to be included in plugins and modules without having to build the images for each usage of the module 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
