### PR TITLE
fix: mta rule link attribute

### DIFF
--- a/providers/shared/attributesets/links/id.ftl
+++ b/providers/shared/attributesets/links/id.ftl
@@ -120,6 +120,10 @@
             "Type"  : STRING_TYPE
         },
         {
+            "Names" : [ "Rule" ],
+            "Type"  : STRING_TYPE
+        },
+        {
             "Names" : "Instance",
             "Type" : STRING_TYPE
         },


### PR DESCRIPTION


## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Add the MTA rule link attribute to the link attributeset.

## Motivation and Context
S3 links to MTA rules are broken. 

## How Has This Been Tested?
Local template generation.

## Followup Actions
- [x] None
