### PR TITLE
feat(globaldb): define change stream support

### DIFF
--- a/providers/shared/components/globaldb/id.ftl
+++ b/providers/shared/components/globaldb/id.ftl
@@ -92,6 +92,24 @@
                         ]
                     }
                 ]
+            },
+            {
+                "Names" : "ChangeStream",
+                "Description" : "Provides a stream of changes made to the table",
+                "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "ChangeView",
+                        "Description" : "The format of changes that will be provided in the stream",
+                        "Types" : STRING_TYPE,
+                        "Values": [ "KeysOnly", "NewItem", "OldItem", "NewAndOldItem" ],
+                        "Default" : "KeysOnly"
+                    }
+                ]
             }
         ]
 /]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds a definition of change streams to the global db component. 

## Motivation and Context

When working with globaldbs its common to integrate them into event driven designs. The change stream provides a continuous stream of change notifications that a service can consume and perform actions on

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

