### PR TITLE
feat: add occurrences entrance

### DIFF
--- a/providers/shared/components/shared/setup.ftl
+++ b/providers/shared/components/shared/setup.ftl
@@ -17,6 +17,30 @@
     /]
 [/#macro]
 
+[#-- Default Occurrence State --]
+[#macro shared_occurrences_generationcontract occurrence ]
+    [@addDefaultGenerationContract subsets=[ "state" ] /]
+[/#macro]
+
+[#macro shared_occurrences_state occurrence ]
+    [#local allOccurrences = asFlattenedArray( [ occurrence, occurrence.Occurrences![] ], true )]
+    [#list allOccurrences as occurrence ]
+
+        [#local occurrencestate = {}]
+        [#list occurrence as k, v ]
+            [#if k != "Occurrences" ]
+                [#local occurrencestate = mergeObjects(occurrencestate, { k : v }) ]
+            [/#if]
+        [/#list]
+
+        [@stateEntry
+            type="Occurrences"
+            id=occurrence.Core.TypedFullName
+            state=occurrencestate
+        /]
+    [/#list]
+[/#macro]
+
 [#-- Default management contract --]
 [#macro shared_unitlist_generationcontract occurrence ]
     [@addDefaultGenerationContract subsets=[ "managementcontract" ] /]

--- a/providers/shared/entrances/entrance.ftl
+++ b/providers/shared/entrances/entrance.ftl
@@ -10,3 +10,4 @@
 [#assign SCHEMASET_ENTRANCE_TYPE         = "schemaset" ]
 [#assign INFO_ENTRANCE_TYPE              = "info" ]
 [#assign VALIDATE_ENTRANCE_TYPE          = "validate" ]
+[#assign OCCURRENCES_ENTRANCE_TYPE       = "occurrences" ]

--- a/providers/shared/entrances/occurrences/entrance.ftl
+++ b/providers/shared/entrances/occurrences/entrance.ftl
@@ -1,0 +1,31 @@
+[#ftl]
+
+[#macro shared_entrance_occurrences ]
+
+  [#assign allDeploymentUnits = true]
+
+  [#-- override the deployment group to get all deployment groups --]
+  [@addCommandLineOption
+      option={
+        "Deployment" : {
+          "Group" : {
+            "Name" : "*"
+          }
+        },
+        "Flow" : {
+          "Names" : [ "components" ]
+        }
+      }
+  /]
+
+  [#if (commandLineOptions.Deployment.Unit.Subset!"") == "generationcontract" ]
+    [#assign allDeploymentUnits = false]
+  [/#if]
+
+  [@generateOutput
+      deploymentFramework=commandLineOptions.Deployment.Framework.Name
+      type=commandLineOptions.Deployment.Output.Type
+      format=commandLineOptions.Deployment.Output.Format
+  /]
+
+[/#macro]

--- a/providers/shared/entrances/occurrences/id.ftl
+++ b/providers/shared/entrances/occurrences/id.ftl
@@ -1,0 +1,18 @@
+[#ftl]
+
+[@addEntrance
+    type=OCCURRENCES_ENTRANCE_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "Provides the state of all occurrences within a district"
+            }
+        ]
+    commandlineoptions=[
+        {
+            "Names" : "*",
+            "Types" : ANY_TYPE
+        }
+    ]
+/]


### PR DESCRIPTION
## Description

Closes: https://github.com/hamlet-io/engine/issues/1577

- Adds a new entrance to provide information specifically around occurrences.
- Adds a new output which provides the state of each occurrence in the district. To remove repetition subocurrences are removed from any occurrence which has a sub occurrence

## Motivation and Context

For occurrence queries in the python executor we use the blueprint output which is quite complicated to find all the occurrences. Providing a specific output makes it easy to query the occurrence details including finding suboccurrence details 

## How Has This Been Tested?

Tested locally

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
