### PR TITLE
fix: certificate behaviour configuration

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -631,6 +631,10 @@ behaviour.
             ]
         },
         {
+            "Names" : "Host",
+            "Types" : STRING_TYPE
+        },
+        {
             "Names" : "IncludeInHost",
             "Children" : [
                 {
@@ -659,6 +663,10 @@ behaviour.
                 },
                 {
                     "Names" : "Version",
+                    "Types" : BOOLEAN_TYPE
+                },
+                {
+                    "Names" : "Host",
                     "Types" : BOOLEAN_TYPE
                 }
             ]


### PR DESCRIPTION


## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Include a couple of parameters in the certificate behaviour configuration definition that are supported by the code to permit a specific host name value to be used rather than assembling it from the component configuration.

## Motivation and Context
Support existing product configurations.
 
## How Has This Been Tested?
Local template generation

## Followup Actions
- [x] None
