### PR TITLE
fix: link attributeset in s3 inventory reports

### DIFF
--- a/providers/shared/components/s3/id.ftl
+++ b/providers/shared/components/s3/id.ftl
@@ -140,10 +140,10 @@
                                 "Description" : "The type of destination for the report"
                             },
                             {
-                                "Names": "Links",
+                                "Names" : "Links",
                                 "Description" : "If destination type is link these are the links that will be used",
                                 "Subobjects" : true,
-                                "Children" : linkChildrenConfiguration
+                                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
                             }
                         ]
                     },


### PR DESCRIPTION




## Description
Use AttributeSet not linkChildrenConfiguration in s3 inventory reports configuration

## Motivation and Context
This usage was missed due to commit sequencing.

<!--- Provide a general summary of your changes in the Title above -->
## How Has This Been Tested?
Local template generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
