### PR TITLE
feat: adaptor attributes

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -1067,8 +1067,8 @@ behaviour.
 [#function writeFileForSync filesArrayName fileName content ]
     [#return
         [
-            'echo "${content}" > "$\{tmpdir}/${fileName}"',
-            'addToArray "${filesArrayName}" "$\{tmpdir}/${fileName}"'
+            r'echo "' + content + r'" > "${tmpdir}/' + fileName + r'"',
+            r'addToArray "' + filesArrayName + r'" "${tmpdir}/' + fileName + r'"'
         ]
     ]
 [/#function]
@@ -1153,14 +1153,14 @@ behaviour.
             ]
         ) +
         [
-            "cp" + " " +
+            r'if [[ -f "' + filepath + r'" ]]; then',
+            "  cp" + " " +
                "\"" + filepath                      + "\"" + " " +
                "\"" + "$\{tmpdir}/$\{tmp_filename}" + "\"" + " || return $?",
-            "#",
-            "addToArray" + " " +
+            "  addToArray" + " " +
                filesArrayName + " " +
                "\"" + "$\{tmpdir}/$\{tmp_filename}" + "\"",
-            "#"
+            r'fi'
         ] ]
 [/#function]
 

--- a/providers/shared/components/adaptor/id.ftl
+++ b/providers/shared/components/adaptor/id.ftl
@@ -69,6 +69,46 @@
                         ]
                     }
                 ]
+            },
+            {
+                "Names" : "Attributes",
+                "Description" : "Define attributes that should be included in the adaptor state",
+                "SubObjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "OutputAttributeType",
+                        "Description" : "The output type to map the attribute to",
+                        "Values" : [
+                            ARN_ATTRIBUTE_TYPE,
+                            URL_ATTRIBUTE_TYPE,
+                            DNS_ATTRIBUTE_TYPE,
+                            NAME_ATTRIBUTE_TYPE,
+                            IP_ADDRESS_ATTRIBUTE_TYPE,
+                            ALLOCATION_ATTRIBUTE_TYPE,
+                            CANONICAL_ID_ATTRIBUTE_TYPE,
+                            CERTIFICATE_ATTRIBUTE_TYPE,
+                            KEY_ATTRIBUTE_TYPE,
+                            QUALIFIER_ATTRIBUTE_TYPE,
+                            ROOT_ATTRIBUTE_TYPE,
+                            PORT_ATTRIBUTE_TYPE,
+                            USERNAME_ATTRIBUTE_TYPE,
+                            PASSWORD_ATTRIBUTE_TYPE,
+                            GENERATEDPASSWORD_ATTRIBUTE_TYPE,
+                            DATABASENAME_ATTRIBUTE_TYPE,
+                            TOPICNAME_ATTRIBUTE_TYPE,
+                            REPOSITORY_ATTRIBUTE_TYPE,
+                            BRANCH_ATTRIBUTE_TYPE,
+                            PREFIX_ATTRIBUTE_TYPE,
+                            LASTRESTORE_ATTRIBUTE_TYPE,
+                            REGION_ATTRIBUTE_TYPE,
+                            EVENTSTREAM_ATTRIBUTE_TYPE,
+                            SECRET_ATTRIBUTE_TYPE,
+                            RESULT_ATTRIBUTE_TYPE
+                        ],
+                        "Types" : STRING_TYPE,
+                        "Mandatory" : true
+                    }
+                ]
             }
         ]
 /]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Description

- Adds support for adaptors to have attributes based on the pseduo stack outputs created within the adaptor 
- Fixes an issue with the syntax of the sync file command 
- Adds a conditional on file copying to make sure that the file exists

## Motivation and Context

Attribute support allows for the adaptor to be integrated with other components that rely on attributes easily 

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

