### PR TITLE
fix: handle multiple load modules in module

### DIFF
--- a/engine/module.ftl
+++ b/engine/module.ftl
@@ -75,11 +75,15 @@
     [/#list]
 
     [#assign moduleInputState =
-        attributeIfContent(COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS, commandLineOption) +
-        attributeIfContent(BLUEPRINT_CONFIG_INPUT_CLASS, blueprint) +
-        attributeIfContent(SETTINGS_CONFIG_INPUT_CLASS, formattedModuleSettings) +
-        attributeIfContent(DEFINITIONS_CONFIG_INPUT_CLASS, definitions) +
-        attributeIfContent(STATE_CONFIG_INPUT_CLASS, stackOutputs)
+        mergeObjects(
+            moduleInputState,
+            {} +
+            attributeIfContent(COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS, commandLineOption) +
+            attributeIfContent(BLUEPRINT_CONFIG_INPUT_CLASS, blueprint) +
+            attributeIfContent(SETTINGS_CONFIG_INPUT_CLASS, formattedModuleSettings) +
+            attributeIfContent(DEFINITIONS_CONFIG_INPUT_CLASS, definitions) +
+            attributeIfContent(STATE_CONFIG_INPUT_CLASS, stackOutputs)
+        )
     ]
 [/#macro]
 


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
merges module input state instead of replacing on each invocation of the macro

## Motivation and Context

This allows modules to run the loadModule macro multiple times to simplify modules and make them easier to follow

## How Has This Been Tested?

Tested locally

## Followup Actions

- [x] None
