### PR TITLE
fix: region in filenames

### DIFF
--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -437,8 +437,14 @@
                                 getCLODeploymentUnit(),
                                 subset,
                                 getCommandLineOptions().Layers[ACCOUNT_LAYER_TYPE],
-                                getCLOSegmentRegion(),
-                                getCLOAccountRegion(),
+                                contentIfContent(
+                                    getCLOSegmentRegion(),
+                                    getProductLayerRegion()
+                                ),
+                                contentIfContent(
+                                    getCLOAccountRegion(),
+                                    getAccountLayerRegion()
+                                )
                                 alternative
                             )]
 
@@ -486,8 +492,8 @@
         "deploymentGroup"        : getCLODeploymentGroup(),
         "resourceGroup"          : getCLODeploymentResourceGroup(),
         "account"                : getCommandLineOptions().Layers[ACCOUNT_LAYER_TYPE],
-        "accountRegion"          : getCLOAccountRegion(),
-        "region"                 : getCLOSegmentRegion(),
+        "accountRegion"          : contentIfContent(getCLOAccountRegion(), getAccountLayerRegion()),
+        "region"                 : contentIfContent(getCLOSegmentRegion(),getProductLayerRegion()),
         "requestReference"       : getCLORequestReference(),
         "configurationReference" : getCLOConfigurationReference(),
         "deploymentMode"         : getDeploymentMode(),


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Add the logic to populate the region in filenames from the CMDB info if it isn't provided on the command line. 

## Motivation and Context
This permits the omission of the assembly of the blueprint prior to running the engine.

## How Has This Been Tested?
Local template generation both with and without the CMDB plugin.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
- executor-bash - https://github.com/hamlet-io/executor-bash/pull/203

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

