### PR TITLE
fix: disable qualifier transformer

### DIFF
--- a/providers/shared/inputseeders/shared/id.ftl
+++ b/providers/shared/inputseeders/shared/id.ftl
@@ -30,10 +30,12 @@
     seeder=SHARED_INPUT_SEEDER
 /]
 
-[@addTransformerToConfigPipeline
+[#-- TODO(mfl) Reenable once layers are in the input processing --]
+[#-- so the layer ids can be included in the qualifiers         --]
+[#--@addTransformerToConfigPipeline
     stage=QUALIFY_SHARED_INPUT_STAGE
     transformer=SHARED_INPUT_SEEDER
-/]
+/--]
 
 [#macro shared_inputloader path]
     [#assign shared_cmdb_masterdata =


### PR DESCRIPTION
## Description
Disable the qualifier transformer in input processing.

## Motivation and Context
At present, solutions have been designed on the assumption that layer ids could be used as the basis for the qualification. The qualifier transformer currently only works on the layer names.

Once layers are better supported in the input processing, the transformer can be updated to include layer ids in the filter and the transformer re-enabled.

## How Has This Been Tested?
Local template generations

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Re-enable once layer processing is part of the input pipeline.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
