### PR TITLE
fix: define deploymentgroups for schemas

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,20 @@ pipeline {
     }
 
     stages {
+
+        stage('Run Schemas Generation as Test') {
+            environment {
+                GENERATION_ENGINE_DIR="${WORKSPACE}"
+                SCHEMA_OUTPUT_DIR="${WORKSPACE}"
+            }
+
+            steps {
+                sh '''#!/usr/bin/env bash
+                    hamlet -i mock -p shared -p aws -p azure schema create-schemas -o "${SCHEMA_OUTPUT_DIR}"
+                '''
+            }
+        }
+
         stage('Run Shared Provider Tests') {
             environment {
                 GENERATION_ENGINE_DIR="${WORKSPACE}"

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -371,27 +371,6 @@
     [/#if]
 [/#list]
 
-[#-- Validate Deployment Info --]
-[#if ((commandLineOptions.Deployment.Mode)!"")?has_content ]
-    [#if ! getDeploymentMode()?has_content ]
-        [@fatal
-            message="Undefined deployment mode used"
-            detail="Could not find definition of provided DeploymentMode"
-            context={ "DeploymentMode" : commandLineOptions.Deployment.Mode }
-        /]
-    [/#if]
-[/#if]
-
-[#if ((commandLineOptions.Deployment.Group.Name)!"")?has_content ]
-    [#if ! getDeploymentGroup()?has_content ]
-        [@fatal
-            message="Undefined deployment group used"
-            detail="Could not find definition of provided DeploymentGroup"
-            context={ "DeploymentGroup" : commandLineOptions.Deployment.Group.Name }
-        /]
-    [/#if]
-[/#if]
-
 [#function getSubnets tier networkResources zoneFilter="" asReferences=true includeZone=false]
     [#local result = [] ]
     [#list networkResources.subnets[tier.Id] as zone, resources]

--- a/providers/shared/entrances/deployment/entrance.ftl
+++ b/providers/shared/entrances/deployment/entrance.ftl
@@ -1,6 +1,28 @@
 [#ftl]
 
 [#macro shared_entrance_deployment ]
+
+    [#-- Validate Deployment Info --]
+    [#if ((commandLineOptions.Deployment.Mode)!"")?has_content ]
+        [#if ! getDeploymentMode()?has_content ]
+            [@fatal
+                message="Undefined deployment mode used"
+                detail="Could not find definition of provided DeploymentMode"
+                context={ "DeploymentMode" : commandLineOptions.Deployment.Mode }
+            /]
+        [/#if]
+    [/#if]
+
+    [#if ((commandLineOptions.Deployment.Group.Name)!"")?has_content ]
+        [#if ! getDeploymentGroup()?has_content ]
+            [@fatal
+                message="Undefined deployment group used"
+                detail="Could not find definition of provided DeploymentGroup"
+                context={ "DeploymentGroup" : commandLineOptions.Deployment.Group.Name }
+            /]
+        [/#if]
+    [/#if]
+
     [#assign deploymentGroupDetails = getDeploymentGroupDetails(getDeploymentGroup())]
     [#assign compositeTemplateContent = (.vars[deploymentGroupDetails.CompositeTemplate])!"" ]
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The introduction of validation for DeploymentGroups at runtime has
caused schema generation to fail. Unless a DeploymentGroup is defined
within a blueprint, the option is invalid as a commandLineOption.

This commit introduces definitions for the groups used for JSONSchema
generation - component, reference, module and attributeset.

It also adds schema generation into the Jenkins pipeline to act as a test for catching this sort of thing in the future.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#1576 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally - can now generate schemas the same as before introduction of #1576 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
