### PR TITLE
feat(template): url image sourcing

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -1084,7 +1084,7 @@ behaviour.
 
 [/#function]
 
-[#function getBuildScript filesArrayName region registry product occurrence filename]
+[#function getBuildScript filesArrayName region registry product occurrence filename buildUnit=""]
     [#return
         [
             "copyFilesFromBucket" + " " +
@@ -1094,7 +1094,10 @@ behaviour.
                 getRegistryPrefix(registry, occurrence),
                 getOccurrenceBuildProduct(occurrence, product),
                 getOccurrenceBuildScopeExtension(occurrence),
-                getOccurrenceBuildUnit(occurrence),
+                buildUnit?has_content?then(
+                    buildUnit,
+                    getOccurrenceBuildUnit(occurrence)
+                ),
                 getOccurrenceBuildReference(occurrence)) + " " +
                 "\"$\{tmpdir}\" || return $?",
             "#",
@@ -1156,7 +1159,7 @@ behaviour.
 
 [/#function]
 
-[#function getImageFromUrlScript region product environment segment occurrence sourceURL imageFormat registryFile expectedImageHash=""  ]
+[#function getImageFromUrlScript region product environment segment occurrence sourceURL imageFormat registryFile expectedImageHash="" createZip=false  ]
 
     [#local registryBucket = getRegistryEndPoint(imageFormat, occurrence) ]
     [#local registryPrefix =
@@ -1182,7 +1185,8 @@ behaviour.
             r'   "' + product + r'" ' +
             r'   "' + environment + r'" ' +
             r'   "' + segment + r'" ' +
-            r'   "' + buildUnit + r'" || exit $?'
+            r'   "' + buildUnit + r'" ' +
+            r'   "' + createZip?c + r'" || exit $?'
         ]
     ]
 [/#function]

--- a/providers/shared/components/template/id.ftl
+++ b/providers/shared/components/template/id.ftl
@@ -82,6 +82,37 @@
                 "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "Image",
+                "Description" : "Control the source of the image that is used for the function",
+                "Children" : [
+                    {
+                        "Names" : "Source",
+                        "Description" : "The source of the image - registry is the hamlet registry",
+                        "Type" : STRING_TYPE,
+                        "Mandatory" : true,
+                        "Values" : [ "registry", "url" ],
+                        "Default" : "registry"
+                    },
+                    {
+                        "Names" : "UrlSource",
+                        "Description" : "Url Source specific Configuration",
+                        "Children" : [
+                            {
+                                "Names" : "Url",
+                                "Description" : "The Url to the lambda zip file",
+                                "Type" : STRING_TYPE
+                            },
+                            {
+                                "Names" : "ImageHash",
+                                "Description" : "The expected sha1 hash of the Url if empty any will be accepted",
+                                "Type" : STRING_TYPE,
+                                "Default" : ""
+                            }
+                        ]
+                    }
+                ]
             }
         ]
 /]


### PR DESCRIPTION
## Description
Adds image sourcing via URL to the template component

Adds a configuration option to the Url image source process to handle
content which hasn't been provided as a zip

## Motivation and Context
This allows for directly sourcing a template file into a deployment instead of going through the build process. The standard build process is still supported. This is mostly for quick prototyping or for demonstration purposes

## How Has This Been Tested?
Tested on development environment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
