### PR TITLE
fix: allow for loading provider input replacement

### DIFF
--- a/providers/shared/inputseeders/shared/id.ftl
+++ b/providers/shared/inputseeders/shared/id.ftl
@@ -79,10 +79,14 @@
                     [#-- Deployment Details --]
                     "Deployment" : {
                         "Provider" : {
-                            "Names" : (providers!"")?has_content?then(
-                                            providers?split(","),
-                                            []
-                            )
+                            "Names" : combineEntities(
+                                            (providers!"")?has_content?then(
+                                                providers?split(","),
+                                                []
+                                            ),
+                                            (commandLineOptions.Deployment.Provider.Names)![],
+                                            UNIQUE_COMBINE_BEHAVIOUR
+                                        )
                         },
                         "Framework" : {
                             "Name" : deploymentFramework!"default"


### PR DESCRIPTION
## Description

This fix uses the unique combine configuration for providers to ensure that we build a list of providers instead of replacing it

## Motivation and Context
the input seeder process uses the mergeObject command to apply state changes as required. When merging the mergeObject behaviour replaces arrays as its hard to merge an array

The main reason for this fix is to handle the update of the provider names command line options when loading plugins from a layer/blueprint. Previously this was being overridden with whatever the shared provider set the value to 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
