### PR TITLE
fix: isolate testing to only include local code

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
 
             steps {
                 sh '''#!/usr/bin/env bash
-                    hamlet -i mock -p shared -p aws -p azure schema create-schemas -o "${SCHEMA_OUTPUT_DIR}"
+                    hamlet -i mock -p shared schema create-schemas -o "${SCHEMA_OUTPUT_DIR}"
                 '''
             }
         }


### PR DESCRIPTION
## Description

Removes the aws and azure providers from the mock schema generation
test

## Motivation and Context

This removes external dependecies on the testing where they aren't required. Changes which are required in plugin repos generally depend on changes in the engine repo. So this essentially creates a dependency loop when changes have been implemented especially around refactors

## How Has This Been Tested?

Will test in PR 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
