### PR TITLE
fix: fix device id for linked EBS volumes

### DIFF
--- a/providers/shared/extensions/extension.ftl
+++ b/providers/shared/extensions/extension.ftl
@@ -375,7 +375,7 @@
                 (_context.VolumeMounts!{}) +
                 {
                     volumeLinkId : {
-                        "DeviceId" : deviceId,
+                        "DeviceId" : "/dev/" + deviceId,
                         "MountPath" : mountPath
                     }
                 }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
Add "/dev/" prefix to DeviceId in DataVolumeMount macro.
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Specified DeviceId in macro goes without "/dev/" prefix, but when VolumeAttachment resource created, it is appended there.
In order to align the values, the DataVolumeMount macro needs to add a prefix to the specified deviceId. 
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Locally.
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

