### PR TITLE
fix: output naming for deployment group prefix

### DIFF
--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -495,13 +495,10 @@
         alternative
     ]
 
-    [#local deploymentGroupDetails = getDeploymentGroupDetails(deployment_group)]
-    [#local level_prefix = ((deploymentGroupDetails.OutputPrefix)!deploymentGroupDetails.Name)!"" ]
-
     [#-- set the default values for the file name parts --]
     [#local filename_parts = {
         "entrance_prefix" : entrance,
-        "level_prefix" : level_prefix,
+        "level_prefix" : deployment_group,
         "deployment_unit_prefix" : deployment_unit,
         "account_prefix" : account,
         "region_prefix" : region,
@@ -530,7 +527,18 @@
         [#case "deployment" ]
         [#case "deploymenttest" ]
 
-        [#switch level_prefix ]
+        [#-- overrride the level prefix to align with older deployment groups --]
+        [#local deploymentGroupDetails = getDeploymentGroupDetails(deployment_group)]
+        [#local filename_parts =
+                    mergeObjects(
+                        filename_parts,
+                        {
+                            "level_prefix" : ((deploymentGroupDetails.OutputPrefix)!deploymentGroupDetails.Name)!deployment_group
+                        }
+                    )
+        ]
+
+        [#switch filename_parts["level_prefix"] ]
             [#case "account" ]
                 [#local filename_parts =
                             mergeObjects(

--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -498,7 +498,7 @@
     [#-- set the default values for the file name parts --]
     [#local filename_parts = {
         "entrance_prefix" : entrance,
-        "level_prefix" : deployment_group,
+        "deployment_group_prefix" : deployment_group,
         "deployment_unit_prefix" : deployment_unit,
         "account_prefix" : account,
         "region_prefix" : region,
@@ -507,7 +507,7 @@
 
     [#local filename_part_order = [
         "entrance_prefix",
-        "level_prefix",
+        "deployment_group_prefix",
         "deployment_unit_prefix",
         "account_prefix",
         "region_prefix",
@@ -533,12 +533,12 @@
                     mergeObjects(
                         filename_parts,
                         {
-                            "level_prefix" : ((deploymentGroupDetails.OutputPrefix)!deploymentGroupDetails.Name)!deployment_group
+                            "deployment_group_prefix" : ((deploymentGroupDetails.OutputPrefix)!deploymentGroupDetails.Name)!deployment_group
                         }
                     )
         ]
 
-        [#switch filename_parts["level_prefix"] ]
+        [#switch filename_parts["deployment_group_prefix"] ]
             [#case "account" ]
                 [#local filename_parts =
                             mergeObjects(


### PR DESCRIPTION
## Description

- fix to account for entrances which use the deployment group as a parameter but don't have deployment group defined in the engine
- renames level_prefix to deployment_group_prefix to align with naming of deployment group

## Motivation and Context

Deployment group and deployment unit have been used as a way to provide parameters to other entrances which don't use the engine defined DeploymentGroups. This uses the deployment group as a standard parameter in output formatting and only performs the lookup and translation where its required. 

## How Has This Been Tested?

Tested locally

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
