### PR TITLE
feat: add base permissions for ec2 components

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1080,6 +1080,31 @@
             ]
     },
     {
+        "Names" : "Permissions",
+        "Children" : [
+            {
+                "Names" : "Decrypt",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "AsFile",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "AppData",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "AppPublic",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            }
+        ]
+    },
+    {
         "Names" : "AutoScaling",
         "Children" : autoScalingChildConfiguration
     },

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -54,6 +54,31 @@
                     ]
             },
             {
+                "Names" : "Permissions",
+                "Children" : [
+                    {
+                        "Names" : "Decrypt",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "AsFile",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "AppData",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "AppPublic",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : false
+                    }
+                ]
+            },
+            {
                 "Names" : "UseInitAsService",
                 "Types" : BOOLEAN_TYPE,
                 "Default" : false

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -64,6 +64,31 @@
                     ]
             },
             {
+                "Names" : "Permissions",
+                "Children" : [
+                    {
+                        "Names" : "Decrypt",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "AsFile",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "AppData",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "AppPublic",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : false
+                    }
+                ]
+            },
+            {
                 "Names" : "Ports",
                 "SubObjects" : true,
                 "Children" : [


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds permissions configuration options for ec2 based components. 

## Motivation and Context

With the ability to run user tasks this allows for flexibility in what you can do and what you can access in the tasks

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

