### PR TITLE
fix: revert type updates

### DIFF
--- a/engine/engine.ftl
+++ b/engine/engine.ftl
@@ -21,7 +21,7 @@ Title and Description are entirely for human consumption and targetted at
 the automated generation of documentation.
 --]
 
-[#assign frameworkObjectAttributes = ["Types", "Id", "Name", "Title", "Description"]]
+[#assign frameworkObjectAttributes = ["Type", "Id", "Name", "Title", "Description"]]
 
 [#function getFrameworkObjectAttributes obj]
     [#return getObjectAttributes(obj, frameworkObjectAttributes)]
@@ -32,7 +32,7 @@ the automated generation of documentation.
 [/#function]
 
 [#function getObjectType obj]
-    [#return obj.Types!""]
+    [#return obj.Type!""]
 [/#function]
 
 [#function getObjectId obj]

--- a/engine/openapi.ftl
+++ b/engine/openapi.ftl
@@ -289,7 +289,7 @@
     {
         "Path" : ".*",
         "Verb" : ".*",
-        "Types" : "",
+        "Type" : "",
         "Variable" : "",
         "Validation" : "all",
         "UseClientCreds" : false,


### PR DESCRIPTION
## Description
Some minor changes to revert Type configuration on properties which weren't part of the getCompositeObject type updates in #1514 

## Motivation and Context
The Type properties in this PR are not used during getCompositeObject processing so should still be kept as the singular Type to maintain compatibility with their usage

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
