### PR TITLE
fix: dind hostname and image details

### DIFF
--- a/providers/shared/extensions/dind/extension.ftl
+++ b/providers/shared/extensions/dind/extension.ftl
@@ -27,13 +27,19 @@
 
     [#assign settings = _context.DefaultEnvironment]
 
-    [@Hostname hostname=_context.Name /]
+    [@Hostname hostname=(_context.Name)?replace("_", "") /]
 
     [#local dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/home/jenkins"  ]
     [#local dockerStageSize = settings["DOCKER_STAGE_SIZE_GB"]!"20"        ]
     [#local dockerStagePersist = (settings["DOCKER_STAGE_PERSIST"]?boolean)!false ]
     [#local dockerLibSize = settings["DOCKER_LIB_VOLUME_SIZE"]!"20"         ]
     [#local dindTLSVerify = settings["DIND_DOCKER_TLS_VERIFY"]!"true"      ]
+
+
+    [@Attributes
+        image="docker"
+        version="dind"
+    /]
 
     [#if dindTLSVerify?boolean ]
         [@Settings


### PR DESCRIPTION
## Description
Minor fixes to the dind extension following testing 
- Ensures the hostname doesn't contain _ characters which aren't supported 
- Sets that attributes for the dind images 

## Motivation and Context
The image configuration in solution was removes and replaced with image sourcing the hostname is from the migration to extensions

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
