### PR TITLE
refactor(schemaset): align task attributes

### DIFF
--- a/providers/shared/tasks/create_schemas/id.ftl
+++ b/providers/shared/tasks/create_schemas/id.ftl
@@ -10,17 +10,12 @@
         ]
     attributes=[
         {
-            "Names" : "DeploymentUnit",
+            "Names" : "SchemaType",
             "Types" : STRING_TYPE,
             "Mandatory" : true
         },
         {
-            "Names" : "DeploymentGroup",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
-            "Names" : "DeploymentProvider",
+            "Names" : "SchemaInstance",
             "Types" : STRING_TYPE,
             "Mandatory" : true
         }

--- a/providers/shared/views/schemaset/setup.ftl
+++ b/providers/shared/views/schemaset/setup.ftl
@@ -6,56 +6,52 @@
 
 [#macro shared_view_default_schemaset_schemacontract ]
 
-    [#local section = commandLineOptions.Deployment.Group.Name]
-    [#local stageId=formatId(section)]
-    [@contractStage
-        id=formatId(section)
-        executionMode=CONTRACT_EXECUTION_MODE_PARALLEL
-        priority=10
-        mandatory=true
-    /]
+    [#local sections = ["component", "reference", "attributeset"] ]
 
-    [#switch section]
-        [#case "component" ]
-            [@includeAllComponentDefinitionConfiguration
-                SHARED_PROVIDER
-                commandLineOptions.Deployment.Provider.Names
-            /]
-            [#local schemas = componentConfiguration?keys ]
-            [#break]
-        [#case "reference" ]
-            [#local schemas = referenceConfiguration?keys ]
-            [#break]
-        [#case "attributeset" ]
-            [#local schemas = attributeSetConfiguration?keys ]
-            [#break]
-        [#default]
-            [@fatal 
-                message="Invalid Schema section"
-                context=section
-            /]
-            [#break]
-    [/#switch]
+    [#list sections as section ]
 
-    [#local outputMappings = 
-        getGenerationContractStepOutputMapping(SHARED_PROVIDER, "schema")]
+        [#local stageId=formatId(section)]
+        [@contractStage
+            id=formatId(section)
+            executionMode=CONTRACT_EXECUTION_MODE_PARALLEL
+            priority=10
+            mandatory=true
+        /]
 
-    [#if schemas?? ]
-        [#list schemas as schema]
-            [@contractStep
-                id=formatId(schema)
-                stageId=stageId
-                taskType=CREATE_SCHEMASET_TASK_TYPE
-                priority=100
-                mandatory=true
-                parameters=
-                    {
-                        "DeploymentGroup" : section,
-                        "DeploymentUnit" : schema,
-                        "DeploymentProvider" : ((commandLineOptions.Deployment.Provider.Names)?join(","))!SHARED_PROVIDER,
-                        "DeploymentFramework" : commandLineOptions.Deployment.Framework.Name
-                    }
-            /]
-        [/#list]
-    [/#if]
+        [#switch section]
+            [#case "component" ]
+                [@includeAllComponentDefinitionConfiguration
+                    SHARED_PROVIDER
+                    commandLineOptions.Deployment.Provider.Names
+                /]
+                [#local schemas = componentConfiguration?keys ]
+                [#break]
+            [#case "reference" ]
+                [#local schemas = referenceConfiguration?keys ]
+                [#break]
+            [#case "attributeset" ]
+                [#local schemas = attributeSetConfiguration?keys ]
+                [#break]
+        [/#switch]
+
+        [#local outputMappings =
+            getGenerationContractStepOutputMapping(SHARED_PROVIDER, "schema")]
+
+        [#if schemas?? ]
+            [#list schemas as schema]
+                [@contractStep
+                    id=formatId(schema)
+                    stageId=stageId
+                    taskType=CREATE_SCHEMASET_TASK_TYPE
+                    priority=100
+                    mandatory=true
+                    parameters=
+                        {
+                            "SchemaType" : section,
+                            "SchemaInstance" : schema
+                        }
+                /]
+            [/#list]
+        [/#if]
+    [/#list]
 [/#macro]

--- a/providers/shared/views/schemaset/setup.ftl
+++ b/providers/shared/views/schemaset/setup.ftl
@@ -15,7 +15,7 @@
             id=formatId(section)
             executionMode=CONTRACT_EXECUTION_MODE_PARALLEL
             priority=10
-            mandatory=true
+            mandatory=false
         /]
 
         [#switch section]
@@ -44,7 +44,7 @@
                     stageId=stageId
                     taskType=CREATE_SCHEMASET_TASK_TYPE
                     priority=100
-                    mandatory=true
+                    mandatory=false
                     parameters=
                         {
                             "SchemaType" : section,


### PR DESCRIPTION
## Description
This refactor renames the task parameters from DeploymentGroup and DeploymentUnit for schema set generation to SchemaType and SchemaInstance. 

It also removes the deployment group filter applied when generating the schemaset contract and instead includes all possible schemas which can be generated. The contract executor can then filter and choose which contracts it would like to generate 

## Motivation and Context

While we use the deployment group and unit parameters in create template to generate the outputs these values don't reflect what the task is actually trying to do, generate a schemaset contract which outlines the schemas that need to be generated

## How Has This Been Tested?
Tested locally using hamlet cli 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
