### PR TITLE
refactor: move alert config into attribute set

### DIFF
--- a/providers/shared/attributesets/alert/id.ftl
+++ b/providers/shared/attributesets/alert/id.ftl
@@ -8,7 +8,7 @@
                 "Type"  : "Description",
                 "Value" : "Configuration of alerts that monitor component resources"
         }]
-    attributes=[    [
+    attributes=[
         {
             "Names" : "Namespace",
             "Types" : STRING_TYPE,

--- a/providers/shared/attributesets/alert/id.ftl
+++ b/providers/shared/attributesets/alert/id.ftl
@@ -1,0 +1,126 @@
+[#ftl]
+
+[@addAttributeSet
+    type=ALERT_ATTRIBUTESET_TYPE
+    pluralType="Alerts"
+    properties=[
+        {
+                "Type"  : "Description",
+                "Value" : "Configuration of alerts that monitor component resources"
+        }]
+    attributes=[    [
+        {
+            "Names" : "Namespace",
+            "Types" : STRING_TYPE,
+            "Default" : ""
+        },
+        {
+            "Names" : "DimensionSource",
+            "Description" : "The source of the alert dimensions - resource lookup or explicit configuration",
+            "Types" : STRING_TYPE,
+            "Values" : [ "Resource", "Configured" ],
+            "Default" : "Resource"
+        },
+        {
+            "Names" : "Resource",
+            "Description" : "Provide a component resource to determine the dimensions of the metric",
+            "Children" : [
+                {
+                    "Names" : "Id",
+                    "Types" : STRING_TYPE
+                },
+                {
+                    "Names" : "Type",
+                    "Types" : STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : "Dimensions",
+            "Description" : "Explicit configured dimensions",
+            "SubObjects" : true,
+            "Children" : [
+                {
+                    "Names" : "Key",
+                    "Description" : "The Key of the dimension",
+                    "Types" : STRING_TYPE
+                },
+                {
+                    "Names" : "Value",
+                    "Description" : "The value of the dimension to match",
+                    "Types" : STRING_TYPE
+                },
+                {
+                    "Names" : "SettingEnvName",
+                    "Description" : "A setting name as env that will provide the dimension value",
+                    "Types": STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : "Metric",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Statistic",
+            "Types" : STRING_TYPE,
+            "Default" : "Sum"
+        },
+        {
+            "Names" : "Description",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "Name",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Threshold",
+            "Types" : NUMBER_TYPE,
+            "Default" : 1
+        },
+        {
+            "Names" : "Severity",
+            "Types" : STRING_TYPE,
+            "Values" : [ "debug", "info", "warn", "error", "fatal"],
+            "Default" : "info"
+        },
+        {
+            "Names" : "Comparison",
+            "Types" : STRING_TYPE,
+            "Default" : "Threshold"
+        },
+        {
+            "Names" : "Operator",
+            "Types" : STRING_TYPE,
+            "Default" : "GreaterThanOrEqualToThreshold"
+        },
+        {
+            "Names" : "Time",
+            "Types" : NUMBER_TYPE,
+            "Default" : 300
+        },
+        {
+            "Names" : "Periods",
+            "Types" : NUMBER_TYPE,
+            "Default" : 1
+        },
+        {
+            "Names" : "ReportOk",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : false
+        },
+        {
+            "Names" : "MissingData",
+            "Types" : STRING_TYPE,
+            "Default" : "notBreaching"
+        },
+        {
+            "Names" : "Unit",
+            "Types" : STRING_TYPE,
+            "Default" : "Count"
+        }
+    ]
+/]

--- a/providers/shared/attributesets/attributeset.ftl
+++ b/providers/shared/attributesets/attributeset.ftl
@@ -1,8 +1,15 @@
 [#ftl]
 
-[#assign LINK_ATTRIBUTESET_TYPE = "link"]
-[#assign CONTEXTPATH_ATTRIBUTESET_TYPE = "contextpath"]
-[#assign OPERATINGSYSTEM_ATTRIBUTESET_TYPE = "operatingsystem" ]
-[#assign OSPATCHING_ATTRIBUTESET_TYPE = "ospatching"]
+[#assign ALERT_ATTRIBUTESET_TYPE = "alert" ]
+
 [#assign COMPUTEIMAGE_ATTRIBUTESET_TYPE = "computeimage"]
+
+[#assign CONTEXTPATH_ATTRIBUTESET_TYPE = "contextpath"]
+
 [#assign ECS_COMPUTEIMAGE_ATTRIBUTESET_TYPE = "ecs_computeimage"]
+
+[#assign LINK_ATTRIBUTESET_TYPE = "link"]
+
+[#assign OPERATINGSYSTEM_ATTRIBUTESET_TYPE = "operatingsystem" ]
+
+[#assign OSPATCHING_ATTRIBUTESET_TYPE = "ospatching"]

--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -227,7 +227,7 @@ object.
             {
                 "Names" : "Alerts",
                 "SubObjects" : true,
-                "Children" : alertChildrenConfiguration
+                "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
             },
             {
                 "Names" : "LogMetrics",

--- a/providers/shared/components/cache/id.ftl
+++ b/providers/shared/components/cache/id.ftl
@@ -89,7 +89,7 @@
             {
                 "Names" : "Alerts",
                 "SubObjects" : true,
-                "Children" : alertChildrenConfiguration
+                "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
             }
         ]
 /]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -74,6 +74,8 @@
 
 [#assign GLOBALDB_COMPONENT_TYPE = "globaldb" ]
 
+[#assign HEALTHCHECK_COMPONENT_TYPE = "healthcheck" ]
+
 [#assign INTERNALTEST_COMPONENT_TYPE = "internaltest" ]
 
 [#assign LAMBDA_COMPONENT_TYPE = "lambda"]
@@ -157,124 +159,6 @@
     ]
 ]
 
-[#assign alertChildrenConfiguration =
-    [
-        {
-            "Names" : "Namespace",
-            "Types" : STRING_TYPE,
-            "Default" : ""
-        },
-        {
-            "Names" : "DimensionSource",
-            "Description" : "The source of the alert dimensions - resource lookup or explicit configuration",
-            "Types" : STRING_TYPE,
-            "Values" : [ "Resource", "Configured" ],
-            "Default" : "Resource"
-        },
-        {
-            "Names" : "Resource",
-            "Description" : "Provide a component resource to determine the dimensions of the metric",
-            "Children" : [
-                {
-                    "Names" : "Id",
-                    "Types" : STRING_TYPE
-                },
-                {
-                    "Names" : "Type",
-                    "Types" : STRING_TYPE
-                }
-            ]
-        },
-        {
-            "Names" : "Dimensions",
-            "Description" : "Explicit configured dimensions",
-            "SubObjects" : true,
-            "Children" : [
-                {
-                    "Names" : "Key",
-                    "Description" : "The Key of the dimension",
-                    "Types" : STRING_TYPE
-                },
-                {
-                    "Names" : "Value",
-                    "Description" : "The value of the dimension to match",
-                    "Types" : STRING_TYPE
-                },
-                {
-                    "Names" : "SettingEnvName",
-                    "Description" : "A setting name as env that will provide the dimension value",
-                    "Types": STRING_TYPE
-                }
-            ]
-        },
-        {
-            "Names" : "Metric",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
-            "Names" : "Statistic",
-            "Types" : STRING_TYPE,
-            "Default" : "Sum"
-        },
-        {
-            "Names" : "Description",
-            "Types" : STRING_TYPE
-        },
-        {
-            "Names" : "Name",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
-            "Names" : "Threshold",
-            "Types" : NUMBER_TYPE,
-            "Default" : 1
-        },
-        {
-            "Names" : "Severity",
-            "Types" : STRING_TYPE,
-            "Values" : [ "debug", "info", "warn", "error", "fatal"],
-            "Default" : "info"
-        },
-        {
-            "Names" : "Comparison",
-            "Types" : STRING_TYPE,
-            "Default" : "Threshold"
-        },
-        {
-            "Names" : "Operator",
-            "Types" : STRING_TYPE,
-            "Default" : "GreaterThanOrEqualToThreshold"
-        },
-        {
-            "Names" : "Time",
-            "Types" : NUMBER_TYPE,
-            "Default" : 300
-        },
-        {
-            "Names" : "Periods",
-            "Types" : NUMBER_TYPE,
-            "Default" : 1
-        },
-        {
-            "Names" : "ReportOk",
-            "Types" : BOOLEAN_TYPE,
-            "Default" : false
-        },
-        {
-            "Names" : "MissingData",
-            "Types" : STRING_TYPE,
-            "Default" : "notBreaching"
-        },
-        {
-            "Names" : "Unit",
-            "Types" : STRING_TYPE,
-            "Default" : "Count"
-        }
-    ]
-]
-
 [#assign scalingPolicyChildrenConfiguration =
     [
         {
@@ -309,7 +193,7 @@
                 },
                 {
                     "Names" : "MetricTrigger",
-                    "Children" : alertChildrenConfiguration
+                    "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
                 }
             ]
         },
@@ -993,7 +877,7 @@
     {
         "Names" : "Alerts",
         "SubObjects" : true,
-        "Children" : alertChildrenConfiguration
+        "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
     },
     {
         "Names" : "ContainerLogGroup",
@@ -1263,7 +1147,7 @@
     {
         "Names" : "Alerts",
         "SubObjects" : true,
-        "Children" : alertChildrenConfiguration
+        "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
     },
     {
         "Names" : "Hibernate",
@@ -1386,7 +1270,7 @@
     {
         "Names" : "Alerts",
         "SubObjects" : true,
-        "Children" : alertChildrenConfiguration
+        "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
     },
     {
         "Names" : "NetworkMode",
@@ -1505,7 +1389,7 @@
     {
         "Names" : "Alerts",
         "SubObjects" : true,
-        "Children" : alertChildrenConfiguration
+        "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
     },
     {
         "Names" : "NetworkMode",

--- a/providers/shared/components/db/id.ftl
+++ b/providers/shared/components/db/id.ftl
@@ -182,7 +182,7 @@
             {
                 "Names" : "Alerts",
                 "SubObjects" : true,
-                "Children" : alertChildrenConfiguration
+                "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
             },
             {
                 "Names" : "Links",

--- a/providers/shared/components/es/id.ftl
+++ b/providers/shared/components/es/id.ftl
@@ -106,7 +106,7 @@
             {
                 "Names" : "Alerts",
                 "SubObjects" : true,
-                "Children" : alertChildrenConfiguration
+                "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
             },
             {
                 "Names" : "Logging",

--- a/providers/shared/components/externalnetwork/id.ftl
+++ b/providers/shared/components/externalnetwork/id.ftl
@@ -95,7 +95,7 @@
             {
                 "Names" : "Alerts",
                 "SubObjects" : true,
-                "Children" : alertChildrenConfiguration
+                "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
             }
         ]
     parent=EXTERNALNETWORK_COMPONENT_TYPE

--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -73,7 +73,7 @@
             {
                 "Names" : "Alerts",
                 "SubObjects" : true,
-                "Children" : alertChildrenConfiguration
+                "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
             },
             {
                 "Names" : ["Memory", "MemorySize"],

--- a/providers/shared/components/lb/id.ftl
+++ b/providers/shared/components/lb/id.ftl
@@ -55,7 +55,7 @@
             {
                 "Names" : "Alerts",
                 "SubObjects" : true,
-                "Children" : alertChildrenConfiguration
+                "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
             },
             {
                 "Names" : "Links",

--- a/providers/shared/components/mobilenotifier/id.ftl
+++ b/providers/shared/components/mobilenotifier/id.ftl
@@ -113,7 +113,7 @@
             {
                 "Names" : "Alerts",
                 "SubObjects" : true,
-                "Children" : alertChildrenConfiguration
+                "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
             },
             {
                 "Names" : "Profiles",

--- a/providers/shared/components/queuehost/id.ftl
+++ b/providers/shared/components/queuehost/id.ftl
@@ -82,7 +82,7 @@
             {
                 "Names" : "Alerts",
                 "SubObjects" : true,
-                "Children" : alertChildrenConfiguration
+                "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
             },
             {
                 "Names" : "Encrypted",

--- a/providers/shared/components/sqs/id.ftl
+++ b/providers/shared/components/sqs/id.ftl
@@ -64,7 +64,7 @@
                 "Names" : "Alerts",
                 "Description" : "Alert support for monitoring queue activity",
                 "SubObjects" : true,
-                "Children" : alertChildrenConfiguration
+                "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
             },
             {
                 "Names" : "Links",

--- a/providers/shared/components/topic/id.ftl
+++ b/providers/shared/components/topic/id.ftl
@@ -30,7 +30,7 @@
             {
                 "Names" : "Alerts",
                 "SubObjects" : true,
-                "Children" : alertChildrenConfiguration
+                "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
             }
         ]
 /]


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

Moves the alert configuration from a childConfiguration global variable to an attribute set

## Motivation and Context

Cleaner usage and understanding of the configuration 

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

