### PR TITLE
refactor: support components with mixed case names

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -504,7 +504,7 @@
         [#local namespaces +=
             [
                 {
-                    "Key" : formatName(parts),
+                    "Key" : (formatName(parts)?lower_case,
                     "Match" : namespaceObject.Match
                 }
             ]
@@ -551,11 +551,11 @@
             []
         ) +
         [
-            {"Key" : occurrence.Core.Name, "Match" : "partial"},
-            {"Key" : occurrence.Core.TypedName, "Match" : "partial"},
-            {"Key" : occurrence.Core.ShortName, "Match" : "partial"},
-            {"Key" : occurrence.Core.ShortTypedName, "Match" : "partial"},
-            {"Key" : deploymentUnit, "Match" : "exact"}
+            {"Key" : (occurrence.Core.Name)?lower_case, "Match" : "partial"},
+            {"Key" : (occurrence.Core.TypedName)?lower_case, "Match" : "partial"},
+            {"Key" : (occurrence.Core.ShortName)?lower_case, "Match" : "partial"},
+            {"Key" : (occurrence.Core.ShortTypedName)?lower_case, "Match" : "partial"},
+            {"Key" : deploymentUnit?lower_case, "Match" : "exact"}
         ]
     ]
     [#return namespaces ]


### PR DESCRIPTION
## Description
Adds support for components with mixed case naming when handling settings namespaces

## Motivation and Context
When processing settings the namespace the settings are added into is lowercased during the processing step. When using a component with mixed casing in its name it can process everything except access settings which are based on its component name. 

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
