### PR TITLE
feat(mobileapp): add support for image config

### DIFF
--- a/providers/shared/components/mobileapp/id.ftl
+++ b/providers/shared/components/mobileapp/id.ftl
@@ -44,6 +44,37 @@
                 "Description" : "Include the OTA Prefix in the OTA Url",
                 "Types" : BOOLEAN_TYPE,
                 "Default" : true
+            },
+            {
+                "Names" : "Image",
+                "Description" : "Control the source of the image for the mobile ota source zip image",
+                "Children" : [
+                    {
+                        "Names" : "Source",
+                        "Description" : "The source of the image - registry: the local hamlet registry - url: an external public url",
+                        "Types" : STRING_TYPE,
+                        "Mandatory" : true,
+                        "Values" : [ "registry", "url" ],
+                        "Default" : "registry"
+                    },
+                    {
+                        "Names" : "Source:url",
+                        "Description" : "Url Source specific Configuration",
+                        "Children" : [
+                            {
+                                "Names" : "Url",
+                                "Description" : "The Url to a zip file containing the mobile app source",
+                                "Types" : STRING_TYPE
+                            },
+                            {
+                                "Names" : "ImageHash",
+                                "Description" : "The expected sha1 hash of the Url if empty any will be accepted",
+                                "Types" : STRING_TYPE,
+                                "Default" : ""
+                            }
+                        ]
+                    }
+                ]
             }
         ]
 /]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds support for configuring the image source on mobile apps. Allows for Urls or the standard registry

## Motivation and Context

Implementation of #https://github.com/hamlet-io/engine/issues/1486 which allows for using external images for application components

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

