### PR TITLE
fix: masterdata inclusion in blueprint

### DIFF
--- a/engine/bootstrap.ftl
+++ b/engine/bootstrap.ftl
@@ -100,10 +100,15 @@
 /]
 
 [@includeCoreProviderConfiguration commandLineOptions.Deployment.Provider.Names /]
+
+[#-- TODO(MFL) Following can be deleted I think as it just does what the next piece --]
+[#-- processing will repeat                                                         --]
+[#--]
 [@seedProviderInputSourceData
     providers=commandLineOptions.Deployment.Provider.Names
     inputTypes=[ "masterdata" ]
 /]
+--]
 
 [#-- Input data Seeding --]
 [#-- This controls the collection of all input data provided to the engine --]
@@ -116,8 +121,10 @@
     inputTypes=seedInputTypes
 /]
 
-[#-- Set the base blueprint from the provider masterdata --]
-[@addBlueprint blueprint=getMasterData() /]
+[#-- Set the base of blueprint from the provider masterdata --]
+[#-- Rebase is needed to ensure any overrides of master     --]
+[#-- data within the blueprint don't get overwritten        --]
+[@rebaseBlueprint base=getMasterData() /]
 
 [#-- Discover the layers which have been defined --]
 [#-- This needs to be done before module loading as layers define the modules to load and their parameters --]
@@ -137,11 +144,18 @@
     [/#list]
 [/#if]
 
+[#-- TODO(MFL) Code below needs reviewing                                  --]
+[#-- As modules will have potentially added to the various types of input, --]
+[#-- it seems odd to then replay the inputs over the top of this again     --]
+[#-- Is this to ensure whatever was explicitly provided takes precedence   --]
+[#-- over modules? Think we don't want that for master data but do for     --]
+[#-- everything else                                                       --]
+
 [#-- Refresh seed to allow for data from modules to be included --]
 [#if refreshInputData ]
     [@seedProviderInputSourceData
         providers=seedProviders
-        inputTypes=seedInputTypes
+        inputTypes=[ "blueprint", "stackoutput", "setting", "definition" ]
     /]
 [/#if]
 

--- a/engine/inputdata/blueprint.ftl
+++ b/engine/inputdata/blueprint.ftl
@@ -6,7 +6,17 @@
 [#macro addBlueprint blueprint={} ]
     [#if blueprint?has_content ]
         [@internalMergeBlueprint
+            base=blueprintObject
             blueprint=blueprint
+        /]
+    [/#if]
+[/#macro]
+
+[#macro rebaseBlueprint base={} ]
+    [#if base?has_content ]
+        [@internalMergeBlueprint
+            base=base
+            blueprint=blueprintObject
         /]
     [/#if]
 [/#macro]
@@ -15,10 +25,10 @@
 -- Internal support functions for blueprint processing --
 -------------------------------------------------------]
 
-[#macro internalMergeBlueprint blueprint ]
+[#macro internalMergeBlueprint base blueprint ]
     [#assign blueprintObject =
         mergeObjects(
-            blueprintObject,
+            base,
             blueprint
         )
     ]

--- a/engine/provider.ftl
+++ b/engine/provider.ftl
@@ -128,7 +128,7 @@
         [#if pluginRequired && !(definedPluginState?has_content) && plugin.Source != "local" ]
             [@fatal
                 message="Plugin setup not complete"
-                detail="A plugin was required but plugin setup as not been run"
+                detail="A plugin was required but plugin setup has not been run"
                 context=plugin
             /]
         [/#if]
@@ -236,12 +236,12 @@
             [/#list]
 
             [#-- Determine the metaparameters for the provider --]
-            [#local directories = 
+            [#local directories =
                 internalGetPluginFiles(
                     [providerMarker.Path, "metaparameters"],
                     [
                         ["[^/]+"]
-                    ] 
+                    ]
                 )
             ]
             [#list directories as directory]


### PR DESCRIPTION
## Description
Ensure overrides in the blueprint of the masterdata are not lost during assembly of the blueprintObject.


## Motivation and Context
Previously, the merging of the masterdata with the blueprint caused changes to be lost. This fix introduces a new function to permit the blueprint to be rebased on the master data effectively ensuring that blueprint data takes precedence over master data.

Some comments were also added to the bootstrap process that need confirmation. If correct, then some of the bootstrap processing (currently commented out) can be removed.

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
Local template generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
