### PR TITLE
fix: align alternative config with gen contract

### DIFF
--- a/engine/output_writer.ftl
+++ b/engine/output_writer.ftl
@@ -141,7 +141,7 @@
                 [@debug
                     message="Unable to invoke output handler"
                     context=handlerFunctionOptions
-                    enabled=true
+                    enabled=false
                 /]
             [/#if]
         [/#list]

--- a/providers/shared/inputseeders/shared/id.ftl
+++ b/providers/shared/inputseeders/shared/id.ftl
@@ -146,7 +146,7 @@
                     "Unit" : {
                         "Name" : deploymentUnit!"",
                         "Subset" : deploymentUnitSubset!"",
-                        "Alternative" : alternative!""
+                        "Alternative" : passAlternative!""
                     },
                     "ResourceGroup" : {
                         "Name" : resourceGroup!""


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Fixes an issue in the executor and engine definitions of the passAlternative value
- Disable a noisey debug statement

## Motivation and Context

Alternative template generation was failing to generate different templates

## How Has This Been Tested?

Tested locally 

## Followup Actions

- [x] None
