### PR TITLE
feat: make refresh input state routine public

### DIFF
--- a/engine/inputdata/commandLineOptions.ftl
+++ b/engine/inputdata/commandLineOptions.ftl
@@ -1,28 +1,6 @@
 [#ftl]
-[#-- Command line options control how the engine behaves --]
 
-[#assign commandLineOptions = {} ]
-
-[#macro addCommandLineOption option={} ]
-    [#if option?has_content ]
-        [@internalMergeCommandLineOption
-            option=option
-        /]
-    [/#if]
-[/#macro]
-
-[#-- Command line options used across a lot of different places --]
-[#--macro setDeploymentUnit deploymentUnit ]
-    [@addCommandLineOption
-        option={
-            "Deployment" : {
-                "Unit" : {
-                    "Name" : deploymentUnit
-                }
-            }
-        }
-    /]
-[/#macro--]
+[#-- Command line option accessors --]
 
 [#function getCLORunId ]
     [#return (getCommandLineOptions().Run.Id)!"" ]
@@ -123,15 +101,3 @@
 [#function getCLOCompositeStackOutputs]
     [#return (getCommandLineOptions().Composites.StackOutputs)![] ]
 [/#function]
-
-
-[#-----------------------------------------------------
--- Internal support functions for blueprint processing --
--------------------------------------------------------]
-
-[#macro internalMergeCommandLineOption option ]
-    [#assign commandLineOptions = mergeObjects(
-                                    commandLineOptions,
-                                    option
-    )]
-[/#macro]

--- a/engine/inputdata/inputsource.ftl
+++ b/engine/inputdata/inputsource.ftl
@@ -214,7 +214,7 @@ state - a single output in the CMDB state
             enabled=false
         /]
 
-        [@internalScheduleInputStateRefresh /]
+        [@scheduleInputStateRefresh /]
     [/#list]
 [/#macro]
 
@@ -377,16 +377,6 @@ to filter the data returned
     [#return getInputState()[COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS]!{} ]
 [/#function]
 
-[#-- TODO(mfl) Remove once input processing complete --]
-[#function getMasterdata ]
-    [#return
-        getConfigPipelineClassCacheForStage(
-            getInputState(),
-            BLUEPRINT_CONFIG_INPUT_CLASS,
-            MASTERDATA_SHARED_INPUT_STAGE
-        )!{} ]
-[/#function]
-
 [#function getBlueprint ]
     [#return getInputState()[BLUEPRINT_CONFIG_INPUT_CLASS]!{} ]
 [/#function]
@@ -442,6 +432,14 @@ Get the value for a point within the state
 [#function getStatePointValue id deploymentUnit="" account="" region="" level="" ]
     [#return getStatePoint(id, deploymentUnit, account, region, level).Value ]
 [/#function]
+
+[#assign inputStateRefreshRequired = false]
+
+[#-- Force a refresh of the input state next time input is requested --]
+[#macro scheduleInputStateRefresh ]
+    [#assign inputStateRefreshRequired = true]
+[/#macro]
+
 [#--
 A stack is used to capture the history of input state changes
 --]
@@ -611,10 +609,6 @@ A stack is used to capture the history of input state changes
             [/#if]
         [/#if]
     [/#if]
-
-    [#-- TODO(mfl) remove once migration to new input source structure complete --]
-    [#-- refresh commandLineOptions on input state change                       --]
-    [@addCommandLineOption inputState.CommandLineOptions!{} /]
 
     [#-- End of critical section --]
     [#assign inputStateRefreshInProgress = false]
@@ -1004,12 +998,7 @@ as processing is typically centred around the initially provided filter values
     [#return inputState]
 [/#function]
 
-[#assign inputStateRefreshRequired = false]
 [#assign inputStateRefreshSuspended = false]
-
-[#macro internalScheduleInputStateRefresh ]
-    [#assign inputStateRefreshRequired = true]
-[/#macro]
 
 [#macro internalSuspendInputStateRefresh ]
     [#assign inputStateRefreshSuspended = true]

--- a/providers/shared/entrances/deployment/entrance.ftl
+++ b/providers/shared/entrances/deployment/entrance.ftl
@@ -9,7 +9,7 @@
             [@fatal
                 message="Undefined deployment mode used"
                 detail="Could not find definition of provided DeploymentMode"
-                context={ "DeploymentMode" : commandLineOptions.Deployment.Mode }
+                context={ "DeploymentMode" : getCLODeploymentMode() }
             /]
         [/#if]
     [/#if]
@@ -19,7 +19,7 @@
             [@fatal
                 message="Undefined deployment group used"
                 detail="Could not find definition of provided DeploymentGroup"
-                context={ "DeploymentGroup" : commandLineOptions.Deployment.Group.Name }
+                context={ "DeploymentGroup" : getCLODeploymentGroup() }
             /]
         [/#if]
     [/#if]


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description
- Expose a method for general use to request a refresh of the input state.
- Remove technical debt

## Motivation and Context
The refresh method is used internally in the input source whenever the seeder configuration of the current input source is changed.

The new use case is for multi-pass processing where the configuration of seeders isn't changing, but the data provided by the seeder varies per pass, so it needs to request the input to be reassessed on each pass.

Also remove technical debt associated with the introduction of the input pipelines
- remove the global `commandLineOptions` variable and associated support as all command line option access should be via the input state accessor method
- remove the masterdata accessor routine as all masterdata management is now done via seeders in the config input pipline.

## How Has This Been Tested?
Scans of all hamlet code repos

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

