### PR TITLE
feat: allow configuration of the schema  property

### DIFF
--- a/engine/schema.ftl
+++ b/engine/schema.ftl
@@ -82,12 +82,12 @@
     [#return asArray(composite.Names)[0]]
 [/#function]
 
-[#function formatSchemaId section unit version="latest"]
-    [#switch section]
-        [#default]
-            [#return formatPath(false, rootSchemaPath, version, "blueprint", "schema-" + section + "-" + unit + "-schema.json")]
-            [#break]
-    [/#switch]
+[#function formatSchemaId section unit version="latest" prefix="" ]
+    [#local filename = "schema-" + section + "-" + unit + "-schema.json" ]
+    [#if prefix?has_content ]
+        [#return formatPath(false, prefix, filename) ]
+    [/#if]
+    [#return formatPath(false, rootSchemaPath, version, "blueprint", filename)]
 [/#function]
 
 [#function formatJsonSchemaFromComposite composite references=[] schemaId=""]

--- a/providers/shared/entrances/schema/entrance.ftl
+++ b/providers/shared/entrances/schema/entrance.ftl
@@ -29,6 +29,16 @@
 [#-- Set the required flow/view --]
 [#function schema_configseeder_commandlineoptions filter state]
 
+    [#local schemaCLOConfig = state.CommandLineOptions.Schema!{}]
+    [#local schemaId = "" ]
+    [#local schemaPrefixed = false ]
+    [#local schemaVersion = "latest" ]
+    [#if schemaCLOConfig?has_content]
+        [#local schemaId = schemaCLOConfig.Id!"" ]
+        [#local schemaPrefixed = schemaCLOConfig.Prefixed!false ]
+        [#local schemaVersion = schemaCLOConfig.Version!"latest" ]
+    [/#if]
+
     [#return
         addToConfigPipelineClass(
             state,
@@ -44,7 +54,12 @@
                 },
                 "View" : {
                     "Name" : SCHEMA_VIEW_TYPE
-                }
+                },
+                "Schema" : {
+                    "Prefixed" : schemaPrefixed,
+                    "Version" : schemaVersion
+                } +
+                attributeIfContent("Id", schemaId)
             }
         )
     ]

--- a/providers/shared/views/schema/setup.ftl
+++ b/providers/shared/views/schema/setup.ftl
@@ -8,12 +8,12 @@
 
     [#local section = getCLODeploymentGroup() ]
     [#local schema = getCLODeploymentUnit() ]
-
-    [#if ["module"]?seq_contains(section)]
-        [#-- Do not assign a schema $Id attribute on non-official schemas --]
-        [#local schemaId = ""]
-    [#else]
-        [#local schemaId = formatSchemaId(section, schema)]
+    
+    [#local schemaCLO = getCommandLineOptions().Schema ]
+    [#local schemaId = schemaCLO.Id!formatSchemaId(section, schema) ]
+    [#local schemaVersion = schemaCLO.Version ]
+    [#if schemaCLO.Prefixed ]
+        [#local schemaId = formatSchemaId(section, schema, schemaVersion, schemaIdUrl )]
     [/#if]
 
     [#switch section]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- new feature
- 
## Description
<!--- Describe your changes in detail -->
Allow the setting of commandLineOptions to control the JSONSchema `$id` property.

Defaults to the existing $id if unprovided.

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Closes #1551 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Locally

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None
