### PR TITLE
feat(dataset): adds support for image config

### DIFF
--- a/providers/shared/components/dataset/id.ftl
+++ b/providers/shared/components/dataset/id.ftl
@@ -37,6 +37,37 @@
                 "Types" : ARRAY_OF_STRING_TYPE,
                 "Description" : "The environments used to build the dataset",
                 "Mandatory" : true
+            },
+            {
+                "Names" : "Image",
+                "Description" : "Control the source of the image for dataset components",
+                "Children" : [
+                    {
+                        "Names" : "Source",
+                        "Description" : "The source of the image - registry: the local hamlet registry - url: an external public url",
+                        "Types" : STRING_TYPE,
+                        "Mandatory" : true,
+                        "Values" : [ "registry", "url" ],
+                        "Default" : "registry"
+                    },
+                    {
+                        "Names" : "Source:url",
+                        "Description" : "Url Source specific Configuration",
+                        "Children" : [
+                            {
+                                "Names" : "Url",
+                                "Description" : "The Url to a zip file containing the mobile app source",
+                                "Types" : STRING_TYPE
+                            },
+                            {
+                                "Names" : "ImageHash",
+                                "Description" : "The expected sha1 hash of the Url if empty any will be accepted",
+                                "Types" : STRING_TYPE,
+                                "Default" : ""
+                            }
+                        ]
+                    }
+                ]
             }
         ]
 /]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds support for defining an external image for dataset components

## Motivation and Context

Allows for external management of images and aligns with https://github.com/hamlet-io/engine/issues/1486 

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

