### PR TITLE
feat: add raw id and name formatting

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -218,19 +218,28 @@
             {
                 "Core" : {
                     "Id" : formatId(occurrence.Core.Extensions.Id),
+                    "RawId" : formatId(occurrence.Core.Extensions.RawId),
                     "TypedId" : formatId(occurrence.Core.Extensions.Id, type),
                     "Name" : formatName(occurrence.Core.Extensions.Name),
+                    "RawName" : formatName(occurrence.Core.Extensions.RawName),
                     "TypedName" : formatName(occurrence.Core.Extensions.Name, type),
                     "FullName" : formatSegmentFullName(occurrence.Core.Extensions.Name),
+                    "RawFullName" : formatSegmentFullName(occurrence.Core.Extensions.RawName),
                     "TypedFullName" : formatSegmentFullName(occurrence.Core.Extensions.Name, type),
                     "ShortName" : formatName(occurrence.Core.Extensions.Id),
+                    "ShortRawName" : formatName(occurrence.Core.Extensions.RawName),
                     "ShortTypedName" : formatName(occurrence.Core.Extensions.Id, type),
                     "ShortFullName" : formatSegmentShortName(occurrence.Core.Extensions.Id),
+                    "ShortRawFullName" : formatSegmentShortName(occurrence.Core.Extensions.RawId),
                     "ShortTypedFullName" : formatSegmentShortName(occurrence.Core.Extensions.Id, type),
                     "RelativePath" : formatRelativePath(occurrence.Core.Extensions.Name),
+                    "ReltiveRawPath" : formatRelativePath(occurrence.Core.Extensions.RawName),
                     "FullRelativePath" : formatSegmentRelativePath(occurrence.Core.Extensions.Name),
+                    "FullRealitveRawPath" : formatSegmentRelativePath(occurrence.Core.Extensions.RawName),
                     "AbsolutePath" : formatAbsolutePath(occurrence.Core.Extensions.Name),
-                    "FullAbsolutePath" : formatSegmentAbsolutePath(occurrence.Core.Extensions.Name)
+                    "AbsoluteRawPath" : formatAbsolutePath(occurrence.Core.Extensions.RawName),
+                    "FullAbsolutePath" : formatSegmentAbsolutePath(occurrence.Core.Extensions.Name),
+                    "FullAbsoluteRawPath" : formatSegmentAbsolutePath(occurrence.Core.Extensions.RawName)
                 }
             }
         ) ]

--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -278,7 +278,9 @@
         [#local componentRawName = component.Name ]
         [#local componentType = type ]
         [#local subComponentId = [] ]
+        [#local subComponentRawId = [] ]
         [#local subComponentName = [] ]
+        [#local subComponentRawName = [] ]
         [#local componentContexts += [component, typeObject] ]
     [#else]
         [#local tierId = parentOccurrence.Core.Tier.Id ]
@@ -289,7 +291,9 @@
         [#local componentRawName = parentOccurrence.Core.Component.RawName ]
         [#local componentType = parentOccurrence.Core.Component.Type ]
         [#local subComponentId = typeObject.Id?split("-") ]
+        [#local subComponentRawId = [ typeObject.Id ] ]
         [#local subComponentName = typeObject.Name?split("-") ]
+        [#local subComponentRawName = [ typeObject.Name ] ]
         [#local componentContexts += [typeObject] ]
     [/#if]
 
@@ -311,10 +315,18 @@
                                 subComponentId +
                                 asArray(instanceId, true, true) +
                                 asArray(versionId, true, true) ]
+                    [#local rawIdExtensions =
+                                subComponentRawId +
+                                asArray(instanceId, true, true) +
+                                asArray(versionId, true, true )]
                     [#local nameExtensions =
                                 subComponentName +
                                 asArray(instanceName, true, true) +
-                                asArray(versionName, true, true) ]
+                                asArray(versionName, true, true)]
+                    [#local rawNameExtensions =
+                                subComponentRawName +
+                                asArray(instanceName, true, true) +
+                                asArray(versionName, true, true)]
                     [#local occurrence =
                         {
                             "Core" : {
@@ -344,13 +356,19 @@
                                 },
                                 "Internal" : {
                                     "IdExtensions" : idExtensions,
-                                    "NameExtensions" : nameExtensions
+                                    "RawIdExtensions" : rawIdExtensions,
+                                    "NameExtensions" : nameExtensions,
+                                    "RawNameExtensions" : rawNameExtensions
                                 },
                                 "Extensions" : {
                                     "Id" :
                                         ((parentOccurrence.Core.Extensions.Id)![tierId, componentId]) + idExtensions,
+                                    "RawId" :
+                                        ((parentOccurrence.Core.Extensions.Id)![tierId, componentRawId]) + rawIdExtensions,
                                     "Name" :
-                                        ((parentOccurrence.Core.Extensions.Name)![tierName, componentName]) + nameExtensions
+                                        ((parentOccurrence.Core.Extensions.Name)![tierName, componentName]) + nameExtensions,
+                                    "RawName" :
+                                        ((parentOccurrence.Core.Extensions.Name)![tierName, componentRawName]) + rawNameExtensions
                                 }
 
                             } +


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds formatting based on the raw id and name values which don't split the id and name values based on - in the id

## Motivation and Context

This ensures unique names and Ids can be generated for all occurrences as these values must be unqiue within the JSON structure of the data

Allows for ensuring there is a unique set of identifiers for each occurrence which is required for  https://github.com/hamlet-io/executor-python/issues/117

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

