### PR TITLE
refactor: composite template inclusion

### DIFF
--- a/engine/extension.ftl
+++ b/engine/extension.ftl
@@ -158,9 +158,25 @@
 
         [#local extensionDetails = getExtensionDetails(id, provider)]
 
-        [#-- Legacy support for fragments which are part of the composite fragment file --]
+        [#-- Legacy support for fragments --]
         [#local fragmentId = id ]
-        [#include fragmentList?ensure_starts_with("/")]
+        [#-- TODO(mfl) Remove check for fragmentList once changes to --
+        [#-- support content intergretation in place --]
+        [#if fragmentList?has_content]
+            [#include fragmentList?ensure_starts_with("/") ]
+        [/#if]
+
+        [#local fragments = getFragments()?trim ]
+        [#if fragments?has_content]
+            [#if !fragments?contains("[#ftl]") ]
+                [#-- Ensure fragments are assembled into a case statement --]
+                [#local fragments = fragments?ensure_starts_with("[#ftl][#switch fragmentId]")?ensure_ends_with("[/#switch]") ]
+            [/#if]
+
+            [#-- Treat as interpretable content --]
+            [#local inlineFragment = fragments?interpret]
+            [@inlineFragment /]
+        [/#if]
 
         [#-- Find the extension function --]
         [#if !(extensionDetails?has_content) ]

--- a/engine/inputdata/inputsource.ftl
+++ b/engine/inputdata/inputsource.ftl
@@ -363,7 +363,7 @@ to filter the data returned
 [#assign BLUEPRINT_CONFIG_INPUT_CLASS = "Blueprint" ]
 [#assign SETTINGS_CONFIG_INPUT_CLASS = "Settings" ]
 [#assign DEFINITIONS_CONFIG_INPUT_CLASS = "Definitions" ]
-[#assign FRAGMENT_CONFIG_INPUT_CLASS = "Fragments" ]
+[#assign FRAGMENTS_CONFIG_INPUT_CLASS = "Fragments" ]
 [#assign STATE_CONFIG_INPUT_CLASS = "State" ]
 [#assign LOADER_CONFIG_INPUT_CLASS = "Loader" ]
 [#assign LAYERS_CONFIG_INPUT_CLASS = "Layers" ]
@@ -400,7 +400,7 @@ to filter the data returned
 [/#function]
 
 [#function getFragments ]
-    [#return getInputState()[FRAGMENT_CONFIG_INPUT_CLASS]!{} ]
+    [#return getInputState()[FRAGMENTS_CONFIG_INPUT_CLASS]!"" ]
 [/#function]
 
 [#function getState ]

--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -120,7 +120,14 @@
     /]
 
     [#if include?has_content]
-        [#include include?ensure_starts_with("/")]
+        [#if include?contains("[#ftl]") ]
+            [#-- treat as interpretable content --]
+            [#local inlineInclude = include?interpret]
+            [@inlineInclude /]
+        [#else]
+            [#-- assume a filename --]
+            [#include include?ensure_starts_with("/") ]
+        [/#if]
     [#else]
         [@processFlows
             level=level
@@ -245,7 +252,14 @@
 
     [#-- Resources --]
     [#if include?has_content]
-        [#include include?ensure_starts_with("/")]
+        [#if include?contains("[#ftl]") ]
+            [#-- treat as interpretable content --]
+            [#local inlineInclude = include?interpret]
+            [@inlineInclude /]
+        [#else]
+            [#-- assume a filename --]
+            [#include include?ensure_starts_with("/") ]
+        [/#if]
     [#else]
         [@processFlows
             level=level
@@ -420,7 +434,7 @@
 
 [/#macro]
 
-[#-- Occuurrence State --]
+[#-- Occurrence State --]
 [#function default_output_state level="" include=""]
     [@initialiseJsonOutput name="states" /]
 
@@ -611,7 +625,14 @@
     [/#if]
 
     [#if include?has_content]
-        [#include include?ensure_starts_with("/")]
+        [#if include?contains("[#ftl]") ]
+            [#-- treat as interpretable content --]
+            [#local inlineInclude = include?interpret]
+            [@inlineInclude /]
+        [#else]
+            [#-- assume a filename --]
+            [#include include?ensure_starts_with("/") ]
+        [/#if]
     [#else]
           [@processFlows
             level=level

--- a/providers/shared/inputseeders/shared/id.ftl
+++ b/providers/shared/inputseeders/shared/id.ftl
@@ -340,7 +340,7 @@
     [#local compositeBlueprint = (blueprint!"")?has_content?then(blueprint?eval, {}) ]
 
     [#if compositeBlueprint?has_content]
-        [#-- Blueprint needed for subsequent stages --]
+        [#-- Blueprint needed for plugin/module determination --]
         [#local result =
             addToConfigPipelineClass(
                 result,
@@ -354,7 +354,7 @@
     [#local compositeSettings = (settings!"")?has_content?then(settings?eval, {}) ]
 
     [#if compositeSettings?has_content]
-        [#-- Settings not needed for plugin/module determination --]
+        [#-- Cache settings ready for normalisation --]
         [#local result =
             addToConfigPipelineStageCacheForClass(
                 result,
@@ -372,7 +372,7 @@
         )
     ]
     [#if compositeDefinitions?has_content]
-        [#-- Definitions not needed for plugin/module determination --]
+        [#-- Cache definitions ready for normalisation --]
         [#local result =
             addToConfigPipelineStageCacheForClass(
                 result,
@@ -386,7 +386,7 @@
     [#local compositeStackOutputs = (stackOutputs!"")?has_content?then(stackOutputs?eval, []) ]
 
     [#if compositeStackOutputs?has_content]
-        [#-- Stack outputs are not needed for plugin/module determination --]
+        [#-- Cache stack outputs ready for normalisation --]
         [#local result =
             addToConfigPipelineStageCacheForClass(
                 result,
@@ -396,6 +396,17 @@
                     []
                 ),
                 CMDB_SHARED_INPUT_STAGE
+            )
+        ]
+    [/#if]
+
+    [#if fragmentTemplate?has_content]
+        [#-- Fragments are not affected by plugin/module determination --]
+        [#local result =
+            addToConfigPipelineClass(
+                result,
+                FRAGMENTS_CONFIG_INPUT_CLASS,
+                fragmentTemplate
             )
         ]
     [/#if]


### PR DESCRIPTION


## Description
Support composite templates to be provided via a filename or via the content being directly included.

## Motivation and Context
As part of moving to dynamic input loading, reliance on pre-assembled content needs to be removed. This change starts the process by using the `?interpret` builtin internally to avoid use of the `[#include]` directive if the content appears to be freemarker markup.

## How Has This Been Tested?
Local template generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
