### PR TITLE
fix: set multiAZ flag for blueprint generation

### DIFF
--- a/providers/shared/views/blueprint/setup.ftl
+++ b/providers/shared/views/blueprint/setup.ftl
@@ -91,16 +91,17 @@
 
         [#if component?is_hash]
 
-        [#local componentType = getComponentType(component)]
+            [#assign multiAZ = component.MultiAZ!solnMultiAZ]
+            [#local componentType = getComponentType(component)]
 
-        [#-- Only include deployed Occurrences --]
-        [#local occurrences = getOccurrences(tier, component) ]
+            [#-- Only include deployed Occurrences --]
+            [#local occurrences = getOccurrences(tier, component) ]
 
-        [#local result += [
-            component + {
-            "Type" : componentType,
-            "Occurrences" : occurrences
-            } ] ]
+            [#local result += [
+                component + {
+                "Type" : componentType,
+                "Occurrences" : occurrences
+                } ] ]
 
         [/#if]
     [/#list]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Adds the multiAZ flag into the blueprint generation process which mimics the component flow. This should be replaced with a much nicer process though

Partial fix for https://github.com/hamlet-io/engine-plugin-aws/issues/280 

## Motivation and Context

Gets around an issue with tasks that use the blueprint to get more information around the task to be completed.

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

