### PR TITLE
refactor: add compute task for system volumes

### DIFF
--- a/providers/shared/components/id.ftl
+++ b/providers/shared/components/id.ftl
@@ -112,6 +112,7 @@
 [#assign REGION_ATTRIBUTE_TYPE = "region"]
 [#assign EVENTSTREAM_ATTRIBUTE_TYPE = "stream"]
 [#assign SECRET_ATTRIBUTE_TYPE = "secret"]
+[#assign RESULT_ATTRIBUTE_TYPE = "result" ]
 
 [#-- special attribute type to handle references --]
 [#assign REFERENCE_ATTRIBUTE_TYPE = "ref" ]

--- a/providers/shared/computetasks/computetask.ftl
+++ b/providers/shared/computetasks/computetask.ftl
@@ -66,13 +66,24 @@
     ]
 /]
 
+[#assign COMPUTE_TASK_SYSTEM_VOLUME_MOUNTING = "system_volume_mounting" ]
+[@addComputeTask
+    type=COMPUTE_TASK_SYSTEM_VOLUME_MOUNTING
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Handle the discovery, formatting and mounting of volumes configured as part of the component"
+        }
+    ]
+/]
+
 [#assign COMPUTE_TASK_DATA_VOLUME_MOUNTING = "data_volume_mounting" ]
 [@addComputeTask
     type=COMPUTE_TASK_DATA_VOLUME_MOUNTING
     properties=[
         {
             "Type"  : "Description",
-            "Value" : "Handle the discovery, formatting and mounting of data volumes"
+            "Value" : "Handle the discovery, formatting and mounting of links to datavolume components"
         }
     ]
 /]


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

Splits system volumes ( volumes defined as part of each instance ) from data volumes which are fixed volumes running as a standalone component

## Motivation and Context

Data mounts are only supported on fixed instance components like the ec2 component as autoscale groups would fight for the volume. Splitting this allows for ec2 to require data mounts and other component types to ignore them 

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

