### PR TITLE
feat: openapi http endpoints and fragment

### DIFF
--- a/providers/shared/extensions/extension.ftl
+++ b/providers/shared/extensions/extension.ftl
@@ -108,6 +108,13 @@
                 )]
 [/#macro]
 
+[#-- API Specific Macros --]
+[#macro OpenAPIDefinition content={} ]
+    [#assign _context += {
+        "OpenAPIDefinition" : mergeObjects((_context.OpenAPIDefinition)!{}, content )
+    }]
+[/#macro]
+
 [#-- Lambda Specific Macros --]
 [#macro lambdaAttributes
         imageBucket=""


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)


## Description

- Adds support for AWS VPC Links for apigateway as part of our openapi integration
- Adds the ability to provide openapi specification for an API as part of a fragment/ extension. This allows for providing or modifying a specification as part of a solution fragment or extension

## Motivation and Context

VPC link allows for private load balancers to be used for backends which are hosted within a VPC. This makes the apigateway the only way for the endpoint to be accessed outside of the VPC 

Setting schema through context allows for creating simple openapi specifications inside of fragment files and removes the need to create build jobs or modules to provide api spec.

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

