### PR TITLE
fix: current unit detection

### DIFF
--- a/providers/shared/services/resource.ftl
+++ b/providers/shared/services/resource.ftl
@@ -2,7 +2,7 @@
 
 [#-- Is a resource part of a deployment unit --]
 [#function isPartOfDeploymentUnit resourceId deploymentUnit deploymentUnitSubset]
-  [#local resourceObject = getStatePoint(resourceId)]
+  [#local pointObject = getStatePoint(resourceId)]
   [#local
     currentDeploymentUnit =
       deploymentUnit +
@@ -11,8 +11,8 @@
         ""
       )
   ]
-  [#return !(resourceObject?has_content &&
-    (resourceObject.DeploymentUnit != currentDeploymentUnit))]
+  [#return !(pointObject.Value?has_content &&
+    (pointObject.DeploymentUnit != currentDeploymentUnit))]
 [/#function]
 
 [#-- Is a resource part of the current deployment unit --]


### PR DESCRIPTION

## Description
Correct logic of `isPartOfCurrentDeploymentUnit()`

## Motivation and Context
With the change to the input processing, correct use of `getStatePoint()` in `isPartOfCurrentDeploymentUnit()` to ensure behaviour of function is unchanged.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
