### PR TITLE
fix: handling of log level lookup

### DIFF
--- a/engine/logging.ftl
+++ b/engine/logging.ftl
@@ -47,7 +47,7 @@
     [/#if]
     [#if level?is_string && level?has_content]
         [#list logLevelDescriptions as value]
-            [#if value?has_content && level?lower_case?starts_with(value)]
+            [#if value?has_content && level?lower_case == value ]
                 [#assign currentLogLevel = value?index]
                 [#break]
             [/#if]

--- a/engine/logging.ftl
+++ b/engine/logging.ftl
@@ -47,7 +47,7 @@
     [/#if]
     [#if level?is_string && level?has_content]
         [#list logLevelDescriptions as value]
-            [#if level?lower_case?starts_with(value)]
+            [#if value?has_content && level?lower_case?starts_with(value)]
                 [#assign currentLogLevel = value?index]
                 [#break]
             [/#if]


### PR DESCRIPTION
## Description

This PR fixes an issue with determining the log level when it isn't empty or set to debug

## Motivation and Context

The log lookup process uses a list to map the string log level to a log
level number. Some entries in the list are empty to handle extra level
spaces.

When the string level is converted it used a startswith check which
considers an empty string as true rather than false

This PR ensures that the log level uses an explicit equals and also
checks that the item in the level list has content

## How Has This Been Tested?

Tested locally 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
