### PR TITLE
refactor: remove startup scripts from masterdata

### DIFF
--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -960,17 +960,6 @@
       "MaxAge": 1800
     }
   },
-  "ScriptStores": {
-    "_startup": {
-      "Engine": "local",
-      "Source": {
-        "Directory": "$\\{GENERATION_STARTUP_DIR}/bootstrap"
-      },
-      "Destination": {
-        "Prefix": "bootstrap"
-      }
-    }
-  },
   "WAFValueSets": {
     "default": {
       "badcookies": [


### PR DESCRIPTION
## Description

Removes the startup script store from the masterdata. 

## Motivation and Context

This base startup functionality is now part of the engine init scripts for the providers

## How Has This Been Tested?

Tested locally

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
