### PR TITLE
feat: add image configuration support for vms

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -1272,26 +1272,3 @@ behaviour.
     [/#if]
     [#return addIdNameToObject(result, default) ]
 [/#function]
-
-
-[#-- OS Patching Config --]
-[#assign osPatchingChildConfiguration = [
-    {
-        "Names" : "Enabled",
-        "Description" : "Enable automatic OS Patching",
-        "Types" : BOOLEAN_TYPE,
-        "Default" : true
-    },
-    {
-        "Names" : "Schedule",
-        "Description" : "UTC based cron schedule to apply updates",
-        "Types" : STRING_TYPE,
-        "Default" : "59 13 * * *"
-    },
-    {
-        "Names" : "SecurityOnly",
-        "Description" : "Only apply security updates",
-        "Types" : BOOLEAN_TYPE,
-        "Default" : false
-    }
-]]

--- a/providers/shared/attributesets/attributeset.ftl
+++ b/providers/shared/attributesets/attributeset.ftl
@@ -2,3 +2,5 @@
 
 [#assign LINK_ATTRIBUTESET_TYPE = "link"]
 [#assign CONTEXTPATH_ATTRIBUTESET_TYPE = "contextpath"]
+[#assign OPERATINGSYSTEM_ATTRIBUTESET_TYPE = "operatingsystem" ]
+[#assign OSPATCHING_ATTRIBUTESET_TYPE = "ospatching"]

--- a/providers/shared/attributesets/operatingsystem/id.ftl
+++ b/providers/shared/attributesets/operatingsystem/id.ftl
@@ -1,0 +1,40 @@
+[#ftl]
+
+[@addAttributeSet
+    type=OPERATINGSYSTEM_ATTRIBUTESET_TYPE
+    pluralType="OperatingSystems"
+    properties=[
+        {
+                "Type"  : "Description",
+                "Value" : "Standard Configuration options to define an operating system"
+        }]
+    attributes=[
+        {
+            "Names" : "Architecture",
+            "Description" : "The CPU Architecture used",
+            "Types" : STRING_TYPE,
+            "Values" : [ "i386", "x86_64", "arm64" ]
+        },
+        {
+            "Names" : "Family",
+            "Description" : "The broad family of operating system",
+            "Types" : STRING_TYPE,
+            "Values" : [ "linux", "windows", "macos" ]
+        },
+        {
+            "Names" : "Distribution",
+            "Description" : "The distribution of the operating system",
+            "Types": STRING_TYPE
+        },
+        {
+            "Names" : "MajorVersion",
+            "Description" : "The major version of the distribution",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "MinorVersion",
+            "Description" : "The minor version of the distribution major version",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/providers/shared/attributesets/ospatching/id.ftl
+++ b/providers/shared/attributesets/ospatching/id.ftl
@@ -1,0 +1,31 @@
+[#ftl]
+
+[@addAttributeSet
+    type=OSPATCHING_ATTRIBUTESET_TYPE
+    pluralType="OSPatches"
+    properties=[
+        {
+                "Type"  : "Description",
+                "Value" : "OS Patching configuration definitions"
+        }]
+    attributes=[
+        {
+            "Names" : "Enabled",
+            "Description" : "Enable automatic OS Patching",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : true
+        },
+        {
+            "Names" : "Schedule",
+            "Description" : "UTC based cron schedule to apply updates",
+            "Types" : STRING_TYPE,
+            "Default" : "59 13 * * *"
+        },
+        {
+            "Names" : "SecurityOnly",
+            "Description" : "Only apply security updates",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : false
+        }
+    ]
+/]

--- a/providers/shared/components/bastion/id.ftl
+++ b/providers/shared/components/bastion/id.ftl
@@ -114,7 +114,7 @@
                         "Values" : [ "Reference" ]
                     },
                     {
-                        "Names" : "Reference",
+                        "Names" : "Source:Reference",
                         "Children" : [
                             {
                                 "Names" : "OS",

--- a/providers/shared/components/bastion/id.ftl
+++ b/providers/shared/components/bastion/id.ftl
@@ -103,6 +103,32 @@
             {
                 "Names" : "OSPatching",
                 "Children" : osPatchingChildConfiguration
+            },
+            {
+                "Names" : "Image",
+                "Description" : "Configures the source of the virtual machine image used for the instance",
+                "Children" : [
+                    {
+                        "Names" : "Source",
+                        "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
+                        "Values" : [ "Reference" ]
+                    },
+                    {
+                        "Names" : "Reference",
+                        "Children" : [
+                            {
+                                "Names" : "OS",
+                                "Description" : "The OS Image family defined in the Region AMI",
+                                "Default" : "Centos"
+                            },
+                            {
+                                "Names" : "Type",
+                                "Description" : "The image Type defined under the family in the Region AMI",
+                                "Default" : "EC2"
+                            }
+                        ]
+                    }
+                ]
             }
         ]
 /]

--- a/providers/shared/components/bastion/id.ftl
+++ b/providers/shared/components/bastion/id.ftl
@@ -22,12 +22,6 @@
                 "Default" : false
             },
             {
-                "Names" : "OS",
-                "Types" : STRING_TYPE,
-                "Values" : ["linux"],
-                "Default" : "linux"
-            },
-            {
                 "Names" : [ "Extensions", "Fragment", "Container" ],
                 "Description" : "Extensions to invoke as part of component processing",
                 "Types" : ARRAY_OF_STRING_TYPE,
@@ -101,30 +95,59 @@
                 "Default" : ""
             },
             {
-                "Names" : "OSPatching",
-                "Children" : osPatchingChildConfiguration
-            },
-            {
-                "Names" : "Image",
-                "Description" : "Configures the source of the virtual machine image used for the instance",
+                "Names" : "ComputeInstance",
+                "Description" : "Configuration of compute instances used in the component",
                 "Children" : [
                     {
-                        "Names" : "Source",
-                        "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
-                        "Values" : [ "Reference" ]
-                    },
-                    {
-                        "Names" : "Source:Reference",
+                        "Names" : "Image",
+                        "Description" : "Configures the source of the virtual machine image used for the instance",
                         "Children" : [
                             {
-                                "Names" : "OS",
-                                "Description" : "The OS Image family defined in the Region AMI",
-                                "Default" : "Centos"
+                                "Names" : "Source",
+                                "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
+                                "Values" : [ "Reference" ]
                             },
                             {
-                                "Names" : "Type",
-                                "Description" : "The image Type defined under the family in the Region AMI",
-                                "Default" : "EC2"
+                                "Names" : "Source:Reference",
+                                "Children" : [
+                                    {
+                                        "Names" : "OS",
+                                        "Description" : "The OS Image family defined in the Region AMI",
+                                        "Default" : "Centos"
+                                    },
+                                    {
+                                        "Names" : "Type",
+                                        "Description" : "The image Type defined under the family in the Region AMI",
+                                        "Default" : "EC2"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "OperatingSystem",
+                        "Description" : "The operating system details of the compute instance",
+                        "AttributeSet" : OPERATINGSYSTEM_ATTRIBUTESET_TYPE
+                    },
+                    {
+                        "Names" : "OSPatching",
+                        "Description" : "Configuration for scheduled OS Patching",
+                        "AttributeSet" : OSPATCHING_ATTRIBUTESET_TYPE
+                    }
+                    {
+                        "Names" : "Bootstrap",
+                        "Description" : "Customisation to setup the compute instance from its image",
+                        "Children" : [
+                            {
+                                "Names" : "Extensions",
+                                "Description" : "A list of extensions to source boostrap tasks from",
+                                "Types" : ARRAY_OF_STRING_TYPE
+                            },
+                            {
+                                "Names" : "UserComputeTasksRequired",
+                                "Description" : "A list of compute task types which must be accounted for in extensions on top of the component tasks",
+                                "Types" : ARRAY_OF_STRING_TYPE,
+                                "Default" : []
                             }
                         ]
                     }

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1291,6 +1291,32 @@
     {
         "Names" : "OSPatching",
         "Children" : osPatchingChildConfiguration
+    },
+    {
+        "Names" : "HostImage",
+        "Description" : "Configures the source of the virtual machine image used for the host instance",
+        "Children" : [
+            {
+                "Names" : "Source",
+                "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
+                "Values" : [ "Reference" ]
+            },
+            {
+                "Names" : "Reference",
+                "Children" : [
+                    {
+                        "Names" : "OS",
+                        "Description" : "The OS Image family defined in the Region AMI",
+                        "Default" : "Centos"
+                    },
+                    {
+                        "Names" : "Type",
+                        "Description" : "The image Type defined under the family in the Region AMI",
+                        "Default" : "ECS"
+                    }
+                ]
+            }
+        ]
     }
 ]]
 

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1289,30 +1289,59 @@
         "Default" : ""
     },
     {
-        "Names" : "OSPatching",
-        "Children" : osPatchingChildConfiguration
-    },
-    {
-        "Names" : "HostImage",
-        "Description" : "Configures the source of the virtual machine image used for the host instance",
+        "Names" : "ComputeInstance",
+        "Description" : "Configuration of compute instances used in the component",
         "Children" : [
             {
-                "Names" : "Source",
-                "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
-                "Values" : [ "Reference" ]
-            },
-            {
-                "Names" : "Source:Reference",
+                "Names" : "Image",
+                "Description" : "Configures the source of the virtual machine image used for the instance",
                 "Children" : [
                     {
-                        "Names" : "OS",
-                        "Description" : "The OS Image family defined in the Region AMI",
-                        "Default" : "Centos"
+                        "Names" : "Source",
+                        "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
+                        "Values" : [ "Reference" ]
                     },
                     {
-                        "Names" : "Type",
-                        "Description" : "The image Type defined under the family in the Region AMI",
-                        "Default" : "ECS"
+                        "Names" : "Source:Reference",
+                        "Children" : [
+                            {
+                                "Names" : "OS",
+                                "Description" : "The OS Image family defined in the Region AMI",
+                                "Default" : "Centos"
+                            },
+                            {
+                                "Names" : "Type",
+                                "Description" : "The image Type defined under the family in the Region AMI",
+                                "Default" : "ECS"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "Names" : "OperatingSystem",
+                "Description" : "The operating system details of the compute instance",
+                "AttributeSet" : OPERATINGSYSTEM_ATTRIBUTESET_TYPE
+            },
+            {
+                "Names" : "OSPatching",
+                "Description" : "Configuration for scheduled OS Patching",
+                "AttributeSet" : OSPATCHING_ATTRIBUTESET_TYPE
+            }
+            {
+                "Names" : "Bootstrap",
+                "Description" : "Customisation to setup the compute instance from its image",
+                "Children" : [
+                    {
+                        "Names" : "Extensions",
+                        "Description" : "A list of extensions to source boostrap tasks from",
+                        "Types" : ARRAY_OF_STRING_TYPE
+                    },
+                    {
+                        "Names" : "UserComputeTasksRequired",
+                        "Description" : "A list of compute task types which must be accounted for in extensions on top of the component tasks",
+                        "Types" : ARRAY_OF_STRING_TYPE,
+                        "Default" : []
                     }
                 ]
             }

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1302,7 +1302,7 @@
                 "Values" : [ "Reference" ]
             },
             {
-                "Names" : "Reference",
+                "Names" : "Source:Reference",
                 "Children" : [
                     {
                         "Names" : "OS",

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -89,30 +89,59 @@
                 "Default" : ""
             },
             {
-                "Names" : "OSPatching",
-                "Children" : osPatchingChildConfiguration
-            },
-            {
-                "Names" : "Image",
-                "Description" : "Configures the source of the virtual machine image used for the instance",
+                "Names" : "ComputeInstance",
+                "Description" : "Configuration of compute instances used in the component",
                 "Children" : [
                     {
-                        "Names" : "Source",
-                        "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
-                        "Values" : [ "Reference" ]
-                    },
-                    {
-                        "Names" : "Source:Reference",
+                        "Names" : "Image",
+                        "Description" : "Configures the source of the virtual machine image used for the instance",
                         "Children" : [
                             {
-                                "Names" : "OS",
-                                "Description" : "The OS Image family defined in the Region AMI",
-                                "Default" : "Centos"
+                                "Names" : "Source",
+                                "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
+                                "Values" : [ "Reference" ]
                             },
                             {
-                                "Names" : "Type",
-                                "Description" : "The image Type defined under the family in the Region AMI",
-                                "Default" : "EC2"
+                                "Names" : "Source:Reference",
+                                "Children" : [
+                                    {
+                                        "Names" : "OS",
+                                        "Description" : "The OS Image family defined in the Region AMI",
+                                        "Default" : "Centos"
+                                    },
+                                    {
+                                        "Names" : "Type",
+                                        "Description" : "The image Type defined under the family in the Region AMI",
+                                        "Default" : "EC2"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "OperatingSystem",
+                        "Description" : "The operating system details of the compute instance",
+                        "AttributeSet" : OPERATINGSYSTEM_ATTRIBUTESET_TYPE
+                    },
+                    {
+                        "Names" : "OSPatching",
+                        "Description" : "Configuration for scheduled OS Patching",
+                        "AttributeSet" : OSPATCHING_ATTRIBUTESET_TYPE
+                    }
+                    {
+                        "Names" : "Bootstrap",
+                        "Description" : "Customisation to setup the compute instance from its image",
+                        "Children" : [
+                            {
+                                "Names" : "Extensions",
+                                "Description" : "A list of extensions to source boostrap tasks from",
+                                "Types" : ARRAY_OF_STRING_TYPE
+                            },
+                            {
+                                "Names" : "UserComputeTasksRequired",
+                                "Description" : "A list of compute task types which must be accounted for in extensions on top of the component tasks",
+                                "Types" : ARRAY_OF_STRING_TYPE,
+                                "Default" : []
                             }
                         ]
                     }

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -91,6 +91,32 @@
             {
                 "Names" : "OSPatching",
                 "Children" : osPatchingChildConfiguration
+            },
+            {
+                "Names" : "Image",
+                "Description" : "Configures the source of the virtual machine image used for the instance",
+                "Children" : [
+                    {
+                        "Names" : "Source",
+                        "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
+                        "Values" : [ "Reference" ]
+                    },
+                    {
+                        "Names" : "Reference",
+                        "Children" : [
+                            {
+                                "Names" : "OS",
+                                "Description" : "The OS Image family defined in the Region AMI",
+                                "Default" : "Centos"
+                            },
+                            {
+                                "Names" : "Type",
+                                "Description" : "The image Type defined under the family in the Region AMI",
+                                "Default" : "EC2"
+                            }
+                        ]
+                    }
+                ]
             }
         ]
 /]

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -102,7 +102,7 @@
                         "Values" : [ "Reference" ]
                     },
                     {
-                        "Names" : "Reference",
+                        "Names" : "Source:Reference",
                         "Children" : [
                             {
                                 "Names" : "OS",

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -93,7 +93,7 @@
                         "Values" : [ "Reference" ]
                     },
                     {
-                        "Names" : "Reference",
+                        "Names" : "Source:Reference",
                         "Children" : [
                             {
                                 "Names" : "OS",

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -80,30 +80,59 @@
                 "Default" : ""
             },
             {
-                "Names" : "OSPatching",
-                "Children" : osPatchingChildConfiguration
-            },
-            {
-                "Names" : "Image",
-                "Description" : "Configures the source of the virtual machine image used for the instance",
+                "Names" : "ComputeInstance",
+                "Description" : "Configuration of compute instances used in the component",
                 "Children" : [
                     {
-                        "Names" : "Source",
-                        "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
-                        "Values" : [ "Reference" ]
-                    },
-                    {
-                        "Names" : "Source:Reference",
+                        "Names" : "Image",
+                        "Description" : "Configures the source of the virtual machine image used for the instance",
                         "Children" : [
                             {
-                                "Names" : "OS",
-                                "Description" : "The OS Image family defined in the Region AMI",
-                                "Default" : "Centos"
+                                "Names" : "Source",
+                                "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
+                                "Values" : [ "Reference" ]
                             },
                             {
-                                "Names" : "Type",
-                                "Description" : "The image Type defined under the family in the Region AMI",
-                                "Default" : "EC2"
+                                "Names" : "Source:Reference",
+                                "Children" : [
+                                    {
+                                        "Names" : "OS",
+                                        "Description" : "The OS Image family defined in the Region AMI",
+                                        "Default" : "Centos"
+                                    },
+                                    {
+                                        "Names" : "Type",
+                                        "Description" : "The image Type defined under the family in the Region AMI",
+                                        "Default" : "EC2"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "OperatingSystem",
+                        "Description" : "The operating system details of the compute instance",
+                        "AttributeSet" : OPERATINGSYSTEM_ATTRIBUTESET_TYPE
+                    },
+                    {
+                        "Names" : "OSPatching",
+                        "Description" : "Configuration for scheduled OS Patching",
+                        "AttributeSet" : OSPATCHING_ATTRIBUTESET_TYPE
+                    }
+                    {
+                        "Names" : "Bootstrap",
+                        "Description" : "Customisation to setup the compute instance from its image",
+                        "Children" : [
+                            {
+                                "Names" : "Extensions",
+                                "Description" : "A list of extensions to source boostrap tasks from",
+                                "Types" : ARRAY_OF_STRING_TYPE
+                            },
+                            {
+                                "Names" : "UserComputeTasksRequired",
+                                "Description" : "A list of compute task types which must be accounted for in extensions on top of the component tasks",
+                                "Types" : ARRAY_OF_STRING_TYPE,
+                                "Default" : []
                             }
                         ]
                     }

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -82,6 +82,32 @@
             {
                 "Names" : "OSPatching",
                 "Children" : osPatchingChildConfiguration
+            },
+            {
+                "Names" : "Image",
+                "Description" : "Configures the source of the virtual machine image used for the instance",
+                "Children" : [
+                    {
+                        "Names" : "Source",
+                        "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
+                        "Values" : [ "Reference" ]
+                    },
+                    {
+                        "Names" : "Reference",
+                        "Children" : [
+                            {
+                                "Names" : "OS",
+                                "Description" : "The OS Image family defined in the Region AMI",
+                                "Default" : "Centos"
+                            },
+                            {
+                                "Names" : "Type",
+                                "Description" : "The image Type defined under the family in the Region AMI",
+                                "Default" : "EC2"
+                            }
+                        ]
+                    }
+                ]
             }
         ]
 /]

--- a/providers/shared/layers/Environment/id.ftl
+++ b/providers/shared/layers/Environment/id.ftl
@@ -167,7 +167,7 @@
         },
         {
             "Names" : "OSPatching",
-            "Children" : osPatchingChildConfiguration
+            "AttributeSet" : OSPATCHING_ATTRIBUTESET_TYPE
         }
     ]
 /]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description
Adds the attributes required to configure the Image used for a virtual machine instance. This can be extended by providers to suit the available configuration options they offer

## Motivation and Context

Part of #1488  Which allows for users to define their own virtual machine images on components as they need to 

## How Has This Been Tested?

Tested locally

## Followup Actions

- [x] None
