### PR TITLE
feat: whatif input provider

### DIFF
--- a/providers/shared/inputsources/composite/stackoutput.ftl
+++ b/providers/shared/inputsources/composite/stackoutput.ftl
@@ -1,46 +1,5 @@
 [#ftl]
 
 [#macro shared_input_composite_stackoutput_seed id="" deploymentUnit="" level="" region="" account=""]
-
-    [#local stackOutputs = [] ]
-
-    [#-- Cloudformation Stack Output Processing --]
-    [#-- Stack outputs from cloudformation are processed based on the output from the awscli command --]
-    [#-- aws cloudformation describe-stacks --]
-    [#-- The component level is determined by the first part of the file name --]
-
-    [#-- cloudformation stack outputs are used as the default shared format to align with PseudoStack Output script --]
-    [#list commandLineOptions.Composites.StackOutputs as stackOutputFile ]
-
-        [#local level = ((stackOutputFile["FileName"])?split('-'))[0] ]
-
-        [#list (stackOutputFile["Content"]![]) as rawStackOutput ]
-            [#if (rawStackOutput["Stacks"]!{})?has_content ]
-                [#list rawStackOutput["Stacks"] as stack ]
-                    [#if (stack["Outputs"]![])?has_content ]
-
-                        [#local stackOutput = {} ]
-
-                        [#if stack["Outputs"]?is_sequence ]
-                            [#list stack["Outputs"] as output ]
-                                [#local stackOutput += {
-                                    output.OutputKey : output.OutputValue
-                                }]
-                            [/#list]
-                        [/#if]
-
-                        [#if stack["Outputs"]?is_hash ]
-                            [#local stackOutput = stack["Outputs"] ]
-                        [/#if]
-
-                        [#if stackOutput?has_content ]
-                            [#local stackOutputs += [ mergeObjects( { "Level" : level} , stackOutput) ] ]
-                        [/#if]
-                    [/#if]
-                [/#list]
-            [/#if]
-        [/#list]
-    [/#list]
-
-    [@addStackOutputs stackOutputs /]
+    [@addStackOutputs getCFCompositeStackOutputs(id, deploymentUnit, level, region, account) /]
 [/#macro]

--- a/providers/shared/inputsources/mock/stackoutput.ftl
+++ b/providers/shared/inputsources/mock/stackoutput.ftl
@@ -2,26 +2,5 @@
 
 [#-- Get stack output --]
 [#macro shared_input_mock_stackoutput id="" deploymentUnit="" level="" region="" account=""]
-    [#switch id?split("X")?last ]
-        [#case URL_ATTRIBUTE_TYPE ]
-            [#local value = "https://mock.local/" + id ]
-            [#break]
-        [#case IP_ADDRESS_ATTRIBUTE_TYPE ]
-            [#local value = "123.123.123.123" ]
-            [#break]
-        [#default]
-            [#local value = formatId( "##MockOutput", id, "##") ]
-    [/#switch]
-
-    [@addStackOutputs 
-        [
-            {
-                "Account" : account,
-                "Region" : region,
-                "Level" : level,
-                "DeploymentUnit" : deploymentUnit,
-                id : value
-            }
-        ]
-    /]
+    [@addStackOutputs getSharedMockStackOutputs(id, deploymentUnit, level, region, account) /]
 [/#macro]

--- a/providers/shared/inputsources/shared/setting.ftl
+++ b/providers/shared/inputsources/shared/setting.ftl
@@ -1,0 +1,98 @@
+[#ftl]
+
+[#---------------------------------------------------------------
+-- Internal support functions for composite setting processing --
+-----------------------------------------------------------------]
+
+[#function internalReformatSettings objects fileRegex=".*"]
+    [#local result = {}]
+    [#list objects!{} as key,value]
+        [#local result =
+            mergeObjects(
+                result,
+                internalReformatFiles(key, value!{}, fileRegex)
+            )]
+    [/#list]
+    [#return result]
+[/#function]
+
+[#function internalReformatFiles key settingsFiles fileRegex]
+    [#local result = {} ]
+    [#list settingsFiles.Files![] as file ]
+        [#-- Ignore the file if it doesn't match the desired regex --]
+        [#if ! file.FileName?lower_case?trim?matches(fileRegex)]
+            [#continue]
+        [/#if]
+
+        [#-- Locate files reative to the CMDB root --]
+        [#local relativeFile =
+            concatenate(
+                [
+                    file.FilePath?remove_beginning(settingsFiles.RootDirectory)?remove_beginning("/"),
+                    file.FileName
+                ],
+                "/"
+            ) ]
+
+        [#-- The namespace starts with the key, followed by any parts of the file path --]
+        [#-- relative to the base directory --]
+        [#local extension = file.FileName?keep_after_last(".")]
+        [#local base = file.FileName?remove_ending("." + extension)]
+        [#local namespace =
+            concatenate(
+                [
+                    key,
+                    file.FilePath?remove_beginning(settingsFiles.BaseDirectory)?lower_case?replace("/", " ")?trim?split(" ")
+                ],
+                "-"
+            ) ]
+
+        [#-- Attribute for file contents --]
+        [#local attribute = base?replace("-","_")?upper_case]
+
+        [#-- asFile --]
+        [#if file.FilePath?lower_case?contains("asfile")]
+            [#local result =
+                mergeObjects(
+                    result,
+                    {
+                        namespace : {
+                            attribute : {
+                                "Value" : file.FileName,
+                                "AsFile" : relativeFile
+                            }
+                        }
+                    }
+                 ) ]
+            [#continue]
+        [/#if]
+
+        [#-- Settings format depends on file extension --]
+        [#switch extension?lower_case]
+            [#case "json"]
+                [#local result =
+                    mergeObjects(
+                        result,
+                        {
+                            namespace : file.Content[0]
+                        }
+                     ) ]
+                [#break]
+            [#default]
+                [#local result =
+                    mergeObjects(
+                        result,
+                        {
+                            namespace : {
+                                attribute : {
+                                    "Value" : file.Content[0],
+                                    "FromFile" : relativeFile
+                                }
+                            }
+                        }
+                    ) ]
+                [#break]
+        [/#switch]
+    [/#list]
+    [#return result]
+[/#function]

--- a/providers/shared/inputsources/shared/stackoutput.ftl
+++ b/providers/shared/inputsources/shared/stackoutput.ftl
@@ -1,0 +1,72 @@
+[#ftl]
+
+[#-- Mock function --]
+[#function getSharedMockStackOutputs id="" deploymentUnit="" level="" region="" account=""]
+    [#switch id?split("X")?last ]
+        [#case URL_ATTRIBUTE_TYPE ]
+            [#local value = "https://mock.local/" + id ]
+            [#break]
+        [#case IP_ADDRESS_ATTRIBUTE_TYPE ]
+            [#local value = "123.123.123.123" ]
+            [#break]
+        [#default]
+            [#local value = formatId( "##MockOutput", id, "##") ]
+    [/#switch]
+
+    [#return
+        [
+            {
+                "Account" : account,
+                "Region" : region,
+                "Level" : level,
+                "DeploymentUnit" : deploymentUnit,
+                id : value
+            }
+        ]
+    ]
+[/#function]
+
+[#-- Cloudformation Stack Output Processing --]
+[#-- Stack outputs from cloudformation are processed based on the output from the awscli command --]
+[#-- aws cloudformation describe-stacks --]
+[#-- The component level is determined by the first part of the file name --]
+
+[#-- cloudformation stack outputs are used as the default shared format to align with PseudoStack Output script --]
+
+[#function getCFCompositeStackOutputs id="" deploymentUnit="" level="" region="" account=""]
+
+    [#local result = []]
+    [#list commandLineOptions.Composites.StackOutputs as stackOutputFile ]
+
+        [#local level = ((stackOutputFile["FileName"])?split('-'))[0] ]
+
+        [#list (stackOutputFile["Content"]![]) as rawStackOutput ]
+            [#if (rawStackOutput["Stacks"]!{})?has_content ]
+                [#list rawStackOutput["Stacks"] as stack ]
+                    [#if (stack["Outputs"]![])?has_content ]
+
+                        [#local stackOutput = {} ]
+
+                        [#if stack["Outputs"]?is_sequence ]
+                            [#list stack["Outputs"] as output ]
+                                [#local stackOutput += {
+                                    output.OutputKey : output.OutputValue
+                                }]
+                            [/#list]
+                        [/#if]
+
+                        [#if stack["Outputs"]?is_hash ]
+                            [#local stackOutput = stack["Outputs"] ]
+                        [/#if]
+
+                        [#if stackOutput?has_content ]
+                            [#local result += [ mergeObjects( { "Level" : level} , stackOutput) ] ]
+                        [/#if]
+                    [/#if]
+                [/#list]
+            [/#if]
+        [/#list]
+    [/#list]
+
+    [#return result]
+[/#function]

--- a/providers/shared/inputsources/whatif/blueprint.ftl
+++ b/providers/shared/inputsources/whatif/blueprint.ftl
@@ -1,0 +1,8 @@
+[#ftl]
+
+[#-- Intial seeding of settings data based on input data --]
+[#macro shared_input_whatif_blueprint_seed ]
+    [@addBlueprint
+        blueprint=commandLineOptions.Composites.Blueprint
+    /]
+[/#macro]

--- a/providers/shared/inputsources/whatif/commandlineoption.ftl
+++ b/providers/shared/inputsources/whatif/commandlineoption.ftl
@@ -1,0 +1,50 @@
+[#ftl]
+
+[#-- This should be a valid region in the Masterdata --]
+[#macro shared_input_whatif_commandlineoption_seed ]
+
+    [#-- Reference metadata --]
+    [@addCommandLineOption
+        option={
+            "References" : {
+                "Request" : requestReference!"",
+                "Configuration" : configurationReference!""
+            }
+        }
+    /]
+
+    [#-- Composite Inputs --]
+    [@addCommandLineOption
+        option={
+            "Composites" : {
+                "Blueprint" : (blueprint!"")?has_content?then(
+                                    blueprint?eval,
+                                    {}
+                ),
+                "Settings" : (settings!"")?has_content?then(
+                                    settings?eval,
+                                    {}
+                ),
+                "Definitions" : ((definitions!"")?has_content && (!definitions?contains("null")))?then(
+                                    definitions?eval,
+                                    {}
+                ),
+                "StackOutputs" : (stackOutputs!"")?has_content?then(
+                                    stackOutputs?eval,
+                                    []
+                )
+            }
+        }
+    /]
+
+    [#-- Regions --]
+    [@addCommandLineOption
+        option={
+            "Regions" : {
+                "Segment" : region!"",
+                "Account" : accountRegion!""
+            }
+        }
+    /]
+
+[/#macro]

--- a/providers/shared/inputsources/whatif/definition.ftl
+++ b/providers/shared/inputsources/whatif/definition.ftl
@@ -1,0 +1,8 @@
+[#ftl]
+
+[#-- Intial seeding of settings data based on input data --]
+[#macro shared_input_whatif_definition_seed ]
+    [@addDefinition
+        definition=commandLineOptions.Composites.Definitions
+    /]
+[/#macro]

--- a/providers/shared/inputsources/whatif/setting.ftl
+++ b/providers/shared/inputsources/whatif/setting.ftl
@@ -1,0 +1,62 @@
+[#ftl]
+
+[#-- Initial seeding of settings data based on input data --]
+[#macro shared_input_whatif_setting_seed ]
+    [@addSettings
+        type="Settings"
+        scope="Accounts"
+        settings=
+            internalReformatSettings(
+                (commandLineOptions.Composites.Settings.Accounts.Settings)!{}
+            )
+    /]
+
+    [#-- (?! ) negates the remaining expression --]
+    [@addSettings
+        type="Settings"
+        scope="Products"
+        settings=
+            mergeObjects(
+                internalReformatSettings(
+                    (commandLineOptions.Composites.Settings.Products.Settings)!{},
+                    r"^(?!.*build\.json|.*credentials\.json|.*sensitive\.json$).*$"
+                ),
+                internalReformatSettings(
+                    (commandLineOptions.Composites.Settings.Products.Operations)!{},
+                    r"^(?!.*build\.json|.*credentials\.json|.*sensitive\.json$).*$"
+                )
+            )
+    /]
+
+    [@addSettings
+        type="Builds"
+        scope="Products"
+        settings=
+            mergeObjects(
+                internalReformatSettings(
+                    (commandLineOptions.Composites.Settings.Products.Settings)!{},
+                    r"^.*build\.json$"
+                ),
+                internalReformatSettings(
+                    (commandLineOptions.Composites.Settings.Products.Builds)!{},
+                    r"^.*build\.json$"
+                )
+            )
+    /]
+
+    [@addSettings
+        type="Sensitive"
+        scope="Products"
+        settings=
+            mergeObjects(
+                internalReformatSettings(
+                    (commandLineOptions.Composites.Settings.Products.Settings)!{},
+                    r"^.*credentials\.json|.*sensitive\.json$"
+                ),
+                internalReformatSettings(
+                    (commandLineOptions.Composites.Settings.Products.Operations)!{},
+                    r"^.*credentials\.json|.*sensitive\.json$"
+                )
+            )
+    /]
+[/#macro]

--- a/providers/shared/inputsources/whatif/stackoutput.ftl
+++ b/providers/shared/inputsources/whatif/stackoutput.ftl
@@ -1,0 +1,16 @@
+[#ftl]
+
+[#macro shared_input_whatif_stackoutput_seed id="" deploymentUnit="" level="" region="" account=""]
+    [@addStackOutputs getCFCompositeStackOutputs(id, deploymentUnit, level, region, account) /]
+[/#macro]
+
+[#macro shared_input_whatif_stackoutput id="" deploymentUnit="" level="" region="" account=""]
+
+    [#local compositeOutput = getCFCompositeStackOutputs(id, deploymentUnit, level, region, account) ]
+    [#if compositeOutput?has_content ]
+        [@addStackOutputs compositeOutput /]
+    [#else]
+        [@addStackOutputs getSharedMockStackOutputs(id, deploymentUnit, level, region, account) /]
+    [/#if]
+
+[/#macro]


### PR DESCRIPTION
## Description
Closes: https://github.com/hamlet-io/engine/issues/1535

- Creates a new input provider, the whatif provider 
- Refactors some of the input processing functions so they can be shared across providers 

## Motivation and Context
The whatif input provider allows you to use a composite CMDB to create and query deployments before actually deploying the changes you've made in your CMDB

Input sources are primarily handled the same way as the composite input source except for StackOutputs. The whatif provider checks to see if a composite stack output can be found and if it can't then it will return a mocked output instead

This allows you to add components to a CMDB to see what they will create before deploying any of their required components. This is really helpful when generating diagrams or running through demonstrations where you don't want to wait for deployments to complete

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
