### PR TITLE
feat: validate deployment mode provided

### DIFF
--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -371,6 +371,27 @@
     [/#if]
 [/#list]
 
+[#-- Validate Deployment Info --]
+[#if ((commandLineOptions.Deployment.Mode)!"")?has_content ]
+    [#if ! getDeploymentMode()?has_content ]
+        [@fatal
+            message="Undefined deployment mode used"
+            detail="Could not find definition of provided DeploymentMode"
+            context={ "DeploymentMode" : commandLineOptions.Deployment.Mode }
+        /]
+    [/#if]
+[/#if]
+
+[#if ((commandLineOptions.Deployment.Group.Name)!"")?has_content ]
+    [#if ! getDeploymentGroup()?has_content ]
+        [@fatal
+            message="Undefined deployment group used"
+            detail="Could not find definition of provided DeploymentGroup"
+            context={ "DeploymentGroup" : commandLineOptions.Deployment.Group.Name }
+        /]
+    [/#if]
+[/#if]
+
 [#function getSubnets tier networkResources zoneFilter="" asReferences=true includeZone=false]
     [#local result = [] ]
     [#list networkResources.subnets[tier.Id] as zone, resources]

--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -1626,7 +1626,7 @@
         },
         "ReplayWindowSize": 1024,
         "DeadPeerDetectionTimeout": 30,
-        "DeadPeerDetectionAction" : "clear",
+        "DeadPeerDetectionAction": "clear",
         "Phase1": {
           "EncryptionAlgorithms": [
             "AES256"
@@ -1753,30 +1753,32 @@
     }
   },
   "DeploymentModes": {
-    "_default": {
-      "Operations": [
-        "update"
-      ],
+    "update": {
+      "Operations": [ "update" ],
       "Membership": "priority",
       "Priority": {
         "GroupFilter": ".*",
         "Order": "LowestFirst"
       }
     },
-    "update": {
-      "Operations": [
-        "update"
-      ],
+    "maintenance": {
+      "Operations": [ "update" ],
       "Membership": "priority",
       "Priority": {
         "GroupFilter": ".*",
         "Order": "LowestFirst"
+      }
+    },
+    "hibernate": {
+      "Operations": [ "update" ],
+      "Membership": "priority",
+      "Priority": {
+        "GroupFilter": ".*",
+        "Order": "HighestFirst"
       }
     },
     "stop": {
-      "Operations": [
-        "delete"
-      ],
+      "Operations": [ "delete" ],
       "Membership": "priority",
       "Priority": {
         "GroupFilter": ".*",
@@ -1784,10 +1786,7 @@
       }
     },
     "stopstart": {
-      "Operations": [
-        "delete",
-        "update"
-      ],
+      "Operations": [ "delete", "update" ],
       "Membership": "priority",
       "Priority": {
         "GroupFilter": ".*",

--- a/providers/shared/inputsources/shared/masterdata.ftl
+++ b/providers/shared/inputsources/shared/masterdata.ftl
@@ -1729,7 +1729,7 @@
           }
         },
         "DeploymentModes" : {
-          "_default" : {
+          "update" : {
             "Operations" : [ "update" ],
             "Membership" : "priority",
             "Priority" : {
@@ -1737,12 +1737,20 @@
               "Order" : "LowestFirst"
             }
           },
-          "update" : {
+          "maintenance" : {
             "Operations" : [ "update" ],
             "Membership" : "priority",
             "Priority" : {
               "GroupFilter" : ".*",
               "Order" : "LowestFirst"
+            }
+          },
+          "hibernate" : {
+            "Operations" : [ "update" ],
+            "Membership" : "priority",
+            "Priority" : {
+              "GroupFilter" : ".*",
+              "Order" : "HighestFirst"
             }
           },
           "stop" : {

--- a/providers/shared/provider.ftl
+++ b/providers/shared/provider.ftl
@@ -9,76 +9,78 @@
     [#local deploymentModeDetails = getDeploymentModeDetails(deploymentMode)]
     [#local deploymentGroupDetails = getDeploymentGroupDetails(deploymentGroup) ]
 
-    [#local executionPolicy = deploymentModeDetails.ExecutionPolicy ]
+    [#if deploymentModeDetails?has_content ]
+        [#local executionPolicy = deploymentModeDetails.ExecutionPolicy ]
 
-    [#local mandatoryContract = false]
-    [#switch executionPolicy ]
-        [#case "Required" ]
-            [#local mandatoryContract = true ]
-            [#break]
-
-        [#case "Optional" ]
-            [#local mandatoryContract = false ]
-            [#break]
-    [/#switch]
-
-    [#if deploymentGroupDetails?has_content ]
-
-        [#local stageId = deploymentGroupDetails.Id ]
-        [#local stagePriority = 0 ]
-        [#local stageEnabled = false ]
-
-        [#-- Determine the group order --]
-        [#switch deploymentModeDetails.Membership ]
-            [#case "explicit" ]
-                [#local groupList = (deploymentModeDetails.Explicit.Groups)![] ]
-                [#if groupList?seq_contains(deploymentGroupDetails.Name) ]
-                    [#local stageEnabled = true]
-                    [#local stagePriority = groupList?seq_index_of(deploymentGroupDetails.Name) + 1 ]
-                [/#if]
+        [#local mandatoryContract = false]
+        [#switch executionPolicy ]
+            [#case "Required" ]
+                [#local mandatoryContract = true ]
                 [#break]
 
-            [#case "priority" ]
-                [#if deploymentGroupDetails.Name?matches( deploymentModeDetails.Priority.GroupFilter ) ]
-                    [#local stageEnabled = true]
-                    [#local stagePriority = valueIfTrue(
-                                                deploymentGroupDetails.Priority,
-                                                (deploymentModeDetails.Priority.Order == "LowestFirst"),
-                                                1000 - deploymentGroupDetails.Priority
-                                            )]
-                [/#if]
+            [#case "Optional" ]
+                [#local mandatoryContract = false ]
                 [#break]
-
         [/#switch]
 
-        [#if stageEnabled ]
-            [@contractStage
-                id=stageId
-                executionMode=CONTRACT_EXECUTION_MODE_PRIORITY
-                priority=stagePriority
-                mandatory=mandatoryContract
-            /]
+        [#if deploymentGroupDetails?has_content ]
 
-            [#local stepPriority = valueIfTrue(
-                deploymentPriority,
-                (deploymentModeDetails.Priority.Order == "LowestFirst"),
-                1000 - deploymentPriority
-            )]]
+            [#local stageId = deploymentGroupDetails.Id ]
+            [#local stagePriority = 0 ]
+            [#local stageEnabled = false ]
 
-            [@contractStep
-                id=formatId(stageId, deploymentUnit)
-                stageId=stageId
-                taskType=MANAGE_DEPLOYMENT_TASK_TYPE
-                priority=stepPriority
-                mandatory=mandatoryContract
-                parameters=
-                    {
-                        "DeploymentUnit" : deploymentUnit,
-                        "DeploymentGroup" : deploymentGroupDetails.Name,
-                        "DeploymentProvider" : deploymentProvider,
-                        "Operations" : deploymentModeDetails.Operations
-                    }
-            /]
+            [#-- Determine the group order --]
+            [#switch deploymentModeDetails.Membership ]
+                [#case "explicit" ]
+                    [#local groupList = (deploymentModeDetails.Explicit.Groups)![] ]
+                    [#if groupList?seq_contains(deploymentGroupDetails.Name) ]
+                        [#local stageEnabled = true]
+                        [#local stagePriority = groupList?seq_index_of(deploymentGroupDetails.Name) + 1 ]
+                    [/#if]
+                    [#break]
+
+                [#case "priority" ]
+                    [#if deploymentGroupDetails.Name?matches( deploymentModeDetails.Priority.GroupFilter ) ]
+                        [#local stageEnabled = true]
+                        [#local stagePriority = valueIfTrue(
+                                                    deploymentGroupDetails.Priority,
+                                                    (deploymentModeDetails.Priority.Order == "LowestFirst"),
+                                                    1000 - deploymentGroupDetails.Priority
+                                                )]
+                    [/#if]
+                    [#break]
+
+            [/#switch]
+
+            [#if stageEnabled ]
+                [@contractStage
+                    id=stageId
+                    executionMode=CONTRACT_EXECUTION_MODE_PRIORITY
+                    priority=stagePriority
+                    mandatory=mandatoryContract
+                /]
+
+                [#local stepPriority = valueIfTrue(
+                    deploymentPriority,
+                    (deploymentModeDetails.Priority.Order == "LowestFirst"),
+                    1000 - deploymentPriority
+                )]]
+
+                [@contractStep
+                    id=formatId(stageId, deploymentUnit)
+                    stageId=stageId
+                    taskType=MANAGE_DEPLOYMENT_TASK_TYPE
+                    priority=stepPriority
+                    mandatory=mandatoryContract
+                    parameters=
+                        {
+                            "DeploymentUnit" : deploymentUnit,
+                            "DeploymentGroup" : deploymentGroupDetails.Name,
+                            "DeploymentProvider" : deploymentProvider,
+                            "Operations" : deploymentModeDetails.Operations
+                        }
+                /]
+            [/#if]
         [/#if]
     [/#if]
 [/#macro]

--- a/providers/shared/references/DeploymentMode/id.ftl
+++ b/providers/shared/references/DeploymentMode/id.ftl
@@ -83,11 +83,6 @@
         [#local deploymentModeDetails = deploymentModes[deploymentMode]]
     [/#if]
 
-    [#if !(deploymentModeDetails?has_content) &&
-            (deploymentModes["_default"]!{})?has_content && deploymentModes["_default"].Enabled  ]
-        [#local deploymentModeDetails = deploymentModes["_default"]]
-    [/#if]
-
     [#if deploymentModeDetails?has_content ]
         [#return
             mergeObjects(


### PR DESCRIPTION
## Description

Fixes: https://github.com/hamlet-io/executor-python/issues/83

Enforces the use of defined deployment modes

- Any deployment mode that is used must now be defined in the blueprint before they can be used
- Adds two common deployment modes hibernate, and maintenance which are used in existing deployment profiles
- Removes the default deployment mode and the fall back used when getting details

## Motivation and Context

This provides better understanding of how deployment modes works and what the behaviour will be when they are used

## How Has This Been Tested?

Tested locally

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
