### PR TITLE
fix: set deployment unit subset for template

### DIFF
--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -527,7 +527,7 @@
     ]
 [/#function]
 
-[#function getGenerationContractStepParameters subset alternative converter ]
+[#function getGenerationContractStepParameters subset alternative converter templateSubset=""]
     [#local outputMappings = getGenerationContractStepOutputMapping(
                                 combineEntities(
                                     getLoaderProviders(),
@@ -539,9 +539,9 @@
                             )]
 
     [#-- Handle Deployment Subset for generation --]
-    [#local deploymentUnitSubset = "" ]
-    [#if subset != "template"]
-        [#local deploymentUnitSubset = subset ]
+    [#local deploymentUnitSubset = subset ]
+    [#if subset == "template"  ]
+        [#local deploymentUnitSubset = templateSubset ]
     [/#if]
 
     [#if alternative == "primary"]

--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -408,7 +408,7 @@
 [#-- GenerationContract --]
 
 [#-- Generation Contracts create a contract document which outlines what documents need to be generated --]
-[#macro addDefaultGenerationContract subsets=[] alternatives=["primary"] converters=[] ]
+[#macro addDefaultGenerationContract subsets=[] alternatives=["primary"] converters=[] templateSubset="" ]
 
     [#local subsets = asArray( subsets ) ]
     [#local alternatives = asArray(alternatives) ]
@@ -516,7 +516,8 @@
                     getGenerationContractStepParameters(
                         subset,
                         alternative,
-                        converter
+                        converter,
+                        templateSubset
                     )]
 
         [@contractStep

--- a/providers/shared/entrances/deployment/entrance.ftl
+++ b/providers/shared/entrances/deployment/entrance.ftl
@@ -45,7 +45,7 @@
                 [#assign ignoreDeploymentUnitSubsetInOutputs = false]
 
                 [#-- We need to initialise the outputs here since we are adding to it out side of the component flow --]
-                [@addDefaultGenerationContract subsets=contractSubsets /]
+                [@addDefaultGenerationContract subsets=contractSubsets templateSubset=getCLODeploymentUnit() /]
             [/#if]
         [/#if]
     [/#list]
@@ -103,4 +103,3 @@
     [#return state]
 
 [/#function]
-


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description
Adds support for overriding the default subset handling for the templateSubset specfically 

## Motivation and Context

When running the template subset the default subset value is an empty string except for resource sets which override this value to provide support for splitting out specific resources in template processing. This makes this option available to control in generation contract steps

Fixes a regression introduced in https://github.com/hamlet-io/engine/pull/1583

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

