### PR TITLE
refactor: remove wait for signal on autoscaling

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -549,12 +549,6 @@
         "Description" : "Enable the collection of autoscale group detailed metrics"
     },
     {
-        "Names" : "WaitForSignal",
-        "Types" : BOOLEAN_TYPE,
-        "Default" : true,
-        "Description" : "Wait for a cfn-signal before treating the instances as alive"
-    },
-    {
         "Names" : "MinUpdateInstances",
         "Types" : NUMBER_TYPE,
         "Default" : 1,


### PR DESCRIPTION

## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

Removes the option to configure wait for signal on autoscaling clusters. This should be enforced as part of our best practices

## Motivation and Context

Removing this option and instead enforcing the use of status signals aligns with the idea of compute tasks and promotes best practice of handling failure in cluster startups 

## How Has This Been Tested?

Tested locally 

## Followup Actions

- [x] None
