### PR TITLE
feat(s3): add support for inventory reports

### DIFF
--- a/providers/shared/components/s3/id.ftl
+++ b/providers/shared/components/s3/id.ftl
@@ -122,6 +122,62 @@
                 "Names" : "Links",
                 "Subobjects" : true,
                 "Children" : linkChildrenConfiguration
+            },
+            {
+                "Names" : "InventoryReports",
+                "Description" : "Provides a listing of all objects in the store on a schedule basis",
+                "Subobjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Destination",
+                        "Description" : "The destination of the reports",
+                        "Children" : [
+                            {
+                                "Names" : "Type",
+                                "Values" : [ "self", "link" ],
+                                "Default" : "self",
+                                "Description" : "The type of destination for the report"
+                            },
+                            {
+                                "Names": "Links",
+                                "Description" : "If destination type is link these are the links that will be used",
+                                "Subobjects" : true,
+                                "Children" : linkChildrenConfiguration
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "IncludeVersions",
+                        "Description" : "Include versions of objects in report",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "InventoryPrefix",
+                        "Description" : "A filter prefix to generate the report for",
+                        "Type" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
+                        "Names" : "InventoryFormat",
+                        "Description" : "The filter for the inventory report",
+                        "Type" : STRING_TYPE,
+                        "Default" : "CSV"
+                    }
+                    {
+                        "Names" : "DestinationPrefix",
+                        "Description" : "A prefix to store the report under in the destination",
+                        "Type" : STRING_TYPE,
+                        "Mandatory" : true
+                    }
+                    {
+                        "Names" : "Schedule",
+                        "Description" : "How often to generate the report",
+                        "Values" : [ "Daily", "Weekly" ],
+                        "Type" : STRING_TYPE,
+                        "Default" : "Daily"
+                    }
+                ]
             }
         ]
 /]


### PR DESCRIPTION
## Description

defines configuration for creating inventory reports for the s3 component. 

## Motivation and Context
Inventory reports list the contents of a nominated bucket and generate a listing of the contents

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
