### PR TITLE
feat: compact log format for console

### DIFF
--- a/client/invokeEntrance.ftl
+++ b/client/invokeEntrance.ftl
@@ -33,6 +33,4 @@
 
 [#-- Find the logs for any that match the stop level or above --]
 [#-- Set the exit code if they are found --]
-[@setExitStatusFromLogs
-    failureLevel=getCommandLineOptions().Logging.StopLevel
-/]
+[@setExitStatusFromLogs /]

--- a/engine/bootstrap.ftl
+++ b/engine/bootstrap.ftl
@@ -78,6 +78,8 @@
 
 [#-- Set desired logging configuration  --]
 [@setLogLevel getCommandLineOptions().Logging.Level /]
+[@setFatalLogLevel getCommandLineOptions().Logging.StopLevel /]
+
 [@setLogFatalStopThreshold getCommandLineOptions().Logging.FatalStopThreshold /]
 [@setLogDepthLimit getCommandLineOptions().Logging.DepthLimit /]
 

--- a/engine/logging.ftl
+++ b/engine/logging.ftl
@@ -239,7 +239,7 @@
 
                     [#switch logFormat]
                         [#case "compact"]
-                            [#local logNotes += [ "Compact log output format used set HAMLET_LOG_FORMAT=full for the complete details" ]]
+                            [#local logNotes += [ "Compact log output format used set GENERATION_LOG_FORMAT=full for the complete details" ]]
                             [#break]
 
                     [/#switch]

--- a/providers/shared/inputseeders/shared/id.ftl
+++ b/providers/shared/inputseeders/shared/id.ftl
@@ -174,6 +174,7 @@
                     "StopLevel" : stopLevel!"fatal",
                     "FatalStopThreshold" : logFatalStopThreshold!0,
                     "DepthLimit" : logDepthLimit!0,
+                    "Format" : logFormat!"compact",
                     "Writers" :
                         (logWriters!"")?has_content?then(
                             logWriters?split(","),


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds a compact log format to support including log messages as part template generation. This allows for logs to be generated and listed across entrances without flooding the console with information

When debug or fatal logs are found compact mode is disabled and the full log message is logged

Includes a log notes section when logs a written with the count of logs and a notice about the compact log format and how you can disable it 

## Motivation and Context

This allows for logs to be included in entrance invokes that will be successful without flooding a console output with warning messages and their content. Instead just the log message is logged. 

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

