### PR TITLE
feat: globaldb secondary indexes

### DIFF
--- a/providers/shared/components/globaldb/id.ftl
+++ b/providers/shared/components/globaldb/id.ftl
@@ -38,6 +38,60 @@
                 "Description" : "A key in the table used to manage the items expiry",
                 "Type" : STRING_TYPE,
                 "Default" : ""
+            },
+            {
+                "Names" : "KeyTypes",
+                "Description" : "Key types - default is string",
+                "SubObjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Type",
+                        "Description" : "Key value type",
+                        "Type" : STRING_TYPE,
+                        "Values" : [STRING_TYPE, NUMBER_TYPE, "binary"]
+                    }
+                ]
+            },
+            {
+                "Names" : "SecondaryIndexes",
+                "Description" : "Alternate indexes for query efficiency",
+                "SubObjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Name",
+                        "Description" : "Index name",
+                        "Type" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "Keys",
+                        "Description" : "List of keys",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Mandatory" : true
+                    },
+                    {
+                        "Names" : "KeyTypes",
+                        "Description" : "Type of each key - default is hash(0) then range",
+                        "Type" : ARRAY_OF_STRING_TYPE,
+                        "Values" : ["hash", "range"]
+                    },
+                    {
+                        "Names" : "Capacity",
+                        "Children" : [
+                            {
+                                "Names" : "Read",
+                                "Description" : "When using provisioned billing the maximum RCU of the table",
+                                "Type" : NUMBER_TYPE,
+                                "Default" : 1
+                            },
+                            {
+                                "Names" : "Write",
+                                "Description" : "When using provisioned billing the maximum WCU of the table",
+                                "Type" : NUMBER_TYPE,
+                                "Default" : 1
+                            }
+                        ]
+                    }
+                ]
             }
         ]
 /]


### PR DESCRIPTION
## Description
Add additional configuration to support secondary indexes and keys with non-string types.

## Motivation and Context
Project need to support more complex globaldb deployments.

## How Has This Been Tested?
Local template generations

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] AWS Implementation - https://github.com/hamlet-io/engine-plugin-aws/pull/204

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
