### PR TITLE
feat: extend multipass generation support

### DIFF
--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -11,6 +11,10 @@
 [#-- Useful if assembling in parts e.g. resources and outputs --]
 [#assign outputs = {} ]
 
+[#macro clearOutputs ]
+    [#assign outputs = {}]
+[/#macro]
+
 [#-- An output has one or more named sections to which content is added.   --]
 [#-- The serialiser macro converts the content of each section into a      --]
 [#-- format suitable for the format of the output.                         --]

--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -481,7 +481,7 @@
 
             /]
 
-            [#-- If pregenration is not reqiured we can complete this pass as part of this entrance invoke --]
+            [#-- If pregeneration is not required we can complete this pass as part of this entrance invoke --]
             [#if ! pregeneration ]
                 [@addEntrancePass
                     contractStep=

--- a/providers/shared/inputseeders/shared/id.ftl
+++ b/providers/shared/inputseeders/shared/id.ftl
@@ -139,21 +139,11 @@
                     "Framework" : {
                         "Name" : deploymentFramework!"default"
                     },
-                    "Output" : {
-                        "Type" : outputType!"",
-                        "Format" : outputFormat!"",
-                        "Prefix" : outputPrefix!""
-                    },
                     "Group" : {
                         "Name" : deploymentGroup!""
                     },
                     "Unit" : {
-                        "Name" : deploymentUnit!"",
-                        "Subset" : deploymentUnitSubset!"",
-                        "Alternative" : passAlternative!""
-                    },
-                    "ResourceGroup" : {
-                        "Name" : resourceGroup!""
+                        "Name" : deploymentUnit!""
                     },
                     "Mode" : deploymentMode!""
                 },
@@ -194,7 +184,6 @@
 
                 [#-- Ouput handling and writing --]
                 "Output" : {
-                    "Pass" : pass!"",
                     "FileName" : outputFileName!"",
                     "Directory" : outputDir!"",
                     "Writers" :


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description

- Adds a status field to contract steps to indicate  if they have already been run. Available values are completed, available and failed 
- Adds an output clear macro which is invoked between entrance passes to ensure the output isn't tainted between passes
- Adds support for adding entrancePasses during the generation contract pass. This allows for the engine to create extra outputs as part of the same call to create the generation contract
- refactors contract steps to allow for them to be passed to the entrancePasses as well as written to file
- removes command line input parameters which are managed by the contract input

## Motivation and Context

The main motivation here is to increase performance in output generation by reducing the repetition in the processing of outputs. By reusing the engine call as much as possible we can have more efficient cache usage and reduce startup processes 

This closes https://github.com/hamlet-io/engine/issues/1666 as we are now generating as many templates as possible within a single pass

This change brings the aws test suite timing down to 

```
real    8m2.570s
user    11m9.057s
sys     2m8.182s
``` 

from 

```
real    9m38.630s
user    11m33.315s
sys     2m16.764s
```

in https://github.com/hamlet-io/executor-bash/pull/204

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- https://github.com/hamlet-io/executor-bash/pull/208

### Consumer Actions:

- None

