### PR TITLE
refactor: change timing log level

### DIFF
--- a/engine/logging.ftl
+++ b/engine/logging.ftl
@@ -29,7 +29,7 @@
 
 [#-- Set LogLevel variable to use a different log level --]
 [#-- Can either be set as a number or as a string       --]
-[#assign currentLogLevel = FATAL_LOG_LEVEL]
+[#assign currentLogLevel = FATAL_LOG_LEVEL ]
 
 [#-- Set the stop threshold                             --]
 [#-- Number of fatal errors at which processing will    --]

--- a/engine/logging.ftl
+++ b/engine/logging.ftl
@@ -6,8 +6,8 @@
 
 [#assign DEBUG_LOG_LEVEL = 0]
 [#assign TRACE_LOG_LEVEL = 1]
+[#assign TIMING_LOG_LEVEL = 2]
 [#assign INFORMATION_LOG_LEVEL = 3]
-[#assign TIMING_LOG_LEVEL = 4]
 [#assign WARNING_LOG_LEVEL = 5]
 [#assign ERROR_LOG_LEVEL = 7]
 [#assign FATAL_LOG_LEVEL = 9]
@@ -15,9 +15,9 @@
 [#assign logLevelDescriptions = [
     "debug",
     "trace",
-    "",
-    "info",
     "timing",
+    "info",
+    "",
     "warn",
     "",
     "error",

--- a/providers/shared/inputseeders/shared/id.ftl
+++ b/providers/shared/inputseeders/shared/id.ftl
@@ -119,7 +119,7 @@
                     },
                     [#-- Logging Details --]
                     "Logging" : {
-                        "Level" : logLevel!""
+                        "Level" : logLevel!"info"
                     },
                     [#-- RunId details --]
                     "Run" : {


### PR DESCRIPTION
## Description

Moves the timing log level in the engine below the info step

## Motivation and Context

Currently the timing messages are being included in standard template outputs if the level is set

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
