### PR TITLE
feat(userpool): add schema attribute constraints

### DIFF
--- a/providers/shared/components/userpool/id.ftl
+++ b/providers/shared/components/userpool/id.ftl
@@ -155,6 +155,46 @@
                         "Names" : "Required",
                         "Types" : BOOLEAN_TYPE,
                         "Default" : true
+                    },
+                    {
+                        "Names" : "Constraints",
+                        "Description" : "Constraints applied to the attribute based on their type",
+                        "Children" : [
+                            {
+                                "Names" : "String",
+                                "Description" : "String based Constraints",
+                                "Children" : [
+                                    {
+                                        "Names" : "MinLength",
+                                        "Description" : "The minimumn length of the attribute 0 = any",
+                                        "Types" : NUMBER_TYPE,
+                                        "Default" : 0
+                                    },
+                                    {
+                                        "Names" : "MaxLength",
+                                        "Description" : "The maximum length of the attribute 0 = any",
+                                        "Types" : NUMBER_TYPE,
+                                        "Default" : 0
+                                    }
+                                ]
+                            },
+                            {
+                                "Names" : "Number",
+                                "Description" : "String based Constraints",
+                                "Children" : [
+                                    {
+                                        "Names" : "MinValue",
+                                        "Description" : "The minimumn value of the attribute",
+                                        "Types" : NUMBER_TYPE
+                                    },
+                                    {
+                                        "Names" : "MaxValue",
+                                        "Description" : "The maximum value of the attribute",
+                                        "Types" : NUMBER_TYPE
+                                    }
+                                ]
+                            }
+                        ]
                     }
                 ]
             },

--- a/providers/shared/components/userpool/id.ftl
+++ b/providers/shared/components/userpool/id.ftl
@@ -180,7 +180,7 @@
                             },
                             {
                                 "Names" : "Number",
-                                "Description" : "String based Constraints",
+                                "Description" : "Number based Constraints",
                                 "Children" : [
                                     {
                                         "Names" : "MinValue",


### PR DESCRIPTION
## Description
Adds support for String or Number based constraints on user pool attributes. Primarily focussed around length and value in line with the support available for AWS Cognito.

These are pretty generic constraints so should flow on to other
providers

## Motivation and Context
https://github.com/hamlet-io/engine-plugin-aws/issues/228 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
