### PR TITLE
fix: handle deployment details in output file name

### DIFF
--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -514,6 +514,7 @@
         "alternative_prefix"
     ]]
 
+    [#-- Alternatives --]
     [#if filename_parts["alternative_prefix"] == "primary" ]
         [#local filename_parts =
             mergeObjects(
@@ -523,6 +524,28 @@
                 })]
     [/#if]
 
+    [#-- Deployment detail prefix handling --]
+    [#switch entrance ]
+        [#case "blueprint"]
+        [#case "info"]
+        [#case "loader"]
+        [#case "occurrences"]
+        [#case "schemaset"]
+        [#case "unitlist"]
+        [#case "validate"]
+            [#local filename_parts =
+                        mergeObjects(
+                            filename_parts,
+                            {
+                                "deployment_group_prefix" : "",
+                                "deployment_unit_prefix" : ""
+                            }
+                        )
+            ]
+            [#break]
+    [/#switch]
+
+    [#-- Deployment based prefixing --]
     [#switch entrance ]
         [#case "deployment" ]
         [#case "deploymenttest" ]


### PR DESCRIPTION
## Description

Skip deployment details in the filename setup when the entrance either generates outputs for all deployments or doesn't do anything with outputs

## Motivation and Context

Makes output filenames align with whats inside the file

## How Has This Been Tested?

Tested locally

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
