### PR TITLE
fix: handle empty deployment unit Ids unitlist

### DIFF
--- a/providers/shared/views/unitlist/setup.ftl
+++ b/providers/shared/views/unitlist/setup.ftl
@@ -49,7 +49,8 @@
             [#if ! ((groupDetails.CompositeTemplate)!"")?has_content
                     && ! (groupDetails.ResourceSets!{})?keys?seq_contains(deploymentUnit)
                     && ! deploymentUnit?ends_with("-epilogue")
-                    && ! deploymentUnit?ends_with("-prologue") ]
+                    && ! deploymentUnit?ends_with("-prologue")
+                    && deploymentUnit?has_content ]
 
                 [#local deployState = getDeploymentUnitStates(deploymentGroup, deploymentUnit ) ]
 


### PR DESCRIPTION
## Description

Some stackoutput files don't include the deployment unit in the stack output. This checks for empty deployment unit entries as we can't include them in the unit list processing

## Motivation and Context

Safer handling of stackoutputs found in the list

## How Has This Been Tested?

Tested locally

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
