### PR TITLE
feat: warnings and deployed link failures

### DIFF
--- a/providers/shared/attributesets/links/id.ftl
+++ b/providers/shared/attributesets/links/id.ftl
@@ -10,6 +10,35 @@
         }]
     attributes=[
         {
+            "Names" : "IncludeInContext",
+            "Description" : "Include the attributes provided by this link in the environment context",
+            "Type" : ARRAY_OF_STRING_TYPE
+        },
+        {
+            "Names" : "ActiveRequired",
+            "Description" : "Require that the linked occurrence has been deployed and is active",
+            "Type" : BOOLEAN_TYPE
+        },
+        {
+            "Names" : "Role",
+            "Description" : "The role of the relationship between the components",
+            "Type" : STRING_TYPE
+        },
+        {
+            "Names" : "Direction",
+            "Description" : "The direction the role applies to between the components",
+            "Type" : STRING_TYPE
+        },
+        {
+            "Names" : "Type",
+            "Type" : STRING_TYPE
+        },
+        {
+            "Names" : "Enabled",
+            "Type" : BOOLEAN_TYPE,
+            "Default" : true
+        },
+        {
             "Names" : "Any",
             "Type" : STRING_TYPE
         },
@@ -38,6 +67,14 @@
             "Names" : "Component",
             "Type" : STRING_TYPE,
             "Mandatory" : true
+        },
+        {
+            "Names" : "Instance",
+            "Type" : STRING_TYPE
+        },
+        {
+            "Names" : "Version",
+            "Type" : STRING_TYPE
         },
         {
             "Names" : ["Function"],
@@ -124,37 +161,8 @@
             "Type"  : STRING_TYPE
         },
         {
-            "Names" : "Instance",
+            "Names" : [ "Secret" ],
             "Type" : STRING_TYPE
-        },
-        {
-            "Names" : "Version",
-            "Type" : STRING_TYPE
-        },
-        {
-            "Names" : "Secret",
-            "Type" : STRING_TYPE
-        },
-        {
-            "Names" : "Role",
-            "Type" : STRING_TYPE
-        },
-        {
-            "Names" : "Direction",
-            "Type" : STRING_TYPE
-        },
-        {
-            "Names" : "Type",
-            "Type" : STRING_TYPE
-        },
-        {
-            "Names" : "Enabled",
-            "Type" : BOOLEAN_TYPE,
-            "Default" : true
-        },
-        {
-            "Names" : "IncludeInContext",
-            "Type" : ARRAY_OF_STRING_TYPE
         }
     ]
 /]

--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -104,6 +104,11 @@
         [#return {} ]
     [/#if]
 
+    [#-- Allow user defined links to specify if the link is required to be active --]
+    [#if (link.ActiveRequired)?? ]
+        [#local activeRequired = link.ActiveRequired ]
+    [/#if]
+
     [#-- Handle external links --]
     [#-- They are deprecated in favour of an external tier but for now --]
     [#-- they can still be used, even with an external tier, by explicitly --]
@@ -186,7 +191,22 @@
             [@debug message="Link matched target" context=targetSubOccurrence enabled=false /]
 
             [#-- Determine if deployed --]
-            [#if ( activeOnly || activeRequired ) && !isOccurrenceDeployed(targetSubOccurrence) ]
+            [#local isDeployed = isOccurrenceDeployed(targetSubOccurrence)]
+
+            [#-- Always warn if linking to an inactive component --]
+            [#if !isDeployed && !activeRequired ]
+                [@warn
+                    message="link occurrence not deployed - ${occurrence.Core.Name} -> ${targetSubOccurrence.Core.Name}"
+                    detail="A link was made to an occurrence which has not been deployed"
+                    context={
+                        "Link" : link,
+                        "EffectiveInstance" : instanceToMatch,
+                        "EffectiveVersion" : versionToMatch
+                    }
+                /]
+            [/#if]
+
+            [#if ( activeOnly || activeRequired ) && !isDeployed ]
                 [#if activeRequired ]
                     [@postcondition
                         function="getLinkTarget"


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds a warning message when an occurrence links to another target which hasn't been deployed
- Adds a link attribute property ActiveRequired which checks to see if the link to an occurrence has been deployed and raises a fatal exception if it can't be found.

## Motivation and Context

implements https://github.com/hamlet-io/engine/issues/1652

This extends existing functionality in the link processing which components can use to throw fatal error on  links that haven't been deployed and allows users to define these dependences themselves. This ensures that components have everything they need to deploy 

While linking to an occurrence that hasn't been deployed is generally handled by the components it is still an potential issue. Raising a warning allows for processing to continue but notifies users of potential issues 

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

