### PR TITLE
feat: account inbound ses configuration

### DIFF
--- a/legacy/account/account_ses.ftl
+++ b/legacy/account/account_ses.ftl
@@ -1,0 +1,42 @@
+[#-- SES ruleset --]
+[#if getDeploymentUnit()?contains("sesruleset") || (groupDeploymentUnits!false) ]
+    [#if deploymentSubsetRequired("generationcontract", false)]
+        [@addDefaultGenerationContract subsets="template" /]
+    [/#if]
+
+    [#if deploymentSubsetRequired("sesruleset", true) ]
+        [@includeServicesConfiguration
+            provider=AWS_PROVIDER
+            services=[AWS_SIMPLE_EMAIL_SERVICE ]
+            deploymentFramework=commandLineOptions.Deployment.Framework.Name
+        /]
+
+        [#if (accountObject["aws:SES"].RuleSet.Name)?has_content]
+            [@createSESReceiptRuleSet
+                id=formatSESReceiptRuleSetId()
+                name=accountObject["aws:SES"].RuleSet.Name
+            /]
+        [#else]
+            [@fatal message="The aws:SES.RuleSet.Name attribute is required in the account object" /]
+        [/#if]
+
+        [#-- Add any required IP Address filtering --]
+        [#if getGroupCIDRs(accountObject["aws:SES"].IPAddressGroups, true, occurrence, true)]
+            [#list (getGroupCIDRs(accountObject["aws:SES"].IPAddressGroups, true, occurrence))?filter(cidr -> cidr?has_content) as cidr ]
+                [@createSESReceiptIPFilter
+                    id=formatSESReceiptFilterId(replaceAlphaNumericOnly(cidr,"X"))
+                    name=formatName("account", replaceAlphaNumericOnly(cidr,"-"))
+                    cidr=cidr
+                /]
+            [/#list]
+
+            [#-- Add a default block all rule --]
+            [@createSESReceiptIPFilter
+                    id=formatSESReceiptFilterId("0X0X0X0X0")
+                    name=formatName("account", "0-0-0-0-0")
+                    cidr="0.0.0.0/0"
+                    allow=false
+                /]
+        [/#if]
+    [/#if]
+[/#if]

--- a/providers/shared/layers/Account/id.ftl
+++ b/providers/shared/layers/Account/id.ftl
@@ -230,6 +230,29 @@
                     "Type" : NUMBER_TYPE
                 }
             ]
+        },
+        {
+            "Names" : "aws:SES",
+            "Description" : "AWS SES Account configuration",
+            "Children" : [
+                {
+                    "Names" : "RuleSet",
+                    "Description" : "Ruleset details. Only one active per account",
+                    "Children" : [
+                        {
+                            "Names" : "Name",
+                            "Description" : "Name of the ruleset",
+                            "Type" : STRING_TYPE,
+                            "Default" : "account-default"
+                        }
+                    ]
+                },
+                {
+                    "Names" : "IPAddressGroups",
+                    "Type" : ARRAY_OF_STRING_TYPE,
+                    "Default" : []
+                }
+            ]
         }
     ]
 /]


### PR DESCRIPTION
## Description
Add the ability to create account level resources for receiving emails. This covers the active ruleset and any IP filters applied to
incoming emails for the account.

## Motivation and Context
The account configuration should be performed in the same region as will be used to configure the rules for inbound mail receipt. This is done by configuring the specific unit region in the Account object.

Because only one rule set can be active in an account/region, and rules are ordered by referencing the names of existing rules, there is a solution level configuration setting on the inbound mta to set the rule expected to exist.

## How Has This Been Tested?
Local template generation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Refactor aws support for inbound mtas to rely on the account level configuration.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
