### PR TITLE
fix: Links as subobjects

### DIFF
--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -179,6 +179,7 @@ object.
                     },
                     {
                         "Names" : "Links",
+                        "Subobjects" : true,
                         "AttributeSet" : LINK_ATTRIBUTESET_TYPE
                     },
                     {

--- a/providers/shared/components/baseline/id.ftl
+++ b/providers/shared/components/baseline/id.ftl
@@ -274,6 +274,7 @@
             },
             {
                 "Names" : "Links",
+                "Subobjects" : true,
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
             },
             {

--- a/providers/shared/components/lb/id.ftl
+++ b/providers/shared/components/lb/id.ftl
@@ -224,6 +224,7 @@
                         "Children"  : [
                             {
                                 "Names" : "Links",
+                                "Subobjects" : true,
                                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
                             }
                         ]


### PR DESCRIPTION
## Description
With the transition to attribute sets, a few instances of Links lost their `Subobjects` attribute resulting in current processing breaking.

## Motivation and Context
Fixes #1544

## How Has This Been Tested?
Local generation of affected customer blueprint

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
