### PR TITLE
Yaml config contract properties

### DIFF
--- a/client/invokeEntrance.ftl
+++ b/client/invokeEntrance.ftl
@@ -43,12 +43,13 @@
         {
             "Type" : "process_template_pass",
             "Parameters" : {
-                "outputFormat" : "",
                 "outputType" : "contract",
+                "outputFormat" : "",
+                "outputConversion" : "",
+                "outputFileName" : getCommandLineOptions().Output.FileName,
                 "pass" : "generationcontract",
                 "deploymentUnitSubset" : "generationcontract",
-                "passAlternative" : "",
-                "outputFileName" : getCommandLineOptions().Output.FileName
+                "passAlternative" : ""
             }
         }
     ]
@@ -138,7 +139,8 @@
                 "Deployment" : {
                     "Output" : {
                         "Type" : (activePass.Parameters.outputType)!"",
-                        "Format" : (activePass.Parameters.outputFormat)!""
+                        "Format" : (activePass.Parameters.outputFormat)!"",
+                        "Conversion" : (activePass.Parameters.outputConversion)!""
                     },
                     "Unit" : {
                         "Subset" : (activePass.Parameters.deploymentUnitSubset)!"",

--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -170,7 +170,7 @@
                                 ""
     )]
 
-    [#local asFileFormat = environmentSettings.FileFormat ]
+    [#local asFileFormat = (environmentSettings.FileFormat)!"json" ]
     [#switch asFileFormat ]
         [#case "json" ]
             [#local asFileSuffix = ".json"]

--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -170,6 +170,16 @@
                                 ""
     )]
 
+    [#local asFileFormat = environmentSettings.FileFormat ]
+    [#switch asFileFormat ]
+        [#case "json" ]
+            [#local asFileSuffix = ".json"]
+            [#break]
+        [#case "yaml"]
+            [#local asFileSuffix = ".yaml"]
+            [#break]
+    [/#switch]
+
     [#local runId = getCLORunId()]
     [#-- Link attributes can be overridden by build and product settings, and --]
     [#-- anything can be overridden if explicitly defined via fragments --]
@@ -185,7 +195,7 @@
                 ) +
                 valueIfTrue(
                     {
-                        "SETTINGS_FILE" : ["s3:/", operationsBucket, getSettingsFilePrefix(occurrence), "config/config_" + runId + ".json"]?join("/"),
+                        "SETTINGS_FILE" : ["s3:/", operationsBucket, getSettingsFilePrefix(occurrence), "config/config_" + runId + asFileSuffix ]?join("/"),
                         "RUN_ID" : runId
                     },
                     ( asFile && hasBaselineLinks),

--- a/engine/inputdata/commandLineOptions.ftl
+++ b/engine/inputdata/commandLineOptions.ftl
@@ -50,8 +50,8 @@
     [#return (getCommandLineOptions().Deployment.Output.Format)!"" ]
 [/#function]
 
-[#function getCLODeploymentOutputPrefix ]
-    [#return (getCommandLineOptions().Deployment.Output.Prefix)!"" ]
+[#function getCLODeploymentOutputConversion ]
+    [#return (getCommandLineOptions().Deployment.Output.Conversion)!"" ]
 [/#function]
 
 [#function getCLODeploymentUnit ]

--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -554,7 +554,7 @@
         "outputConversion"       : outputMappings["OutputConversion"],
         "pass"                   : subset,
         "passAlternative"        : alternative,
-        "deploymentUnitSubset"   : outputMappings["Subset"],
+        "deploymentUnitSubset"   : deploymentUnitSubset,
         "outputFileName"         : getOutputFileName(subset, alternative, converter)
     }]
 [/#function]

--- a/legacy/account/account_console.ftl
+++ b/legacy/account/account_console.ftl
@@ -3,7 +3,11 @@
     [#if deploymentSubsetRequired("generationcontract", false)]
         [@addDefaultGenerationContract
             subsets=[ "prologue", "template" ]
-            alternatives=["primary", "replace1", "replace2"]
+            alternatives=[
+                "primary",
+                { "subset" : "template", "alternative" : "replace1" },
+                { "subset" : "template", "alternative" : "replace2" }
+            ]
         /]
     [/#if]
 

--- a/providers/shared/components/adaptor/id.ftl
+++ b/providers/shared/components/adaptor/id.ftl
@@ -34,6 +34,41 @@
                 "Names" : "Links",
                 "SubObjects" : true,
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+            },
+            {
+                "Names" : "Environment",
+                "Children" : settingsChildConfiguration
+            },
+            {
+                "Names" : "Image",
+                "Description" : "Control the source of the image for the adaptor scripts",
+                "Children" : [
+                    {
+                        "Names" : "Source",
+                        "Description" : "The source of the image - registry: the local hamlet registry - url: an external public url - none: no source image",
+                        "Types" : STRING_TYPE,
+                        "Mandatory" : true,
+                        "Values" : [ "registry", "url", "none" ],
+                        "Default" : "registry"
+                    },
+                    {
+                        "Names" : "Source:url",
+                        "Description" : "Url Source specific Configuration",
+                        "Children" : [
+                            {
+                                "Names" : "Url",
+                                "Description" : "The Url to a zip file containing the scripts to run",
+                                "Types" : STRING_TYPE
+                            },
+                            {
+                                "Names" : "ImageHash",
+                                "Description" : "The expected sha1 hash of the Url if empty any will be accepted",
+                                "Types" : STRING_TYPE,
+                                "Default" : ""
+                            }
+                        ]
+                    }
+                ]
             }
         ]
 /]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -407,6 +407,13 @@
             "Default" : false
         },
         {
+            "Names" : "FileFormat",
+            "Types" : STRING_TYPE,
+            "Description" : "The format of the file when using AsFile",
+            "Values" : [ "json", "yaml" ],
+            "Default" : "json"
+        },
+        {
             "Names" : "Json",
             "Children" : [
                 {

--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -482,7 +482,7 @@
             [/#list]
         [/#if]
 
-        [#if alternative?is_collection ]
+        [#if alternative?is_hash ]
             [#if subsets?seq_contains(alternative.subset)]
                 [#local subsetAlternatives += [{ "subset" : alternative.subset, "alternative" : alternative.alternative}] ]
             [/#if]

--- a/providers/shared/tasks/process_template_pass/id.ftl
+++ b/providers/shared/tasks/process_template_pass/id.ftl
@@ -10,32 +10,17 @@
         ]
     attributes=[
         {
-            "Names" : "entrance",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
-            "Names" : "flows",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
-            "Names" : "providers",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
-            "Names" : "deploymentFramework",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
             "Names" : "outputType",
             "Types" : STRING_TYPE,
             "Mandatory" : true
         },
         {
             "Names" : "outputFormat",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "outputConversion",
             "Types" : STRING_TYPE,
             "Mandatory" : true
         },
@@ -55,52 +40,7 @@
             "Mandatory" : true
         },
         {
-            "Names" : "deploymentUnit",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
             "Names" : "deploymentUnitSubset",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
-            "Names" : "deploymentGroup",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
-            "Names" : "resourceGroup",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
-            "Names" : "account",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
-            "Names" : "accountRegion",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
-            "Names" : "region",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
-            "Names" : "requestReference",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
-            "Names" : "configurationReference",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
-        },
-        {
-            "Names" : "deploymentMode",
             "Types" : STRING_TYPE,
             "Mandatory" : true
         }


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description

- Adds support for generation converters which allow for generating outputs based on one format and then have the output writer convert it to another one. The  primary usage for this is converting from json to yaml since the generated output is the same but just needs to be converted 
- Adds a more specific configuration option for alternative outputs to allow for applying alternatives to specific subsets instead of all of them 
- Adds a properties section to contracts which contain contextual level information that can be applied to all stages in the contract or provide executors with extra information 
- Refactors the process_template_pass outputs to only include the ones required 
- refactors standard generation steps into a single stage instead of multiple ones per alternative. This makes the processing of outputs more efficient and easier to follow 
- Adds image support for adapators

## Motivation and Context

converters allow for JSON and yaml based config files to be created to support different tools that would use them. The refactor of the contract output makes it faster to generate outputs and to reduce the number of outputs required 

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- https://github.com/hamlet-io/engine-plugin-aws/pull/291

### Consumer Actions:

- None

