### PR TITLE
feat: set SES inbound active ruleset

### DIFF
--- a/legacy/account/account_ses.ftl
+++ b/legacy/account/account_ses.ftl
@@ -1,42 +1,59 @@
 [#-- SES ruleset --]
 [#if getCLODeploymentUnit()?contains("sesruleset") || (groupDeploymentUnits!false) ]
     [#if deploymentSubsetRequired("generationcontract", false)]
-        [@addDefaultGenerationContract subsets="template" /]
+        [@addDefaultGenerationContract subsets=["template", "epilogue"] /]
     [/#if]
 
-    [#if deploymentSubsetRequired("sesruleset", true) ]
-        [@includeServicesConfiguration
-            provider=AWS_PROVIDER
-            services=[AWS_SIMPLE_EMAIL_SERVICE ]
-            deploymentFramework=getCLODeploymentFramework()
-        /]
+    [#if ! (accountObject["aws:SES"].RuleSet.Name)?has_content]
+        [@fatal message="The aws:SES.RuleSet.Name attribute is required in the account object" /]
+    [#else]
 
-        [#if (accountObject["aws:SES"].RuleSet.Name)?has_content]
+        [#if deploymentSubsetRequired("epilogue", false) ]
+            [@addToDefaultBashScriptOutput
+                content=
+                    [
+                        "case $\{STACK_OPERATION} in",
+                        "  create|update)",
+                        "   info \"Setting active rule set to " + accountObject["aws:SES"].RuleSet.Name + "\"",
+                        "   setActiveSESRuleSet" + " " +
+                            regionId + " " +
+                            accountObject["aws:SES"].RuleSet.Name + " || return $?"
+                        "   ;;",
+                        " esac"
+                    ]
+            /]
+        [/#if]
+
+        [#if deploymentSubsetRequired("sesruleset", true) ]
+            [@includeServicesConfiguration
+                provider=AWS_PROVIDER
+                services=[AWS_SIMPLE_EMAIL_SERVICE ]
+                deploymentFramework=getCLODeploymentFramework()
+            /]
+
             [@createSESReceiptRuleSet
                 id=formatSESReceiptRuleSetId()
                 name=accountObject["aws:SES"].RuleSet.Name
             /]
-        [#else]
-            [@fatal message="The aws:SES.RuleSet.Name attribute is required in the account object" /]
-        [/#if]
 
-        [#-- Add any required IP Address filtering --]
-        [#if getGroupCIDRs(accountObject["aws:SES"].IPAddressGroups, true, occurrence, true)]
-            [#list (getGroupCIDRs(accountObject["aws:SES"].IPAddressGroups, true, occurrence))?filter(cidr -> cidr?has_content) as cidr ]
+            [#-- Add any required IP Address filtering --]
+            [#if getGroupCIDRs(accountObject["aws:SES"].IPAddressGroups, true, occurrence, true)]
+                [#list (getGroupCIDRs(accountObject["aws:SES"].IPAddressGroups, true, occurrence))?filter(cidr -> cidr?has_content) as cidr ]
+                    [@createSESReceiptIPFilter
+                        id=formatSESReceiptFilterId(replaceAlphaNumericOnly(cidr,"X"))
+                        name=formatName("account", replaceAlphaNumericOnly(cidr,"-"))
+                        cidr=cidr
+                    /]
+                [/#list]
+
+                [#-- Add a default block all rule --]
                 [@createSESReceiptIPFilter
-                    id=formatSESReceiptFilterId(replaceAlphaNumericOnly(cidr,"X"))
-                    name=formatName("account", replaceAlphaNumericOnly(cidr,"-"))
-                    cidr=cidr
-                /]
-            [/#list]
-
-            [#-- Add a default block all rule --]
-            [@createSESReceiptIPFilter
-                    id=formatSESReceiptFilterId("0X0X0X0X0")
-                    name=formatName("account", "0-0-0-0-0")
-                    cidr="0.0.0.0/0"
-                    allow=false
-                /]
+                        id=formatSESReceiptFilterId("0X0X0X0X0")
+                        name=formatName("account", "0-0-0-0-0")
+                        cidr="0.0.0.0/0"
+                        allow=false
+                    /]
+            [/#if]
         [/#if]
     [/#if]
 [/#if]


### PR DESCRIPTION


## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Set the active inbound SES ruleset.

## Motivation and Context
Fixes https://github.com/hamlet-io/engine-plugin-aws/issues/318

While a ruleset can be created via cloud formation, setting which ruleset is active can only be done via the CLI.

## How Has This Been Tested?
Local template generation

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/executor-bash/pull/219

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

