### PR TITLE
feat(apigateway): image sourcing support

### DIFF
--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -244,6 +244,37 @@ object.
             {
                 "Names" : "Tracing",
                 "Children" : tracingChildConfiguration
+            },
+            {
+                "Names" : "Image",
+                "Description" : "Control the source of the image that is used for the function",
+                "Children" : [
+                    {
+                        "Names" : "Source",
+                        "Description" : "The source of the image - registry: the local hamlet registry - url: an external public url - none: no source image",
+                        "Types" : STRING_TYPE,
+                        "Mandatory" : true,
+                        "Values" : [ "registry", "url", "none" ],
+                        "Default" : "registry"
+                    },
+                    {
+                        "Names" : "Source:url",
+                        "Description" : "Url Source specific Configuration",
+                        "Children" : [
+                            {
+                                "Names" : "Url",
+                                "Description" : "The Url to the lambda zip file",
+                                "Types" : STRING_TYPE
+                            },
+                            {
+                                "Names" : "ImageHash",
+                                "Description" : "The expected sha1 hash of the Url if empty any will be accepted",
+                                "Types" : STRING_TYPE,
+                                "Default" : ""
+                            }
+                        ]
+                    }
+                ]
             }
         ]
 /]

--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -247,7 +247,7 @@ object.
             },
             {
                 "Names" : "Image",
-                "Description" : "Control the source of the image that is used for the function",
+                "Description" : "Control the source of the image for the openapi specification",
                 "Children" : [
                     {
                         "Names" : "Source",
@@ -263,7 +263,7 @@ object.
                         "Children" : [
                             {
                                 "Names" : "Url",
-                                "Description" : "The Url to the lambda zip file",
+                                "Description" : "The Url to the openapi file",
                                 "Types" : STRING_TYPE
                             },
                             {


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds support for specifying alternate image sources for apigateway

Also includes a none option which can be used in modules which specify the apidefintion and inject it as part of the blueprint processing

## Motivation and Context

Allows for external sources to be used for API Gateway definitions which simplifies the build process and also removes unnecessary pregeneraiton scripts when they aren't required

## How Has This Been Tested?

Tested locally

## Followup Actions

- [x] None
