### PR TITLE
feat(gateway): add dpd action configuration

### DIFF
--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -1626,6 +1626,7 @@
         },
         "ReplayWindowSize": 1024,
         "DeadPeerDetectionTimeout": 30,
+        "DeadPeerDetectionAction" : "clear",
         "Phase1": {
           "EncryptionAlgorithms": [
             "AES256"

--- a/providers/shared/references/SecurityProfile/id.ftl
+++ b/providers/shared/references/SecurityProfile/id.ftl
@@ -145,6 +145,11 @@
                     "Types" : NUMBER_TYPE
                 },
                 {
+                    "Names" : "DeadPeerDetectionAction",
+                    "Types" : STRING_TYPE,
+                    "Values" : [ "clear", "none", "restart" ]
+                },
+                {
                     "Names" : "Phase1",
                     "Children" : [
                         {


### PR DESCRIPTION
## Description

Adds the ability to specify the dead peer detection action when a Dead Peer Detection failure occurs as part of the vpngateway security profile

## Motivation and Context
Support configuration of the VPN Gateway as part of hamlet deploy 
Implements: https://github.com/hamlet-io/engine/issues/1562 

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
