### PR TITLE
feat(userpool): authprovider extensions

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -135,7 +135,7 @@
     [#return result.Environment]
 [/#function]
 
-[#function getDefaultBaselineVariables links ]
+[#function getDefaultBaselineVariables links={} ]
     [#local result = {"Links" : links, "Environment": {} }]
     [#list links as name,value]
         [#if (value.Direction?lower_case != "inbound") || includeInbound]
@@ -146,13 +146,16 @@
 [/#function]
 
 
-[#function defaultEnvironment occurrence links baselineLinks]
+[#function defaultEnvironment occurrence links baselineLinks={}]
     [#return
         occurrence.Configuration.Environment.General +
         occurrence.Configuration.Environment.Build +
         occurrence.Configuration.Environment.Sensitive +
         getDefaultLinkVariables(links, true) +
-        getDefaultBaselineVariables(baselineLinks)
+        baselineLinks?has_content?then(
+            getDefaultBaselineVariables(baselineLinks),
+            {}
+        )
     ]
 [/#function]
 

--- a/providers/shared/components/userpool/id.ftl
+++ b/providers/shared/components/userpool/id.ftl
@@ -295,6 +295,17 @@
     attributes=
         [
             {
+                "Names" : "Links",
+                "Subobjects" : true,
+                "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : [ "Extensions" ],
+                "Description" : "Extensions to invoke as part of component processing",
+                "Types" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
                 "Names" : "Engine",
                 "Description" : "The authentication provider type",
                 "Types" : STRING_TYPE,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds extensions and links to the AuthProvider sub component of a userpool

## Motivation and Context

This allows for extensions to define the settings required to configure federation to be generated through code in extensions. This allows for links or other dynamically generated values

## How Has This Been Tested?
Tested locally and on development deployment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
