### PR TITLE
feat: deployment state reporting

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -137,6 +137,11 @@
     [#return getDeploymentUnitId(solution) ]
 [/#function]
 
+[#function getOccurrenceDeploymentGroup occurrence]
+    [#local solution = occurrence.Configuration.Solution ]
+    [#return solution["deployment:Group"]!"" ]
+[/#function]
+
 [#function isOccurrenceEnabled occurrence]
     [#return (occurrence.Configuration.Solution.Enabled)!true ]
 [/#function]

--- a/providers/shared/components/shared/setup.ftl
+++ b/providers/shared/components/shared/setup.ftl
@@ -24,23 +24,13 @@
 
 [#macro shared_unitlist_managementcontract occurrence ]
 
-    [@createOccurrenceManagementContractStep
-        occurrence=occurrence
-    /]
+    [#local allOccurrences = asFlattenedArray( [ occurrence, occurrence.Occurrences![] ], true )]
+    [#list allOccurrences as occurrence ]
 
-    [#list (occurrence.Occurrences)![] as subOccurrence ]
         [@createOccurrenceManagementContractStep
-            occurrence=subOccurrence
+            occurrence=occurrence
         /]
     [/#list]
-
-    [#if getOutputContent("stages")?has_content ]
-        [#list getOutputContent("stages")?keys as deploymentGroup ]
-            [@createResourceSetManagementContractStep
-                deploymentGroupDetails=getDeploymentGroupDetails(deploymentGroup)
-            /]
-        [/#list]
-    [/#if]
 [/#macro]
 
 [#-- Default testcase --]

--- a/providers/shared/entrances/unitlist/entrance.ftl
+++ b/providers/shared/entrances/unitlist/entrance.ftl
@@ -11,6 +11,12 @@
           "Group" : {
             "Name" : "*"
           }
+        },
+        "Flow" : {
+          "Names" : [ "components", "views" ]
+        },
+        "View" : {
+          "Name" : UNITLIST_VIEW_TYPE
         }
       }
   /]

--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -1739,16 +1739,19 @@
     "segment": {
       "Priority": 10,
       "Level": "segment",
+      "OutputLevel" : "seg",
       "ResourceSets": {}
     },
     "solution": {
       "Priority": 100,
       "Level": "solution",
+      "OutputLevel" : "soln",
       "ResourceSets": {}
     },
     "application": {
       "Priority": 200,
       "Level": "application",
+      "OutputLevel" : "app",
       "ResourceSets": {}
     }
   },

--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -1715,16 +1715,19 @@
           "segment" : {
             "Priority" : 10,
             "Level" : "segment",
+            "OutputLevel" : "seg",
             "ResourceSets" : {}
           },
           "solution" : {
             "Priority" : 100,
             "Level" : "solution",
+            "OutputLevel" : "soln",
             "ResourceSets" : {}
           },
           "application" : {
             "Priority" : 200,
             "Level" : "application",
+            "OutputLevel" : "app",
             "ResourceSets" : {}
           }
         },
@@ -1759,6 +1762,14 @@
             "Priority" : {
               "GroupFilter" : ".*",
               "Order" : "LowestFirst"
+            }
+          },
+          "_orphan" : {
+            "Operations" : [ "delete" ],
+            "Membership" : "priority",
+            "Priority" : {
+              "GroupFilter" : ".*",
+              "Order" : "HighestFirst"
             }
           }
         }

--- a/providers/shared/references/DeploymentGroup/id.ftl
+++ b/providers/shared/references/DeploymentGroup/id.ftl
@@ -29,6 +29,11 @@
             "Mandatory" : true
         },
         {
+            "Names" : "OutputLevel",
+            "Description" : "Overrides the Group Id when performing output checks - Defaults to the Id of the Group",
+            "Types" : STRING_TYPE
+        },
+        {
             "Names" : "ResourceSets",
             "Description" : "Generate deployments based on resource labels across all units in the group",
             "SubObjects" : true,
@@ -93,6 +98,29 @@
             deploymentGroups[deploymentGroup]
         )
     ]
+[/#function]
+
+[#function getDeploymentGroupFromOutputLevel outputLevel ]
+    [#local levelMatches = [] ]
+    [#local groupMatches = []]
+
+    [#list getDeploymentGroups()?keys as deploymentGroup ]
+        [#local details = getDeploymentGroupDetails(deploymentGroup)]
+
+        [#if (details.OutputLevel)?? && details.OutputLevel == outputLevel ]
+            [#local levelMatches = combineEntities( levelMatches, [ deploymentGroup ], UNIQUE_COMBINE_BEHAVIOUR ) ]
+        [/#if]
+
+        [#if deploymentGroup == outputLevel ]
+            [#local groupMatches = combineEntities( groupMatches, [ deploymentGroup ], UNIQUE_COMBINE_BEHAVIOUR ) ]
+        [/#if]
+    [/#list]
+
+    [#if levelMatches?has_content ]
+        [#return levelMatches ]
+    [#else]
+        [#return groupMatches![]]
+    [/#if]
 [/#function]
 
 [#function getDeploymentGroups ]

--- a/providers/shared/tasks/manage_deployment/id.ftl
+++ b/providers/shared/tasks/manage_deployment/id.ftl
@@ -32,7 +32,7 @@
         {
             "Names" : "CurrentState",
             "Description" : "The current state of the deployment",
-            "NotValues" : [ "notdeployed", "deployed", "orphaned" ],
+            "Values" : [ "notdeployed", "deployed", "orphaned" ],
             "Types" : STRING_TYPE,
             "Mandatory" : false
         }

--- a/providers/shared/tasks/manage_deployment/id.ftl
+++ b/providers/shared/tasks/manage_deployment/id.ftl
@@ -28,6 +28,13 @@
             "Names" : "DeploymentProvider",
             "Types" : STRING_TYPE,
             "Mandatory" : true
+        },
+        {
+            "Names" : "CurrentState",
+            "Description" : "The current state of the deployment",
+            "NotValues" : [ "notdeployed", "deployed", "orphaned" ],
+            "Types" : STRING_TYPE,
+            "Mandatory" : false
         }
     ]
 /]

--- a/providers/shared/views/unitlist/setup.ftl
+++ b/providers/shared/views/unitlist/setup.ftl
@@ -1,0 +1,89 @@
+[#ftl]
+
+[#macro shared_view_unitlist_managementcontract ]
+
+    [#-- Look through all stack outputs to determine all of the possible deployments that exisit --]
+    [#-- Stack outputs not part of the deployment state are considered orphaned --]
+    [#-- Using this state we then create a contract step using the _orphan deployment mode to decide what to do --]
+    [#list stackOutputsList as stackOutput ]
+
+        [#local deploymentUnit = stackOutput.DeploymentUnit ]
+
+        [#local deploymentGroups = []]
+        [#if ((stackOutput.Level)!"")?has_content ]
+            [#local deploymentGroups = getDeploymentGroupFromOutputLevel(stackOutput.Level) ]
+        [#else]
+            [#local deploymentGroups = getDeploymentGroupsFromState() ]
+        [/#if]
+
+        [#list deploymentGroups as deploymentGroup ]
+            [#local groupDetails = getDeploymentGroupDetails(deploymentGroup)]
+
+            [#if (groupDetails.ResourceSets!{})?keys?seq_contains(deploymentUnit) ]
+
+                [@addDeploymentState
+                    deploymentGroup=deploymentGroup
+                    deploymentUnit=deploymentUnit
+                    deployed=true
+                /]
+
+                [#-- Orphan Resource sets which have been disabled but are deployed exist --]
+                [#if ! (groupDetails.ResourceSets[deploymentUnit].Enabled) ]
+
+                    [@createResourceSetManagementContractStep
+                        deploymentGroup=deploymentGroup
+                        deploymentUnit=deploymentUnit
+                        currentState="orphaned"
+                        priority=999
+                        deploymentMode="_orphan"
+                    /]
+
+                [/#if]
+
+            [/#if]
+
+            [#-- Fiters out edge cases --]
+            [#-- - Account units - We don't know the resources which belong to an account to say if its suppose to be deployed or not --]
+            [#-- - Resource Sets - We don't know the resources which belong to a resource set to say if its suppose to be deployed or not --]
+            [#-- - psuedo stack outputs - They use the unit to show that the stackoutput is different --]
+            [#if ! ((groupDetails.CompositeTemplate)!"")?has_content
+                    && ! (groupDetails.ResourceSets!{})?keys?seq_contains(deploymentUnit)
+                    && ! deploymentUnit?ends_with("-epilogue")
+                    && ! deploymentUnit?ends_with("-prologue") ]
+
+                [#local deployState = getDeploymentUnitStates(deploymentGroup, deploymentUnit ) ]
+
+                [#if ! deployState?has_content ]
+                    [@createManagementContractStage
+                        deploymentUnit=deploymentUnit
+                        deploymentPriority=999
+                        deploymentGroup=deploymentGroup
+                        deploymentProvider=((commandLineOptions.Deployment.Provider.Names)[0])!SHARED_PROVIDER
+                        currentState="orphaned"
+                        deploymentMode="_orphan"
+                    /]
+                [/#if]
+            [/#if]
+        [/#list]
+    [/#list]
+
+    [#-- Add all of the required Resource Sets - Set deployed state to false --]
+    [#if getOutputContent("stages")?has_content ]
+        [#list getOutputContent("stages")?keys as deploymentGroup ]
+            [#local groupDetails = getDeploymentGroupDetails(deploymentGroup)]
+
+            [#list (groupDetails.ResourceSets)?values as resourceSet ]
+
+                [#local deploymentUnit = resourceSet["deployment:Unit"] ]
+
+                [@createResourceSetManagementContractStep
+                    deploymentGroup=deploymentGroup
+                    deploymentUnit=deploymentUnit
+                    currentState=getDeploymentUnitStates(deploymentGroup, deploymentUnit)
+                                    ?seq_contains(true)?then("deployed", "notdeployed")
+                /]
+            [/#list]
+        [/#list]
+    [/#if]
+
+[/#macro]

--- a/providers/shared/views/view.ftl
+++ b/providers/shared/views/view.ftl
@@ -6,3 +6,4 @@
 [#assign INFO_VIEW_TYPE      = "info" ]
 [#assign LOADER_VIEW_TYPE    = "loader" ]
 [#assign VALIDATE_VIEW_TYPE  = "validate" ]
+[#assign UNITLIST_VIEW_TYPE  = "unitlist" ]


### PR DESCRIPTION
## Description

Adds the ability to determine the current deployment state of a deployment unit

The following modes are supported:
- deployed - at least one resource can be found in occurrences which
belong to the deployment unit/group
- notdeployed - no resources could be found for in occurrences which
belong to the deployment unit/group
- orphaned - stack outputs exist for this deployment unit/group but are
corresponding deployment/group could not be found in active definitions

The deployment state is included in the managementcontract unitlist which allows for an executor to make decisions on how to manage its tasks based on the current state of the deployment

## Motivation and Context

Its currently hard to know the state of any given deployment unit that has been made within hamlet. The only way at the moment is to look in the state directory for stack output files. 

Part of: 
 - https://github.com/hamlet-io/executor-python/issues/70


## How Has This Been Tested?

Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
