### PR TITLE
Fix - Schema Reference Data Outputs

### DIFF
--- a/providers/shared/views/schema/setup.ftl
+++ b/providers/shared/views/schema/setup.ftl
@@ -96,19 +96,21 @@
 
             [#-- Key Value Pairs of AttributeSet Name : Configuration --]
             [#list attributeSetConfiguration as id,configuration]
-                [@addSchema
-                    section="attributeset"
-                    schema=id
-                    configuration=
-                    formatJsonSchemaFromComposite(
-                        {
-                            "Names" : id,
-                            "Type" : OBJECT_TYPE,
-                            "SubObjects" : true,
-                            "Children" : configuration.Attributes
-                        }
-                    )
-                /]
+                [#if configuration.Type.Singular?lower_case == schema]
+                    [@addSchema
+                        section="attributeset"
+                        schema=id
+                        configuration=
+                        formatJsonSchemaFromComposite(
+                            {
+                                "Names" : id,
+                                "Type" : OBJECT_TYPE,
+                                "SubObjects" : true,
+                                "Children" : configuration.Attributes
+                            }
+                        )
+                    /]
+                [/#if]
             [/#list]
             [#break]
 

--- a/providers/shared/views/schema/setup.ftl
+++ b/providers/shared/views/schema/setup.ftl
@@ -68,20 +68,27 @@
 
         [#case "reference"]
 
-            [#list referenceConfiguration as id,configuration]
-                [@addSchema
-                    section="reference"
-                    schema=configuration.Type.Plural
-                    configuration=
-                        formatJsonSchemaFromComposite(
-                            {
-                                "Names" : configuration.Type.Plural,
-                                "Type" : OBJECT_TYPE,
-                                "SubObjects" : true,
-                                "Children" : configuration.Attributes
-                            },
-                            attributeSetConfiguration?keys)
-                /]
+            [#-- The CommandLineOption for Schema expects the singular name. --]
+            [#-- But the compositeObject structure uses pluralised names as  --]
+            [#-- the object ID's. So we check the singular name matches first--]
+            [#-- then re-set schema name value to the pluralisation.         --]
+            [#list referenceConfiguration as id, configuration]
+                [#if configuration.Type.Singular?lower_case == schema]
+
+                    [@addSchema
+                        section="reference"
+                        schema=configuration.Type.Singular
+                        configuration=
+                            formatJsonSchemaFromComposite(
+                                {
+                                    "Names" : configuration.Type.Plural,
+                                    "Type" : OBJECT_TYPE,
+                                    "SubObjects" : true,
+                                    "Children" : configuration.Attributes
+                                },
+                                attributeSetConfiguration?keys)
+                    /]
+                [/#if]
             [/#list]
             [#break]
 

--- a/providers/shared/views/schema/setup.ftl
+++ b/providers/shared/views/schema/setup.ftl
@@ -119,10 +119,22 @@
 
     [/#switch]
 
-    [@addSchemaToDefaultJsonOutput
-        section=schema
-        schemaId=formatSchemaId(section, schema)
-        config=getSchema(section)!{}
-    /]
+    [#local schemaOutputConfiguration = getSchema(section)!{}]
+
+    [#if schemaOutputConfiguration?has_content]
+        [@addSchemaToDefaultJsonOutput
+            section=schema
+            schemaId=formatSchemaId(section, schema)
+            config=schemaOutputConfiguration
+        /]
+    [#else]
+        [@fatal
+            message="Schema instance type not found. Did you mean to try the Singular Name?"
+            context={
+                "SchemaType" : section,
+                "SchemaInstance" : schema
+            }
+        /]
+    [/#if]
 
 [/#macro]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Create one schema definition per file output for the `reference` and `attributeset` schema types.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Schema generation was creating individual file outputs for each schema instance, but each output contained all definitions. This was occurring for both `reference` and `attributeset` schema types, though only obvious for the former as the latter only has a single instance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local schema generation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
