### PR TITLE
fix: regression in unitlist generation

### DIFF
--- a/providers/shared/provider.ftl
+++ b/providers/shared/provider.ftl
@@ -84,7 +84,8 @@
                             "DeploymentUnit" : deploymentUnit,
                             "DeploymentGroup" : deploymentGroupDetails.Name,
                             "DeploymentProvider" : deploymentProvider,
-                            "Operations" : deploymentModeDetails.Operations
+                            "Operations" : deploymentModeDetails.Operations,
+                            "CurrentState" : currentState
                         }
                 /]
             [/#if]

--- a/providers/shared/tasks/manage_deployment/id.ftl
+++ b/providers/shared/tasks/manage_deployment/id.ftl
@@ -34,7 +34,7 @@
             "Description" : "The current state of the deployment",
             "Values" : [ "notdeployed", "deployed", "orphaned" ],
             "Types" : STRING_TYPE,
-            "Mandatory" : false
+            "Mandatory" : true
         }
     ]
 /]


### PR DESCRIPTION
## Description

Add the CurrentState back into the contract output state and make it a mandatory task output since the python executor relies on it

## Motivation and Context

Due to a merge conflict in another PR the current state was removed from the unit list output

## How Has This Been Tested?

Tested locally

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
