### PR TITLE
feat: Stop on fatal

### DIFF
--- a/engine/bootstrap.ftl
+++ b/engine/bootstrap.ftl
@@ -5,11 +5,11 @@
 [#include "engine.ftl"]
 [#include "common.ftl"]
 
-[#-- flow --]
-[#include "flow.ftl" ]
-
 [#-- logging --]
 [#include "logging.ftl" ]
+
+[#-- flow --]
+[#include "flow.ftl" ]
 
 [#-- AttributeSets --]
 [#include "attributeset.ftl"]

--- a/engine/logging.ftl
+++ b/engine/logging.ftl
@@ -31,6 +31,12 @@
 [#-- Can either be set as a number or as a string       --]
 [#assign currentLogLevel = FATAL_LOG_LEVEL]
 
+[#-- Set the stop threshold                             --]
+[#-- Number of fatal errors at which processing will    --]
+[#-- be stopped                                         --]
+[#-- <=0 ==> skip threshold checking                    --]
+[#assign logFatalStopThreshold = 0]
+
 [#function getLogLevel ]
     [#return currentLogLevel]
 [/#function]
@@ -133,7 +139,10 @@
     /]
 [/#macro]
 
-[#macro fatal message context={} detail={} enabled=true]
+[#assign logFatalMessageCount = 0]
+
+[#macro fatal message context={} detail={} enabled=true stop=false]
+
     [@logMessage
         severity=FATAL_LOG_LEVEL
         message=message
@@ -141,6 +150,19 @@
         detail=detail
         enabled=enabled
     /]
+
+    [#-- one more fatal message seen --]
+    [#assign logFatalMessageCount += 1]
+
+    [#if stop ||
+        ((logFatalStopThreshold > 0) && (logFatalMessageCount >= logFatalStopThreshold)) ]
+        [#-- report whatever has been logged as the stop cause --]
+        [#stop getJSON({"HamletMessages" : logMessages}) ]
+    [/#if]
+[/#macro]
+
+[#macro setLogFatalStopThreshold threshold ]
+    [#local logFatalStopThreshold = threshold ]
 [/#macro]
 
 [#macro precondition function context={} detail={} enabled=true]


### PR DESCRIPTION
## Description
Add the ability to stop after a threshold number of fatal errors, as well as the option for a fatal error to always cause processing to stop.

The default behaviour reflects current behaviour where there is no limit so all fatal errors will be reported together.

## Motivation and Context
When debugging complex behaviour, it is sometimes useful to know the state of processing at a particular point, especially when later processing throws a template error. This change permits a fatal error with `stop=true` to be added to know the exact state of variables etc.

The threshold behaviour allows for different user preference e.g. stop on first fatal error or permit multiple fatal errors to be recorded before processing stops.

## How Has This Been Tested?
Local deployments

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
