### PR TITLE
feat: compute tasks and extensions

### DIFF
--- a/engine/bootstrap.ftl
+++ b/engine/bootstrap.ftl
@@ -41,6 +41,9 @@
 [#-- Component handling --]
 [#include "component.ftl" ]
 
+[#-- Compute tasks --]
+[#include "computetask.ftl" ]
+
 [#-- Service Handling --]
 [#include "services.ftl" ]
 
@@ -103,4 +106,3 @@
 
 [#-- Level utility support --]
 [#include "commonApplication.ftl"]
-

--- a/engine/computetask.ftl
+++ b/engine/computetask.ftl
@@ -1,0 +1,93 @@
+[#ftl]
+
+[#--
+    Compute tasks define a common definition of a an action that a compute instance needs to complete
+    The idea with compute tasks is to define a standard set of tasks that component developers
+    can require for their components
+    User defined extensions can then implement the tasks required to ensure that the component
+    will work as expected
+--]
+
+[#assign computeTaskConfiguration = {}]
+
+[#-- Macros to assemble the component configuration --]
+[#macro addComputeTask type properties  ]
+    [@internalMergeComputeTaskConfiguration
+        type=type
+        configuration=
+            {
+                "Properties" : asArray(properties)
+            }
+    /]
+[/#macro]
+
+[#function getComputeTaskTypes ]
+    [#return computeTaskConfiguration?keys]
+[/#function]
+
+[#function getComputeTasks ]
+    [#return computeTaskConfiguration]
+[/#function]
+
+[#function getOccurrenceComputeTaskConfig occurrence computeResourceId context compteTaskExtensions componentComputeTasks userComputeTasks ]
+
+    [#local context = mergeObjects(
+                        context,
+                        {
+                            "ComputeResourceId" : computeResourceId
+                        }
+                    )]
+
+    [#local context = invokeExtensions(occurrence, context, {}, compteTaskExtensions, true)]
+
+    [@validateRequiredComputeTasks
+        computeTasks=(context.ComputeTasks)![]
+        componentComputeTasks=componentComputeTasks
+        userComputeTasks=userComputeTasks
+    /]
+
+    [#return (context.ComputeTaskConfig)!{}]
+[/#function]
+
+[#macro validateRequiredComputeTasks computeTasks componentComputeTasks userComputeTasks ]
+    [#local missingComponentTasks = []]
+    [#local missingUserTasks = []]
+
+    [#list componentComputeTasks as componentComputeTask ]
+        [#if ! (computeTasks?seq_contains(componentComputeTask))]
+            [#local missingComponentTasks += [ componentComputeTask ]]
+        [/#if]
+    [/#list]
+
+    [#list userComputeTasks as userComputeTask ]
+        [#if ! (computeTasks?seq_contains(userComputeTasks))]
+            [#local missingUserTasks += [ userComputeTask ]]
+        [/#if]
+    [/#list]
+
+    [#if missingComponentTasks?has_content || missingUserTasks?has_content ]
+        [@fatal
+            message="Required component compute task was not included"
+            detail="Add a computeInitConfigSection to an extension which will perform the required task"
+            context={
+                "CurrentComputeTasks" : computeTasks,
+                "MissingComponentTasks" : missingComponentTasks,
+                "MissingUserTasks" : missingUserTasks
+            }
+        /]
+    [/#if]
+[/#macro]
+[#-------------------------------------------------------
+-- Internal support functions for task processing      --
+---------------------------------------------------------]
+
+[#-- Helper macro - not for general use --]
+[#macro internalMergeComputeTaskConfiguration type configuration]
+    [#assign computeTaskConfiguration =
+        mergeObjects(
+            computeTaskConfiguration,
+            {
+                type : configuration
+            }
+        )]
+[/#macro]

--- a/engine/computetask.ftl
+++ b/engine/computetask.ftl
@@ -8,6 +8,10 @@
     will work as expected
 --]
 
+[#-- Extension Scopes --]
+[#-- Compute tasks work through the extensions mechanism --]
+[#assign COMPUTETASK_EXTENSION_SCOPE = "computetask"]
+
 [#assign computeTaskConfiguration = {}]
 
 [#-- Macros to assemble the component configuration --]
@@ -38,7 +42,7 @@
                         }
                     )]
 
-    [#local context = invokeExtensions(occurrence, context, {}, compteTaskExtensions, true)]
+    [#local context = invokeExtensions(occurrence, context, {}, compteTaskExtensions, true, "deployment", "computetask")]
 
     [@validateRequiredComputeTasks
         computeTasks=(context.ComputeTasks)![]

--- a/engine/extension.ftl
+++ b/engine/extension.ftl
@@ -5,6 +5,9 @@
 [#-- Generally used for advanced configuration scenarios including programmatic settings and adding specialised resource --]
 [#-- Extensions are defined as part plugin but can also be added to users CMDBs as an embedded extension --]
 
+[#-- Extension Scopes --]
+[#assign SETUP_EXTENSION_SCOPE = "setup" ]
+
 [#-- the _context variable is used during context processing to store the changes resulting from the extension --]
 [#assign _context = {}]
 
@@ -61,7 +64,7 @@
 
 
 [#-- Define properties of an extension --]
-[#macro addExtension id description supportedTypes aliases=[] entrances=["deployment"] scopes=["setup"] provider="shared" ]
+[#macro addExtension id description supportedTypes aliases=[] entrances=["deployment"] scopes=[ SETUP_EXTENSION_SCOPE ] provider=SHARED_PROVIDER ]
 
     [#local extensionConfiguration = [
         "InhibitEnabled",
@@ -227,6 +230,21 @@
                         "SupportedTypes" : extensionDetails.SupportedTypes,
                         "ComponentType" : occurrence.Core.Type,
                         "Component" : occurrence.Core.FullName
+                    }
+                /]
+                [#continue]
+            [/#if]
+
+            [#if extensionDetails?has_content && ! ( extensionDetails.Scopes?seq_contains(scope) )]
+                [@fatal
+                    message="The extension does not support the extension scope required"
+                    detail="Extensions are invoked at different stages of processing and are invoked with different scope filters on the provided extensions"
+                    context={
+                        "OccurrenceContext" : occurrenceContext,
+                        "ExtensionId" : id,
+                        "Provider" : provider,
+                        "SupportedScopes" : extensionDetails.Scopes,
+                        "CurrentScope" : scope
                     }
                 /]
                 [#continue]

--- a/engine/extension.ftl
+++ b/engine/extension.ftl
@@ -35,9 +35,12 @@
     [/#if]
 [/#function]
 
-[#function formatExtensionIds occurrence ids=[] ]
+[#function formatExtensionIds occurrence ids=[] idsOnly=false ]
     [#local idBases = combineEntities(
-                            getOccurrenceExtensionBase(occurrence),
+                            idsOnly?then(
+                                [],
+                                getOccurrenceExtensionBase(occurrence)
+                            ),
                             ids,
                             UNIQUE_COMBINE_BEHAVIOUR) ]
 
@@ -131,7 +134,7 @@
     [/#list]
 [/#macro]
 
-[#function invokeExtensions occurrence context baseOccurrence={} additionalIds=[] entrance="deployment" scope="setup" provider="shared"  ]
+[#function invokeExtensions occurrence context baseOccurrence={} additionalIds=[] additonalOnly=false entrance="deployment" scope="setup" provider="shared"  ]
 
     [#-- Replace the global context with the components context --]
     [#assign _context = context ]
@@ -148,7 +151,7 @@
                                 baseOccurrence,
                                 occurrence) ]
 
-    [#list formatExtensionIds(baseOccurrence, additionalIds) as id]
+    [#list formatExtensionIds(baseOccurrence, additionalIds, additonalOnly) as id]
 
         [#local extensionContext = {
             "Id" : id,

--- a/engine/provider.ftl
+++ b/engine/provider.ftl
@@ -334,6 +334,22 @@
                 /]
             [/#list]
 
+            [#-- Determine the computetasks for the provider --]
+            [#local directories =
+                internalGetPluginFiles(
+                    [providerMarker.Path, "computetasks"],
+                    [
+                        ["[^/]+"]
+                    ]
+                )
+            ]
+            [#list directories as directory]
+                [@internalIncludeTemplatesInDirectory
+                    directory,
+                    ["id", "computetask"]
+                /]
+            [/#list]
+
             [#-- Determine the extensions for the provider --]
             [#local directories =
                 internalGetPluginFiles(
@@ -979,6 +995,12 @@
     [@internalIncludeTemplatesInDirectory
         [providerMarker.Path, "entrances"],
         [ "entrance" ]
+    /]
+
+    [#-- aws/computetasks/computetask.ftl --]
+    [@internalIncludeTemplatesInDirectory
+        [providerMarker.Path, "computetasks"],
+        [ "computetask" ]
     /]
 
     [#-- aws/extensions/extension.ftl --]

--- a/providers/shared/components/bastion/id.ftl
+++ b/providers/shared/components/bastion/id.ftl
@@ -105,7 +105,8 @@
                             {
                                 "Names" : "Source",
                                 "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
-                                "Values" : [ "Reference" ]
+                                "Values" : [ "Reference" ],
+                                "Default" : "Reference"
                             },
                             {
                                 "Names" : "Source:Reference",
@@ -133,18 +134,19 @@
                         "Names" : "OSPatching",
                         "Description" : "Configuration for scheduled OS Patching",
                         "AttributeSet" : OSPATCHING_ATTRIBUTESET_TYPE
-                    }
+                    },
                     {
-                        "Names" : "Bootstrap",
+                        "Names" : "ComputeTasks",
                         "Description" : "Customisation to setup the compute instance from its image",
                         "Children" : [
                             {
                                 "Names" : "Extensions",
                                 "Description" : "A list of extensions to source boostrap tasks from",
-                                "Types" : ARRAY_OF_STRING_TYPE
+                                "Types" : ARRAY_OF_STRING_TYPE,
+                                "Default" : []
                             },
                             {
-                                "Names" : "UserComputeTasksRequired",
+                                "Names" : "UserTasksRequired",
                                 "Description" : "A list of compute task types which must be accounted for in extensions on top of the component tasks",
                                 "Types" : ARRAY_OF_STRING_TYPE,
                                 "Default" : []

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1299,7 +1299,8 @@
                     {
                         "Names" : "Source",
                         "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
-                        "Values" : [ "Reference" ]
+                        "Values" : [ "Reference" ],
+                        "Default" : "Reference"
                     },
                     {
                         "Names" : "Source:Reference",
@@ -1327,18 +1328,19 @@
                 "Names" : "OSPatching",
                 "Description" : "Configuration for scheduled OS Patching",
                 "AttributeSet" : OSPATCHING_ATTRIBUTESET_TYPE
-            }
+            },
             {
-                "Names" : "Bootstrap",
+                "Names" : "ComputeTasks",
                 "Description" : "Customisation to setup the compute instance from its image",
                 "Children" : [
                     {
                         "Names" : "Extensions",
                         "Description" : "A list of extensions to source boostrap tasks from",
-                        "Types" : ARRAY_OF_STRING_TYPE
+                        "Types" : ARRAY_OF_STRING_TYPE,
+                        "Default" : []
                     },
                     {
-                        "Names" : "UserComputeTasksRequired",
+                        "Names" : "UserTasksRequired",
                         "Description" : "A list of compute task types which must be accounted for in extensions on top of the component tasks",
                         "Types" : ARRAY_OF_STRING_TYPE,
                         "Default" : []

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -99,7 +99,8 @@
                             {
                                 "Names" : "Source",
                                 "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
-                                "Values" : [ "Reference" ]
+                                "Values" : [ "Reference" ],
+                                "Default" : "Reference"
                             },
                             {
                                 "Names" : "Source:Reference",
@@ -127,18 +128,19 @@
                         "Names" : "OSPatching",
                         "Description" : "Configuration for scheduled OS Patching",
                         "AttributeSet" : OSPATCHING_ATTRIBUTESET_TYPE
-                    }
+                    },
                     {
-                        "Names" : "Bootstrap",
+                        "Names" : "ComputeTasks",
                         "Description" : "Customisation to setup the compute instance from its image",
                         "Children" : [
                             {
                                 "Names" : "Extensions",
                                 "Description" : "A list of extensions to source boostrap tasks from",
-                                "Types" : ARRAY_OF_STRING_TYPE
+                                "Types" : ARRAY_OF_STRING_TYPE,
+                                "Default" : []
                             },
                             {
-                                "Names" : "UserComputeTasksRequired",
+                                "Names" : "UserTasksRequired",
                                 "Description" : "A list of compute task types which must be accounted for in extensions on top of the component tasks",
                                 "Types" : ARRAY_OF_STRING_TYPE,
                                 "Default" : []

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -90,7 +90,8 @@
                             {
                                 "Names" : "Source",
                                 "Description" : "Where to source the image id from - Reference: uses the Regions AMIs reference property to find the image",
-                                "Values" : [ "Reference" ]
+                                "Values" : [ "Reference" ],
+                                "Default" : "Reference"
                             },
                             {
                                 "Names" : "Source:Reference",
@@ -118,18 +119,19 @@
                         "Names" : "OSPatching",
                         "Description" : "Configuration for scheduled OS Patching",
                         "AttributeSet" : OSPATCHING_ATTRIBUTESET_TYPE
-                    }
+                    },
                     {
-                        "Names" : "Bootstrap",
+                        "Names" : "ComputeTasks",
                         "Description" : "Customisation to setup the compute instance from its image",
                         "Children" : [
                             {
                                 "Names" : "Extensions",
                                 "Description" : "A list of extensions to source boostrap tasks from",
-                                "Types" : ARRAY_OF_STRING_TYPE
+                                "Types" : ARRAY_OF_STRING_TYPE,
+                                "Default" : []
                             },
                             {
-                                "Names" : "UserComputeTasksRequired",
+                                "Names" : "UserTasksRequired",
                                 "Description" : "A list of compute task types which must be accounted for in extensions on top of the component tasks",
                                 "Types" : ARRAY_OF_STRING_TYPE,
                                 "Default" : []

--- a/providers/shared/computetasks/computetask.ftl
+++ b/providers/shared/computetasks/computetask.ftl
@@ -1,0 +1,122 @@
+[#ftl]
+
+[#assign COMPUTE_TASK_GENERAL_TASK = "general_task" ]
+[@addComputeTask
+    type=COMPUTE_TASK_GENERAL_TASK
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "A general task for user level configuration"
+        }
+    ]
+/]
+
+[#assign COMPUTE_TASK_RUN_STARTUP_CONFIG = "run_startup_config" ]
+[@addComputeTask
+    type=COMPUTE_TASK_RUN_STARTUP_CONFIG
+    properties=[
+        {
+            "Type" : "Description",
+            "Value" : "Run the process which will setup and execute the startup configuration process"
+        }
+    ]
+/]
+
+[#assign COMPUTE_TASK_HAMLET_ENVIRONMENT_VARIABLES = "hamlet_env_var" ]
+[@addComputeTask
+    type=COMPUTE_TASK_HAMLET_ENVIRONMENT_VARIABLES
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Add hamlet settings as environment varaibles available as part of the default user shell"
+        }
+    ]
+/]
+
+[#assign COMPUTE_TASK_OS_SECURITY_PATCHING = "os_security_patching" ]
+[@addComputeTask
+    type=COMPUTE_TASK_OS_SECURITY_PATCHING
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Enable a scheduled process to apply OS level security patching"
+        }
+    ]
+/]
+
+[#assign COMPUTE_TASK_SYSTEM_LOG_FORWARDING = "system_log_forwarding" ]
+[@addComputeTask
+    type=COMPUTE_TASK_SYSTEM_LOG_FORWARDING
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Enable forwarding of system log events to a standard log store"
+        }
+    ]
+/]
+
+[#assign COMPUTE_TASK_FILE_DIR_CREATION = "file_dir_create" ]
+[@addComputeTask
+    type=COMPUTE_TASK_FILE_DIR_CREATION
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Create files and directories as part of system startup"
+        }
+    ]
+/]
+
+[#assign COMPUTE_TASK_DATA_VOLUME_MOUNTING = "data_volume_mounting" ]
+[@addComputeTask
+    type=COMPUTE_TASK_DATA_VOLUME_MOUNTING
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Handle the discovery, formatting and mounting of data volumes"
+        }
+    ]
+/]
+
+[#assign COMPUTE_TASK_USER_ACCESS = "user_access" ]
+[@addComputeTask
+    type=COMPUTE_TASK_USER_ACCESS
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Update the default account to include access for links to user components"
+        }
+    ]
+/]
+
+[#assign COMPUTE_TASK_RUN_SCRIPTS_DEPLOYMENT = "run_scripts_deployment" ]
+[@addComputeTask
+    type=COMPUTE_TASK_RUN_SCRIPTS_DEPLOYMENT
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Retrive and execute a scripts.zip image stored in the scripts registry"
+        }
+    ]
+/]
+
+[#assign COMPUTE_TASK_EFS_MOUNT = "efs_mount" ]
+[@addComputeTask
+    type=COMPUTE_TASK_EFS_MOUNT
+    properties=[
+        {
+            "Type" : "Description",
+            "Value" : "Find and configure mounts for links to efs components"
+        }
+    ]
+/]
+
+[#assign COMPUTE_TASK_USER_BOOTSTRAP = "user_bootstrap" ]
+[@addComputeTask
+    type=COMPUTE_TASK_USER_BOOTSTRAP
+    properties=[
+        {
+            "Type" : "Description",
+            "Value" : "Run tasks provided through Bootstraps defined in the solution"
+        }
+    ]
+/]

--- a/providers/shared/extensions/extension.ftl
+++ b/providers/shared/extensions/extension.ftl
@@ -156,7 +156,6 @@
 
 
 [#-- ECS Specific Macros --]
-
 [#macro Host name value]
     [#assign _context +=
         {
@@ -374,6 +373,36 @@
                     }
                 }
         }]
+[/#macro]
+
+[#macro computeTaskConfigSection computeTaskTypes id engine priority content ]
+
+    [#assign _context +=
+        {
+            "ComputeTasks" : combineEntities(
+                                    (_context.ComputeTasks)![],
+                                    asFlattenedArray(computeTaskTypes),
+                                    UNIQUE_COMBINE_BEHAVIOUR
+                                )
+        }
+    ]
+
+    [#assign _context +=
+        {
+            "ComputeTaskConfig" :
+                (_context.ComputeTaskConfig!{}) +
+                {
+                    id : {
+                        engine : {
+                            "ComputeResourceId" : _context.ComputeResourceId,
+                            "Priorty" : priority,
+                            "Content" : content
+                        }
+
+                    }
+                }
+        }
+    ]
 [/#macro]
 
 


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description

Adds support for compute tasks and their usage through extensions. 

A compute task is defined by component developers and provide a description of the tasks which need to be completed in order for a virtual machine to work as part of a component. The component developer defines tasks and then includes a required list of tasks as part of the state of the occurrence.  

Users can then specify a list of compute task extensions which implement these tasks using the cloud configuration tools provided in the support of the provider and the virtual machine instance. If all of the tasks aren't implemented in the extensions the generation will fail and provide the user with the missing tasks 

Users can also include their own extensions which will be included as part of the virtual machine configuration. 

## Motivation and Context

The primary motivation for this is to allow for customisation of instances used as part of components including changing Operating System or Instance Image. This aligns with #1627 which allows users to source an image as required, when this happens there is a need to be able to change any aspect of the boostrap configuration process to ailgn with what the OS supports. 

This is part of the implementation of #1488 

## How Has This Been Tested?

Tested locally 

## Followup Actions

- [x] None
