### PR TITLE
feat: add storage profile configuration

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -284,27 +284,24 @@ behaviour.
 [#function getProcessor occurrence type processorProfileName="" ]
 
     [#local tc = formatComponentShortName( occurrence.Core.Tier.Id, occurrence.Core.Component.Id)]
-
-    [#local processorProfile = (processorProfileName?has_content)?then(
+    [#local processorProfileName = (processorProfileName?has_content)?then(
                                     processorProfileName,
                                     occurrence.Configuration.Solution.Profiles.Processor
                                 )]
 
-    [#if (component[type].Processor)??]
-        [#return component[type].Processor]
-    [/#if]
-    [#if (processors[solutionObject.CapacityProfile][tc])??]
-        [#return processors[solutionObject.CapacityProfile][tc]]
-    [/#if]
-    [#if (processors[solutionObject.CapacityProfile][type])??]
-        [#return processors[solutionObject.CapacityProfile][type]]
-    [/#if]
-    [#if (processors[processorProfile][tc])??]
-        [#return processors[processorProfile][tc]]
-    [/#if]
-    [#if (processors[processorProfile][type])??]
-        [#return processors[processorProfile][type]]
-    [/#if]
+    [#local processorProfile = (processors[processorProfileName])!{}]
+
+    [#list processorProfile as key,value ]
+        [#switch key?lower_case ]
+            [#case tc?lower_case ]
+                [#return processorProfile[key]]
+                [#break]
+            [#case type?lower_case]
+                [#return processorProfile[key]]
+                [#break]
+        [/#switch]
+    [/#list]
+
     [#return {}]
 [/#function]
 
@@ -570,27 +567,28 @@ behaviour.
 [/#function]
 
 [#-- Get storage settings --]
-[#function getStorage occurrence type extensions...]
-    [#local tc = formatComponentShortName(
-                    occurrence.Core.Tier,
-                    occurrence.Core.Component,
-                    extensions)]
-    [#local defaultProfile = "default"]
-    [#if (component[type].Storage)??]
-        [#return component[type].Storage]
-    [/#if]
-    [#if (storage[solutionObject.CapacityProfile][tc])??]
-        [#return storage[solutionObject.CapacityProfile][tc]]
-    [/#if]
-    [#if (storage[solutionObject.CapacityProfile][type])??]
-        [#return storage[solutionObject.CapacityProfile][type]]
-    [/#if]
-    [#if (storage[defaultProfile][tc])??]
-        [#return storage[defaultProfile][tc]]
-    [/#if]
-    [#if (storage[defaultProfile][type])??]
-        [#return storage[defaultProfile][type]]
-    [/#if]
+[#function getStorage occurrence type storageProfileName="" ]
+
+    [#local tc = formatComponentShortName( occurrence.Core.Tier.Id, occurrence.Core.Component.Id)]
+    [#local storageProfileName = (storageProfileName?has_content)?then(
+                                    storageProfileName,
+                                    occurrence.Configuration.Solution.Profiles.Storage
+                                )]
+
+    [#local storageProfile = (storage[storageProfileName])!{}]
+
+    [#list storageProfile as key,value ]
+        [#switch key?lower_case ]
+            [#case tc?lower_case ]
+                [#return storageProfile[key]]
+                [#break]
+            [#case type?lower_case]
+                [#return storageProfile[key]]
+                [#break]
+        [/#switch]
+    [/#list]
+
+    [#return {}]
 [/#function]
 
 

--- a/providers/shared/components/bastion/id.ftl
+++ b/providers/shared/components/bastion/id.ftl
@@ -48,6 +48,11 @@
                             "Default" : "default"
                         },
                         {
+                            "Names" : "Storage",
+                            "Types" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
                             "Names" : "Network",
                             "Types":  STRING_TYPE,
                             "Default" : "default"

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1174,6 +1174,11 @@
                     "Default" : "default"
                 },
                 {
+                    "Names" : "Storage",
+                    "Types" : STRING_TYPE,
+                    "Default" : "default"
+                },
+                {
                     "Names" : "Alert",
                     "Types" : STRING_TYPE,
                     "Default" : "default"

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -37,6 +37,11 @@
                             "Default" : "default"
                         },
                         {
+                            "Names" : "Storage",
+                            "Types" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
                             "Names" : "Network",
                             "Types" : STRING_TYPE,
                             "Default" : "default"

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -47,6 +47,11 @@
                             "Default" : "default"
                         },
                         {
+                            "Names" : "Storage",
+                            "Types" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
                             "Names" : "Network",
                             "Types" : STRING_TYPE,
                             "Default" : "default"

--- a/providers/shared/components/es/id.ftl
+++ b/providers/shared/components/es/id.ftl
@@ -77,6 +77,11 @@
                             "Default" : "default"
                         },
                         {
+                            "Names" : "Storage",
+                            "Types" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
                             "Names" : "Alert",
                             "Types" : STRING_TYPE,
                             "Default" : "default"


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)


## Description

- Adds support for defining a storage profile to use through the solution configuration.
- Adds case insensitive matching for the component type when looking up the processor storage profiles


## Motivation and Context

These appear to have missed before when we added profiles for processors and the other methods listed in the profile lookup process appear to have been removed as well. This aligns and standardises the configuration approach. 

## How Has This Been Tested?

Tested locally 

## Followup Actions

- [x] None
