### PR TITLE
feat(ecs): add compute provider support on service

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1315,7 +1315,7 @@
                         "Children" : [
                             {
                                 "Names" : "Provider",
-                                "Description" : "The default container compute provider - _engine uses he default provider of the engine",
+                                "Description" : "The default container compute provider - _engine uses the default provider of the engine",
                                 "Types"  : STRING_TYPE,
                                 "Values" : [ "_engine" ],
                                 "Default" : "_engine"

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1214,6 +1214,13 @@
 
 [#assign containerServiceAttributes = [
     {
+        "Names" : "Engine",
+        "Description" : "The engine used to run the container",
+        "Types" : STRING_TYPE,
+        "Values" : [ "ec2" ],
+        "Default" : "ec2"
+    },
+    {
         "Names" : "Containers",
         "SubObjects" : true,
         "Children" : containerChildrenConfiguration
@@ -1275,7 +1282,7 @@
     {
         "Names" : "NetworkMode",
         "Types" : STRING_TYPE,
-        "Values" : ["none", "bridge", "awsvpc", "host"],
+        "Values" : ["none", "bridge", "host"],
         "Default" : ""
     },
     {
@@ -1298,6 +1305,55 @@
                 "Types" : BOOLEAN_TYPE,
                 "Description" : "Each task is running on a different container instance when true",
                 "Default" : true
+            },
+            {
+                "Names" : "ComputeProvider",
+                "Description" : "The compute provider placement policy",
+                "Children" : [
+                    {
+                        "Names" : "Default",
+                        "Children" : [
+                            {
+                                "Names" : "Provider",
+                                "Description" : "The default container compute provider - _engine uses he default provider of the engine",
+                                "Types"  : STRING_TYPE,
+                                "Values" : [ "_engine" ],
+                                "Default" : "_engine"
+                            },
+                            {
+                                "Names" : "Weight",
+                                "Types" : NUMBER_TYPE,
+                                "Description" : "The ratio of containers allocated to the provider based on the configured providers",
+                                "Default" : 1
+                            },
+                            {
+                                "Names" : "RequiredCount",
+                                "Description" : "The minimum count of containers to run on the default provider",
+                                "Types" : NUMBER_TYPE,
+                                "Default" : 1
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "Additional",
+                        "Description" : "Providers who will meet the additional compute capacity outside of the default",
+                        "SubObjects" : true,
+                        "Children" : [
+                            {
+                                "Names" : "Provider",
+                                "Types" : STRING_TYPE,
+                                "Values" : [ "_engine" ],
+                                "Mandatory" : true
+                            },
+                            {
+                                "Names" : "Weight",
+                                "Types" : NUMBER_TYPE,
+                                "Description" : "The ratio of containers allocated to the provider based on the configured providers",
+                                "Default" : 1
+                            }
+                        ]
+                    }
+                ]
             }
         ]
     },
@@ -1337,8 +1393,9 @@
 [#assign containerTaskAttributes = [
     {
         "Names" : "Engine",
+        "Description" : "The engine used to run the container",
         "Types" : STRING_TYPE,
-        "Values" : [ "ec2", "fargate" ],
+        "Values" : [ "ec2" ],
         "Default" : "ec2"
     },
     {
@@ -1394,7 +1451,7 @@
     {
         "Names" : "NetworkMode",
         "Types" : STRING_TYPE,
-        "Values" : ["none", "bridge", "awsvpc", "host"],
+        "Values" : ["none", "bridge", "host"],
         "Default" : ""
     },
     {

--- a/providers/shared/components/ecs/id.ftl
+++ b/providers/shared/components/ecs/id.ftl
@@ -34,15 +34,7 @@
                 "Value" : "An orchestrated container with always on scheduling"
             }
         ]
-    attributes=[
-        {
-            "Names" : "Engine",
-            "Types" : STRING_TYPE,
-            "Values" : [ "ec2", "fargate" ],
-            "Default" : "ec2"
-        }
-    ] +
-    containerServiceAttributes
+    attributes=containerServiceAttributes
 /]
 
 [@addComponentDeployment


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds support for specifying the compute provider on the ecs service. When using compute providers the providers available depends on the engine. So we set the default provider to the provider recommended by the engine
- Removes vendor specific attributes from the container definitions and instead uses attribute extensions to define them in the provider

## Motivation and Context

This configuration allows for services to specify the compute provider configuration that they require specifically allowing for different services within the same container host to be hosted using different strategies 

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

