### PR TITLE
feat: extend component schema

### DIFF
--- a/engine/extension.ftl
+++ b/engine/extension.ftl
@@ -137,7 +137,7 @@
     [/#list]
 [/#macro]
 
-[#function invokeExtensions occurrence context baseOccurrence={} additionalIds=[] additonalOnly=false entrance="deployment" scope="setup" provider="shared"  ]
+[#function invokeExtensions occurrence context baseOccurrence={} additionalIds=[] additionalOnly=false entrance="deployment" scope="setup" provider="shared"  ]
 
     [#-- Replace the global context with the components context --]
     [#assign _context = context ]
@@ -154,7 +154,7 @@
                                 baseOccurrence,
                                 occurrence) ]
 
-    [#list formatExtensionIds(baseOccurrence, additionalIds, additonalOnly) as id]
+    [#list formatExtensionIds(baseOccurrence, additionalIds, additionalOnly) as id]
 
         [#local extensionContext = {
             "Id" : id,

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -311,8 +311,11 @@
     [#return occurrence]
 [/#function]
 
-[#function extendAttributes attributes=[] extensions=[] prefix=""]
+[#function extendAttributes attributes=[] extensions=[] prefix="" disablePrefix="shared:" ]
+
     [#local result = []]
+    [#local prefix = prefix?ensure_ends_with(":")]
+
     [#if extensions?has_content]
         [#list attributes as attribute]
 
@@ -350,8 +353,18 @@
                     [#local extendedAttributes = {}]
                     [#local extendedValues = (attribute.Values)![]]
                     [#list (attributeExtension.Values)![] as extensionValue]
-                        [#local extendedValues +=
-                            [extensionValue?ensure_starts_with(prefix + ":")] ]
+
+                        [#if extensionValue?is_string ]
+                            [#local extendedValues +=
+                                [
+                                    extensionValue?starts_with(disablePrefix)?then(
+                                        extensionValue?remove_beginning(disablePrefix),
+                                        extensionValue?ensure_starts_with(prefix)
+                                    )
+                                ]]
+                        [#else ]
+                            [#local extendedValues += extensionValue ]
+                        [/#if]
 
                         [#local extendedAttributes += {
                             "Values" : getUniqueArrayElements(extendedValues)

--- a/providers/shared/references/ComputeProvider/id.ftl
+++ b/providers/shared/references/ComputeProvider/id.ftl
@@ -41,7 +41,7 @@
                 },
                 {
                     "Names" : "Additional",
-                    "Description" : "Providers who will meet the additonal compute capacity outside of the default",
+                    "Description" : "Providers who will meet the additional compute capacity outside of the default",
                     "SubObjects" : true,
                     "Children" : [
                         {

--- a/providers/shared/views/schema/setup.ftl
+++ b/providers/shared/views/schema/setup.ftl
@@ -60,19 +60,33 @@
             /]
             [#local configuration = componentConfiguration[schema] ]
 
-            [#assign schemaComponentAttributes = []]
+            [#local schemaComponentAttributes = []]
 
             [#-- Construct Component Attributes --]
-            [#list providerDictionary?keys as provider]
+            [#list configuration.ResourceGroups as id, resourceGroup ]
+                [#list (resourceGroup.Attributes)!{} as provider, attributes ]
+                    [#if attributes?has_content ]
+                        [#local schemaComponentAttributes = combineEntities(
+                            schemaComponentAttributes,
+                            attributes,
+                            ADD_COMBINE_BEHAVIOUR
+                        )]
+                    [/#if]
+                [/#list]
+            [/#list]
 
-                [#if (configuration.ResourceGroups["default"].Attributes[provider]!{})?has_content]
-
-                    [#assign schemaComponentAttributes = combineEntities(
-                        schemaComponentAttributes,
-                        configuration.ResourceGroups["default"].Attributes[provider],
-                        ADD_COMBINE_BEHAVIOUR)]
-
-                [/#if]
+            [#-- Extend the attributes based on loaded providers --]
+            [#list configuration.ResourceGroups as id, resourceGroup ]
+                [#list (resourceGroup.Extensions)!{} as provider, extensions ]
+                    [#if extensions?has_content ]
+                        [#local schemaComponentAttributes =
+                                        extendAttributes(
+                                            schemaComponentAttributes,
+                                            extensions,
+                                            provider
+                                        )]
+                    [/#if]
+                [/#list]
             [/#list]
 
             [#-- Construct SubComponent References as Attributes--]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds support for a disable prefix when extending existing values through attribute extensions. 
- Includes attribute extensions and the deployment provider during component schema generation to ensure that the schema aligns with what is available

## Motivation and Context

This is primarily for backwards compatibility for provider specific values which didn't have the provider prefix. This allows the values to be migrated to the appropriate provider but still keep their non-prefixed value

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

