### PR TITLE
feat: Attribute set extensions

### DIFF
--- a/engine/attributeset.ftl
+++ b/engine/attributeset.ftl
@@ -18,6 +18,34 @@
     /]
 [/#macro]
 
+[#macro addExtendedAttributeSet baseType provider type pluralType properties attributes ]
+    [#local baseAttributeSetConfig = getAttributeSet(baseType)]
+    [#if ! (baseAttributeSetConfig?has_content)  ]
+        [@fatal
+            message="Could not find base attribute set to extend"
+            detail="Ensure the attribute set is available or you are using a provider that is available"
+            context={
+                "BaseType" : baseType,
+                "Type" : type,
+                "Provider" : provider
+            }
+        /]
+    [/#if]
+
+    [#local extendedAttributes = extendAttributes(baseAttributeSetConfig.Attributes, attributes, provider)]
+
+    [@addAttributeSet
+        type=type
+        pluralType=pluralType
+        properties=properties
+        attributes=extendedAttributes
+    /]
+[/#macro]
+
+[#function getAttributeSet type ]
+    [#return (attributeSetConfiguration[type])!{} ]
+[/#function]
+
 [#-----------------------------------------------------
 -- Internal support functions for AttributeSet processing --
 -------------------------------------------------------]

--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -704,7 +704,8 @@ are added.
         [/#if]
     [/#list]
 
-    [#local normalisedAttributes = normaliseCompositeConfiguration(attributes)]
+    [#local expandedAttributes = expandCompositeConfiguration(attributes)]
+    [#local normalisedAttributes = normaliseCompositeConfiguration(expandedAttributes)]
 
     [#-- Determine the values for explicitly listed attributes --]
     [#local result = {} ]
@@ -976,6 +977,38 @@ are added.
     [#return result ]
 [/#function]
 
+[#function expandCompositeConfiguration attributes ]
+
+    [#-- If attribute value is defined as an AttributeSet, evaluate --]
+    [#-- it and use the result as the attribute's Children.         --]
+    [#local evaluatedRefAttributes = []]
+    [#list attributes![] as attribute]
+        [#if attribute?is_hash ]
+            [#if attribute.AttributeSet?has_content && !(attribute.Children?has_content)]
+                [#-- AttributeSet provides the child attributes --]
+                [#local children = (attributeSetConfiguration[attribute.AttributeSet].Attributes)![] ]
+
+                [#if !children?has_content ]
+                    [@fatal
+                        message="Unable to determine child attributes from AttributeSet"
+                        context=attribute
+                    /]
+                    [#-- Add a minimal child configuration to ensure processing completes --]
+                    [#local children = [{"Names" : "AttributeSet", "Types" : STRING_TYPE}] ]
+                [/#if]
+
+                [#local evaluatedRefAttributes += [ attribute + { "Children" : expandCompositeConfiguration(children) } ] ]
+            [#else]
+                [#-- Attribute has no reference to evaluate, so add to results --]
+                [#local evaluatedRefAttributes += [attribute]]
+            [/#if]
+        [#else]
+            [#local evaluatedRefAttributes += [attribute]]
+        [/#if]
+    [/#list]
+    [#return evaluatedRefAttributes ]
+[/#function]
+
 [#function normaliseCompositeConfiguration attributes ]
     [#-- Normalise attributes --]
     [#local normalisedAttributes = [] ]
@@ -1051,30 +1084,7 @@ are added.
         [/#if]
     [/#if]
 
-    [#-- If attribute value is defined as an AttributeSet, evaluate --]
-    [#-- it and use the result as the attribute's Children.         --]
-    [#local evaluatedRefAttributes = []]
-    [#list normalisedAttributes![] as attribute]
-        [#if attribute.AttributeSet?has_content ]
-            [#-- AttributeSet provides the child attributes --]
-            [#local children = (attributeSetConfiguration[attribute.AttributeSet].Attributes)![] ]
-
-            [#if !children?has_content ]
-                [@fatal
-                    message="Unable to determine child attributes from AttributeSet"
-                    context=attribute
-                /]
-                [#-- Add a minimal child configuration to ensure processing completes --]
-                [#local children = [{"Names" : "AttributeSet", "Types" : STRING_TYPE}] ]
-            [/#if]
-
-            [#local evaluatedRefAttributes += [ attribute + { "Children" : children } ] ]
-        [#else]
-            [#-- Attribute has no reference to evaluate, so add to results --]
-            [#local evaluatedRefAttributes += [attribute]]
-        [/#if]
-    [/#list]
-    [#return evaluatedRefAttributes ]
+    [#return normalisedAttributes ]
 [/#function]
 
 [#macro validateCompositeObject attributes=[] objects=[] ]

--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -982,30 +982,32 @@ are added.
     [#-- If attribute value is defined as an AttributeSet, evaluate --]
     [#-- it and use the result as the attribute's Children.         --]
     [#local evaluatedRefAttributes = []]
-    [#list attributes![] as attribute]
-        [#if attribute?is_hash ]
-            [#if attribute.AttributeSet?has_content && !(attribute.Children?has_content)]
-                [#-- AttributeSet provides the child attributes --]
-                [#local children = (attributeSetConfiguration[attribute.AttributeSet].Attributes)![] ]
+    [#if attributes?has_content]
+        [#list asFlattenedArray(attributes) as attribute]
+            [#if attribute?is_hash ]
+                [#if attribute.AttributeSet?has_content && !(attribute.Children?has_content)]
+                    [#-- AttributeSet provides the child attributes --]
+                    [#local children = (attributeSetConfiguration[attribute.AttributeSet].Attributes)![] ]
 
-                [#if !children?has_content ]
-                    [@fatal
-                        message="Unable to determine child attributes from AttributeSet"
-                        context=attribute
-                    /]
-                    [#-- Add a minimal child configuration to ensure processing completes --]
-                    [#local children = [{"Names" : "AttributeSet", "Types" : STRING_TYPE}] ]
+                    [#if !children?has_content ]
+                        [@fatal
+                            message="Unable to determine child attributes from AttributeSet"
+                            context=attribute
+                        /]
+                        [#-- Add a minimal child configuration to ensure processing completes --]
+                        [#local children = [{"Names" : "AttributeSet", "Types" : STRING_TYPE}] ]
+                    [/#if]
+
+                    [#local evaluatedRefAttributes += [ attribute + { "Children" : expandCompositeConfiguration(children) } ] ]
+                [#else]
+                    [#-- Attribute has no reference to evaluate, so add to results --]
+                    [#local evaluatedRefAttributes += [attribute]]
                 [/#if]
-
-                [#local evaluatedRefAttributes += [ attribute + { "Children" : expandCompositeConfiguration(children) } ] ]
             [#else]
-                [#-- Attribute has no reference to evaluate, so add to results --]
                 [#local evaluatedRefAttributes += [attribute]]
             [/#if]
-        [#else]
-            [#local evaluatedRefAttributes += [attribute]]
-        [/#if]
-    [/#list]
+        [/#list]
+    [/#if]
     [#return evaluatedRefAttributes ]
 [/#function]
 

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -337,18 +337,36 @@
                         /]
                     [/#if]
                 [#else]
-                    [#local extendedValues = attribute.Values]
-                    [#list attributeExtension.Values as extensionValue]
+
+                    [#local extendedAttributes = {}]
+                    [#local extendedValues = (attribute.Values)![]]
+                    [#list (attributeExtension.Values)![] as extensionValue]
                         [#local extendedValues +=
                             [extensionValue?ensure_starts_with(prefix + ":")] ]
+
+                        [#local extendedAttributes += {
+                            "Values" : getUniqueArrayElements(extendedValues)
+                        }]
+
                     [/#list]
+
+                    [#if ((attributeExtension.Default)!"")?has_content ]
+                        [#local extendedAttributes += {
+                            "Default" : attributeExtension.Default
+                        } ]
+                    [/#if]
+
+                    [#if ((attributeExtension.AttributeSet)![])?has_content ]
+                        [#local extendedAttributes += {
+                            "AttributeSet" : attributeExtension.AttributeSet,
+                            "Children" : []
+                        }]
+                    [/#if]
 
                     [#local result += [
                         mergeObjects(
                             attribute,
-                            {
-                                "Values" : getUniqueArrayElements(extendedValues)
-                            }
+                            extendedAttributes
                         )]]
                 [/#if]
             [#else]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds support for creating extended attribute sets, extended attribute sets allow for overriding attribute Values, Defaults and AttributeSets along with adding prefixed attributes if they aren't part of the attribute set used as the base. 

## Motivation and Context

Attribute sets are really useful to share configuration and show that the same configuration is being used. However there are times when you might want to override default values at the provider level or add additional attributes across a provider. This allows you to do that and only add the overrides you require. 

## How Has This Been Tested?

Tested locally 

## Followup Actions

- [x] None
