### PR TITLE
feat(s3): add s3vpcaccess

### DIFF
--- a/providers/shared/components/s3/id.ftl
+++ b/providers/shared/components/s3/id.ftl
@@ -79,6 +79,12 @@
                 ]
             },
             {
+                "Names" : [ "Extensions" ],
+                "Description" : "Extensions to invoke as part of component processing",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
                 "Names" : "Style",
                 "Type" : STRING_TYPE,
                 "Description" : "TODO(mfl): Think this can be removed"

--- a/providers/shared/extensions/s3vpcaccess/extension.ftl
+++ b/providers/shared/extensions/s3vpcaccess/extension.ftl
@@ -9,7 +9,7 @@
         "Set up an access within VPC to s3 items"
     ]
     supportedTypes=[
-        "*"
+        S3_COMPONENT_TYPE
     ]
 /]
 

--- a/providers/shared/extensions/s3vpcaccess/extension.ftl
+++ b/providers/shared/extensions/s3vpcaccess/extension.ftl
@@ -1,0 +1,89 @@
+[#ftl]
+
+[@addExtension
+    id="s3vpcaccess"
+    aliases=[
+        "_s3vpcaccess"
+    ]
+    description=[
+        "Set up an access within VPC to s3 items"
+    ]
+    supportedTypes=[
+        "*"
+    ]
+/]
+
+[#macro shared_extension_s3vpcaccess_deployment_setup occurrence ]
+        [#local solution = occurrence.Configuration.Solution ]
+        [#local policyStatements = [] ]
+        [#local resources = occurrence.State.Resources ]
+        [#local s3Name = resources["bucket"].Name ]
+
+        [#list solution.PublicAccess?values as publicAccessConfiguration]
+        [#list publicAccessConfiguration.Paths as publicPrefix]
+            [#if publicAccessConfiguration.Enabled ]
+                [#local publicIPWhiteList =
+                    getIPCondition(getGroupCIDRs(publicAccessConfiguration.IPAddressGroups, true)) ]
+
+                [#-- aws:SourceVpc condition is needed to make public files accessible from docker containers running within VPC --]
+
+                [#local occurrenceNetwork = getOccurrenceNetwork(occurrence) ]
+                [#local networkLink = occurrenceNetwork.Link!{} ]
+                [#if networkLink?has_content ]
+                    [#local networkLinkTarget = getLinkTarget(occurrence, networkLink, false) ]
+                    [#local networkConfiguration = networkLinkTarget.Configuration.Solution]
+                    [#local networkResources = networkLinkTarget.State.Resources ]
+                    [#local vpcId = networkResources["vpc"].Id ]
+
+                    [#switch publicAccessConfiguration.Permissions ]
+                        [#case "ro" ]
+                            [#local policyStatements += s3ReadPermission(
+                                                            s3Name,
+                                                            publicPrefix,
+                                                            "*",
+                                                            "*",
+                                                            {
+                                                                "StringEquals": {
+                                                                    "aws:SourceVpc": getExistingReference(vpcId)
+                                                                }
+                                                            })]
+                            [#break]
+                        [#case "wo" ]
+                            [#local policyStatements += s3WritePermission(
+                                                            s3Name,
+                                                            publicPrefix,
+                                                            "*",
+                                                            "*",
+                                                            {
+                                                                "StringEquals": {
+                                                                    "aws:SourceVpc": getExistingReference(vpcId)
+                                                                }
+                                                            })]
+                            [#break]
+                        [#case "rw" ]
+                            [#local policyStatements += s3AllPermission(
+                                                            s3Name,
+                                                            publicPrefix,
+                                                            "*",
+                                                            "*",
+                                                            {
+                                                                "StringEquals": {
+                                                                    "aws:SourceVpc": getExistingReference(vpcId)
+                                                                }
+                                                            })]
+                            [#break]
+                    [/#switch]
+                [/#if]
+
+
+            [/#if]
+        [/#list]
+    [/#list]
+
+    [#assign _context +=
+        {
+            "Policy" : policyStatements
+        }
+    ]
+
+[/#macro]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
An extension that provides access for publically available files in an s3 bucket from the VPC.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For one of the tenants, we faced the situation when SourIP condition wasn't working for accessing the publically available files from the docker containers running on ECS within a VPC, so SourceVPC condition needed to be added.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
