### PR TITLE
feat(datapipeline): image source configuration

### DIFF
--- a/providers/shared/components/datapipeline/id.ftl
+++ b/providers/shared/components/datapipeline/id.ftl
@@ -67,6 +67,37 @@
                             "Default" : "default"
                         }
                     ]
+            },
+            {
+                "Names" : "Image",
+                "Description" : "Control the source of the image for the mobile ota source zip image",
+                "Children" : [
+                    {
+                        "Names" : "Source",
+                        "Description" : "The source of the image - registry: the local hamlet registry - url: an external public url",
+                        "Types" : STRING_TYPE,
+                        "Mandatory" : true,
+                        "Values" : [ "registry", "url" ],
+                        "Default" : "registry"
+                    },
+                    {
+                        "Names" : "Source:url",
+                        "Description" : "Url Source specific Configuration",
+                        "Children" : [
+                            {
+                                "Names" : "Url",
+                                "Description" : "The Url to a zip file containing the mobile app source",
+                                "Types" : STRING_TYPE
+                            },
+                            {
+                                "Names" : "ImageHash",
+                                "Description" : "The expected sha1 hash of the Url if empty any will be accepted",
+                                "Types" : STRING_TYPE,
+                                "Default" : ""
+                            }
+                        ]
+                    }
+                ]
             }
         ]
 /]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds the ability to use an external url for datapipeline image sourcing 
Part of https://github.com/hamlet-io/engine/issues/1486

## Motivation and Context

This allows users to manage images outside of hamlet while still using our deployment process as required 

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

