### PR TITLE
fix: use loaded providers as definitive providers

### DIFF
--- a/engine/entrance.ftl
+++ b/engine/entrance.ftl
@@ -103,7 +103,7 @@
 [#macro invokeEntranceMacro type ]
 
     [#local macroOptions = []]
-    [#list getCLODeploymentProviders() as provider ]
+    [#list getLoader().Providers as provider ]
         [#local macroOptions +=
             [
                 [ provider, "entrance", type ]
@@ -124,16 +124,16 @@
         [@fatal
             message="Could not find entrance macro with provided options"
             context=macroOptions
-            enabled=false
+            enabled=true
+            stop=true
         /]
-        [#stop "HamletFatal: Unable to find an entrance macro: ${type}" ]
     [/#if]
 [/#macro]
 
 [#macro addEntranceInputSteps type ]
 
     [#local macroOptions = []]
-    [#list getCLODeploymentProviders() as provider ]
+    [#list getLoaderProviders() as provider ]
         [#local macroOptions +=
             [
                 [ provider, "entrance", type, "inputsteps" ]

--- a/engine/entrance.ftl
+++ b/engine/entrance.ftl
@@ -103,7 +103,7 @@
 [#macro invokeEntranceMacro type ]
 
     [#local macroOptions = []]
-    [#list getLoader().Providers as provider ]
+    [#list getLoaderProviders() as provider ]
         [#local macroOptions +=
             [
                 [ provider, "entrance", type ]

--- a/engine/inputdata/blueprint.ftl
+++ b/engine/inputdata/blueprint.ftl
@@ -43,7 +43,7 @@
     [#-- Components --]
     [@includeAllComponentDefinitionConfiguration
         SHARED_PROVIDER
-        getCLODeploymentProviders()
+        getLoaderProviders()
     /]
 
     [#local componentChildren = []]

--- a/engine/inputdata/inputsource.ftl
+++ b/engine/inputdata/inputsource.ftl
@@ -415,6 +415,9 @@ to filter the data returned
     [#return getInputState()[LOADER_CONFIG_INPUT_CLASS]!{} ]
 [/#function]
 
+[#function getLoaderProviders ]
+    [#return (getLoader().Providers)![]]
+[/#function]
 [#--
 Get the value for a point within the state
 --]
@@ -1021,4 +1024,3 @@ as processing is typically centred around the initially provided filter values
         [#assign inputStateRefreshRequired = false]
     [/#if]
 [/#macro]
-

--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -433,7 +433,7 @@
 
     [#local outputMappings = getGenerationContractStepOutputMapping(
                                 combineEntities(
-                                    getCLODeploymentProviders(),
+                                    getLoaderProviders(),
                                     [ SHARED_PROVIDER],
                                     UNIQUE_COMBINE_BEHAVIOUR
                                 ),
@@ -448,7 +448,7 @@
 [#function getGenerationContractStepParameters subset alternative ]
     [#local outputMappings = getGenerationContractStepOutputMapping(
                                 combineEntities(
-                                    getCLODeploymentProviders(),
+                                    getLoaderProviders(),
                                     [ SHARED_PROVIDER],
                                     UNIQUE_COMBINE_BEHAVIOUR
                                 ),
@@ -464,7 +464,7 @@
     [#return {
         "entrance"               : getCLOEntranceType(),
         "flows"                  : getCLOFlows()?join(","),
-        "providers"              : (getCLODeploymentProviders()?join(","))!SHARED_PROVIDER,
+        "providers"              : (getLoaderProviders()?join(","))!SHARED_PROVIDER,
         "deploymentFramework"    : getCLODeploymentFramework(),
         "outputType"             : outputMappings["OutputType"],
         "outputFormat"           : outputMappings["OutputFormat"],

--- a/engine/output_writer.ftl
+++ b/engine/output_writer.ftl
@@ -129,7 +129,7 @@
             [#break]
         [/#if]
 
-        [#list combineEntities( getCLODeploymentProviders(), [ SHARED_PROVIDER ], UNIQUE_COMBINE_BEHAVIOUR) as provider ]
+        [#list combineEntities( getLoaderProviders(), [ SHARED_PROVIDER ], UNIQUE_COMBINE_BEHAVIOUR) as provider ]
             [#local handlerFunctionOptions = [
                 [ provider, "outputhandler", handler ]
             ]]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -5,7 +5,7 @@
 [@includeSharedComponentConfiguration component="baseline" /]
 
 [#-- Temporary AWS stuff --]
-[#if getCLODeploymentProviders()?seq_contains("aws") ]
+[#if getLoaderProviders()?seq_contains("aws") ]
     [@includeProviderComponentDefinitionConfiguration provider="aws" component="baseline" /]
     [@includeProviderComponentConfiguration provider="aws" component="baseline" services="baseline" /]
     [@includeProviderComponentDefinitionConfiguration provider="aws" component="s3" /]
@@ -130,7 +130,7 @@
         [#assign accountId = accountObject.Id ]
         [#assign accountName = accountObject.Name ]
 
-        [#if getCLODeploymentProviders()?seq_contains("aws")]
+        [#if getLoaderProviders()?seq_contains("aws")]
             [#assign credentialsBucket = getExistingReference(formatAccountS3Id("credentials"))]
             [#assign credentialsBucketRegion = getExistingReference(formatAccountS3Id("credentials"), REGION_ATTRIBUTE_TYPE)]
 
@@ -204,7 +204,7 @@
 
         [/#if]
 
-        [#if getCLODeploymentProviders()?seq_contains("aws")]
+        [#if getLoaderProviders()?seq_contains("aws")]
             [#assign segmentSeed = getExistingReference(formatSegmentSeedId()) ]
 
             [#assign legacyVpc = getExistingReference(formatVPCId())?has_content ]
@@ -226,7 +226,7 @@
         [#assign sshEnabled = segmentObject.Bastion.Enabled ]
         [#assign sshActive = sshEnabled && segmentObject.Bastion.Active ]
 
-        [#if getCLODeploymentProviders()?seq_contains("aws")]
+        [#if getLoaderProviders()?seq_contains("aws")]
             [#assign sshFromProxySecurityGroup = getExistingReference(formatSSHFromProxySecurityGroupId())]
         [/#if]
 
@@ -695,5 +695,3 @@
     [/#list]
     [#return codes]
 [/#function]
-
-

--- a/providers/shared/components/shared/setup.ftl
+++ b/providers/shared/components/shared/setup.ftl
@@ -99,7 +99,7 @@
             [#local testCase = testCases[testCaseName] ]
 
             [#local outputProviders = combineEntities(
-                                            getCLODeploymentProviders(),
+                                            getLoaderProviders(),
                                             [ SHARED_PROVIDER],
                                             UNIQUE_COMBINE_BEHAVIOUR
                                         )]

--- a/providers/shared/flows/views/flow.ftl
+++ b/providers/shared/flows/views/flow.ftl
@@ -15,7 +15,7 @@
         view=getCLOView()
     /]
 
-    [#local primaryProvider = (getCLODeploymentProviders()[0])!SHARED_PROVIDER ]
+    [#local primaryProvider = (getLoaderProviders()[0])!SHARED_PROVIDER ]
 
     [@includeProviderViewDefinitionConfiguration
         provider=primaryProvider

--- a/providers/shared/provider.ftl
+++ b/providers/shared/provider.ftl
@@ -125,7 +125,7 @@
             deploymentUnit=resourceSet["deployment:Unit"]
             deploymentGroup=deploymentGroupDetails.Name
             deploymentPriority=priority?has_content?then(priority, resourceSet["deployment:Priority"])
-            deploymentProvider=getCLODeploymentProviders()[0]
+            deploymentProvider=getLoaderProviders()[0]
             currentState=currentState
             deploymentMode=deploymentMode
         /]

--- a/providers/shared/views/info/setup.ftl
+++ b/providers/shared/views/info/setup.ftl
@@ -7,7 +7,7 @@
 [#macro shared_view_default_info ]
 
     [#-- Load sections which are dynamically loaded through discovery --]
-    [#local providersList = asFlattenedArray( [ SHARED_PROVIDER, getCLODeploymentProviders() ] ) ]
+    [#local providersList = asFlattenedArray( [ SHARED_PROVIDER, getLoaderProviders() ] ) ]
     [@includeAllComponentDefinitionConfiguration providersList /]
     [@includeAllViewConfiguration providersList /]
 

--- a/providers/shared/views/schema/setup.ftl
+++ b/providers/shared/views/schema/setup.ftl
@@ -28,7 +28,7 @@
                 [#break]
             [#else]
 
-                [#local schemaLayerConfig = 
+                [#local schemaLayerConfig =
                     getLayerConfiguration(schema?capitalize)]
 
                 [#local schemaLayerAttributes = schemaLayerConfig.Attributes![]]
@@ -56,7 +56,7 @@
 
             [@includeAllComponentDefinitionConfiguration
                 SHARED_PROVIDER
-                getCLODeploymentProviders()
+                getLoaderProviders()
             /]
             [#local configuration = componentConfiguration[schema] ]
 

--- a/providers/shared/views/schemaset/setup.ftl
+++ b/providers/shared/views/schemaset/setup.ftl
@@ -22,7 +22,7 @@
             [#case "component" ]
                 [@includeAllComponentDefinitionConfiguration
                     SHARED_PROVIDER
-                    getCLODeploymentProviders()
+                    getLoaderProviders()
                 /]
                 [#local schemas = componentConfiguration?keys ]
                 [#break]
@@ -40,7 +40,7 @@
         [#local outputMappings =
             getGenerationContractStepOutputMapping(
                                 combineEntities(
-                                    getCLODeploymentProviders(),
+                                    getLoaderProviders(),
                                     [ SHARED_PROVIDER],
                                     UNIQUE_COMBINE_BEHAVIOUR
                                 ),

--- a/providers/shared/views/unitlist/setup.ftl
+++ b/providers/shared/views/unitlist/setup.ftl
@@ -59,7 +59,7 @@
                         deploymentUnit=deploymentUnit
                         deploymentPriority=999
                         deploymentGroup=deploymentGroup
-                        deploymentProvider=(getCLODeploymentProviders()[0])!SHARED_PROVIDER
+                        deploymentProvider=(getLoaderProviders()[0])!SHARED_PROVIDER
                         currentState="orphaned"
                         deploymentMode="_orphan"
                     /]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Uses the loaded providers as the definitive list of providers that the engine is using for a given pass.

## Motivation and Context

We currently have 2 ways of defining the providers used in a solution the command line options using the -p flag and the CMDB approach which defines the plugins to load which also act as providers

This loaded providers are based on what is found in the plugins along with the command line options used.  This ensures that the providers loaded through the CMDB are included in processing of entrances, and other functions within in the engine

## How Has This Been Tested?

Tested locally

## Followup Actions

- [x] None
