### PR TITLE
feat: adds mount path to volume config

### DIFF
--- a/providers/shared/references/Storage/id.ftl
+++ b/providers/shared/references/Storage/id.ftl
@@ -23,6 +23,11 @@
                             "Mandatory" : true
                         },
                         {
+                            "Names" : "MountPath",
+                            "Types" : STRING_TYPE,
+                            "Description" : "The OS path to mount the volume"
+                        },
+                        {
                             "Names" : "Size",
                             "Types" : NUMBER_TYPE,
                             "Mandatory" : true


### PR DESCRIPTION
## Description

Adds the ability to define a mount path for a volume this is used by config scripts to setup and mount a volume

## Motivation and Context

This allows for the volume mounting to be managed as part of an ec2 instance startup. This allows users to define their volumes and where they get mounted 

## How Has This Been Tested?

Tested locally

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
