### PR TITLE
fix: default storage profile name

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -572,7 +572,7 @@ behaviour.
     [#local tc = formatComponentShortName( occurrence.Core.Tier.Id, occurrence.Core.Component.Id)]
     [#local storageProfileName = (storageProfileName?has_content)?then(
                                     storageProfileName,
-                                    occurrence.Configuration.Solution.Profiles.Storage
+                                    (occurrence.Configuration.Solution.Profiles.Storage)!"default"
                                 )]
 
     [#local storageProfile = (storage[storageProfileName])!{}]

--- a/providers/shared/components/baseline/id.ftl
+++ b/providers/shared/components/baseline/id.ftl
@@ -235,6 +235,16 @@
                         "Default" : true
                     }
                 ]
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : [
+                    {
+                        "Names" : "Storage",
+                        "Types" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
             }
         ]
     parent=BASELINE_COMPONENT_TYPE

--- a/providers/shared/components/s3/id.ftl
+++ b/providers/shared/components/s3/id.ftl
@@ -17,6 +17,16 @@
     attributes=
         [
             {
+                "Names" : "Profiles",
+                "Children" : [
+                    {
+                        "Names" : "Storage",
+                        "Types" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
+            },
+            {
                 "Names" : "Lifecycle",
                 "Children" : [
                     {


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Sets a default storage profile name to handle components which don't have storage profiles configured
- Adds storage profiles to components which might use storage profiles in some providers

## Motivation and Context

Makes the handling of default storage profiles easier and defines configuration requirements that were hiding 

## How Has This Been Tested?

Tested locally 

## Followup Actions

- [x] None
