### PR TITLE
feat: add raw ids for occurrence details

### DIFF
--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -326,11 +326,15 @@
                                 },
                                 "Instance" : {
                                     "Id" : firstContent(instanceId, (parentOccurrence.Core.Instance.Id)!""),
-                                    "Name" : firstContent(instanceName, (parentOccurrence.Core.Instance.Name)!"")
+                                    "RawId" : firstContent(instance.Id, (parentOccurrence.Core.Instance.RawId)!""),
+                                    "Name" : firstContent(instanceName, (parentOccurrence.Core.Instance.Name)!""),
+                                    "RawName" : firstContent(instance.Name, (parentOccurrence.Core.Instance.RawName)!"")
                                 },
                                 "Version" : {
                                     "Id" : firstContent(versionId, (parentOccurrence.Core.Version.Id)!""),
-                                    "Name" : firstContent(versionName, (parentOccurrence.Core.Version.Name)!"")
+                                    "RawId" : firstContent(version.Id, (parentOccurrence.Core.Version.RawId)!""),
+                                    "Name" : firstContent(versionName, (parentOccurrence.Core.Version.Name)!""),
+                                    "RawName" : firstContent(version.Name, (parentOccurrence.Core.Version.RawName)!"")
                                 },
                                 "Internal" : {
                                     "IdExtensions" : idExtensions,


### PR DESCRIPTION
## Description

Adds the Raw Id field for Version and Instance which uses the details from the CMDB or the default value. 

## Motivation and Context

This is useful for user facing output that reads these files. in the CMDB when we have "default" as the instance or version Id its replaced with an empty string. This makes naming and output in deployment easier. But harder to align the whats in the CMDB with query commands

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
