### PR TITLE
fix: RawId and Name values for subcomponents

### DIFF
--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -273,7 +273,10 @@
         [#local tierId = getTierId(tier) ]
         [#local tierName = getTierName(tier) ]
         [#local componentId = getComponentId(component) ]
+        [#local componentRawId = component.Id ]
         [#local componentName = getComponentName(component) ]
+        [#local componentRawName = component.Name ]
+        [#local componentType = type ]
         [#local subComponentId = [] ]
         [#local subComponentName = [] ]
         [#local componentContexts += [component, typeObject] ]
@@ -281,7 +284,10 @@
         [#local tierId = parentOccurrence.Core.Tier.Id ]
         [#local tierName = parentOccurrence.Core.Tier.Name ]
         [#local componentId = parentOccurrence.Core.Component.Id ]
+        [#local componentRawId = parentOccurrence.Core.Component.RawId ]
         [#local componentName = parentOccurrence.Core.Component.Name ]
+        [#local componentRawName = parentOccurrence.Core.Component.RawName ]
+        [#local componentType = parentOccurrence.Core.Component.Type ]
         [#local subComponentId = typeObject.Id?split("-") ]
         [#local subComponentName = typeObject.Name?split("-") ]
         [#local componentContexts += [typeObject] ]
@@ -319,10 +325,10 @@
                                 },
                                 "Component" : {
                                     "Id" : componentId,
-                                    "RawId" : component.Id,
+                                    "RawId" : componentRawId,
                                     "Name" : componentName,
-                                    "RawName" : component.Name,
-                                    "Type" : type
+                                    "RawName" : componentRawName,
+                                    "Type" : componentType
                                 },
                                 "Instance" : {
                                     "Id" : firstContent(instanceId, (parentOccurrence.Core.Instance.Id)!""),
@@ -353,7 +359,10 @@
                                 subComponentId,
                                 {
                                     "Id" : formatId(subComponentId),
-                                    "Name" : formatName(subComponentName)
+                                    "RawId" : component.Id,
+                                    "Name" : formatName(subComponentName),
+                                    "RawName" : component.Name,
+                                    "Type" : type
                                 }
                             ),
                             "State" : {


### PR DESCRIPTION
## Description

Fixes #1584 

- Fixes an issue where subcomponents would report the rawId for the
component they belong to as their subcomponent details.
- adds the same details as a component in the subcomponent state
details. This ensures that this information is available as required

## Motivation and Context

The RawId represents the Id or Name value as it was provided in the CMDB, this makes it easy to understand the source of a given configuration when using query tools and for performing troubleshooting.

## How Has This Been Tested?

Tested locally

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X ] None of the above.
