### PR TITLE
fix: loader module control

### DIFF
--- a/engine/inputdata/inputsource.ftl
+++ b/engine/inputdata/inputsource.ftl
@@ -548,8 +548,8 @@ A stack is used to capture the history of input state changes
                     [#-- Provide the state thus far - mainly for CLO access --]
                     [#assign inputState = newState]
 
-                    [#-- Ensure required plugins --]
-                    [#if newState[COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS].Plugins.MissingPluginAction?lower_case == "stop"]
+                    [#-- Ensure required plugins are loaded if not refreshing plugins --]
+                    [#if !newState[COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS].Plugins.RefreshRequired]
                         [#local unloadedPlugins =
                             getUnloadedPlugins(
                                 newState[COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS].Plugins.State,

--- a/providers/shared/inputseeders/shared/id.ftl
+++ b/providers/shared/inputseeders/shared/id.ftl
@@ -121,7 +121,7 @@
                                     pluginState?eval,
                                     {}
                     ),
-                    "MissingPluginAction" : missingPluginAction!"stop"
+                    "RefreshRequired" :  ((pluginRefreshRequired!"") == "true")
                 },
                 [#-- Deployment Details --]
                 "Deployment" : {
@@ -475,7 +475,9 @@
 
     [#local activeModules = getActiveModulesFromLayers() ]
     [#local moduleState = {} ]
-    [#if activeModules?has_content ]
+    [#if activeModules?has_content &&
+            [#-- Don't try to load modules when refreshing plugin state --]
+            !state[COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS].Plugins.RefreshRequired]
         [@debug
             message="Active modules"
             context=activeModules


### PR DESCRIPTION
## Description
When using the loader entrance to refresh the plugin state, no modules need be loaded as they are not needed to determine the plugins required.

## Motivation and Context
Fixes #1615

## How Has This Been Tested?
Local configuration of plugins/modules

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
The following change needs to be committed for the engine change to take effect
- [x] https://github.com/hamlet-io/executor-bash/pull/190

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
