### PR TITLE
feat: input qualification

### DIFF
--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -1757,6 +1757,23 @@ are not included in the Match Filter
     ]
 [/#function]
 
+[#function getEnrichedFilter filter enrichmentFilter]
+    [#local result = {} ]
+    [#list filter as id, value]
+        [#local result +=
+            {
+                id :
+                    getUniqueArrayElements(
+                        value,
+                        getFilterAttribute(enrichmentFilter, id)
+                    )
+            }
+        ]
+    [/#list]
+    [#return result]
+[/#function]
+
+
 [#-- Check for a match between a Current Filter and a Match Filter --]
 [#function filterMatch currentFilter matchFilter matchBehaviour]
 
@@ -1894,21 +1911,22 @@ is the equivalent of
     "Value" : 100,
     "Qualifiers : [
         {
-            "Filter" : {"Any" : "prod"},
-            "MatchBehaviour" : ANY_FILTER_MATCH_BEHAVIOUR,
-            "Value" : 50,
-            "CombineBehaviour" : MERGE_COMBINE_BEHAVIOUR
-        },
-        {
             "Filter" : {"Any" : "industry"},
             "MatchBehaviour" : ANY_FILTER_MATCH_BEHAVIOUR,
             "Value" : 23,
+            "CombineBehaviour" : MERGE_COMBINE_BEHAVIOUR
+        },
+        {
+            "Filter" : {"Any" : "prod"},
+            "MatchBehaviour" : ANY_FILTER_MATCH_BEHAVIOUR,
+            "Value" : 50,
             "CombineBehaviour" : MERGE_COMBINE_BEHAVIOUR
         }
     ]
 }
 
-and if both prod and industry matched, the effective value would be 23.
+and if both prod and industry matched, the effective value would be 50
+since "prod" comes after "industry".
 
 Qualifiers can be nested, so processing is recursive.
 --]

--- a/engine/inputdata/layer.ftl
+++ b/engine/inputdata/layer.ftl
@@ -154,6 +154,30 @@
     [/#list]
 [/#macro]
 
+[#function getLayerIdsAndNamesForFilter]
+    [#local result = {} ]
+    [#list layerConfiguration as id, layer ]
+        [#-- Only include layers where one of the input filter attributes --]
+        [#-- matches the layer type                                       --]
+        [#list asArray(layer.InputFilterAttributes) as inputFilterAttribute]
+            [#if layer.Type == inputFilterAttribute.Id]
+                [#local activeLayerData = getActiveLayer(layer.Type) ]
+                [#local idAndName =
+                    getUniqueArrayElements(
+                        arrayIfTrue(activeLayerData.Id!"", activeLayerData.Id??),
+                        arrayIfTrue(activeLayerData.Name!"", activeLayerData.Name??)
+                    )
+                ]
+                [#if idAndName?has_content]
+                    [#local result += { inputFilterAttribute.Id : idAndName } ]
+                [/#if]
+                [#break]
+            [/#if]
+        [/#list]
+    [/#list]
+    [#return result]
+[/#function]
+
 [#-------------------------------------------------------
 -- Internal support functions for component processing --
 ---------------------------------------------------------]

--- a/engine/logging.ftl
+++ b/engine/logging.ftl
@@ -324,6 +324,15 @@
     /]
 [/#macro]
 
+[#macro information message context={} detail={} enabled=true]
+    [@info
+        message=message
+        context=context
+        detail=detail
+        enabled=enabled
+    /]
+[/#macro]
+
 [#macro timing message context={} detail={} enabled=true]
     [@logMessage
         severity=TIMING_LOG_LEVEL
@@ -337,6 +346,15 @@
 [#macro warn message context={} detail={} enabled=true]
     [@logMessage
         severity=WARNING_LOG_LEVEL
+        message=message
+        context=context
+        detail=detail
+        enabled=enabled
+    /]
+[/#macro]
+
+[#macro warning message context={} detail={} enabled=true]
+    [@warn
         message=message
         context=context
         detail=detail
@@ -377,6 +395,16 @@
         /]
         [#stop "hamlet fatal log" ]
     [/#if]
+[/#macro]
+
+[#macro fatalstop message context={} detail={} enabled=true ]
+    [@fatal
+        message=message
+        context=context
+        detail=detail
+        enabled=enabled
+        stop=true
+    /]
 [/#macro]
 
 [#macro setLogFatalStopThreshold threshold ]

--- a/providers/shared/inputseeders/shared/id.ftl
+++ b/providers/shared/inputseeders/shared/id.ftl
@@ -50,12 +50,10 @@
     seeder=SHARED_INPUT_SEEDER
 /]
 
-[#-- TODO(mfl) Reenable once layers are in the input processing --]
-[#-- so the layer ids can be included in the qualifiers         --]
-[#--@addTransformerToConfigPipeline
+[@addTransformerToConfigPipeline
     stage=QUALIFY_SHARED_INPUT_STAGE
     transformer=SHARED_INPUT_SEEDER
-/--]
+/]
 
 [@addSeederToStatePipeline
     stage=FIXTURE_SHARED_INPUT_STAGE
@@ -612,11 +610,14 @@
 
 [#function shared_configtransformer_qualify filter state]
 
-    [#-- Now process the qualifications, validating on the basis of known layer filter attributes --]
+    [#-- Provided filter is enriched to include ids and names for any --]
+    [#-- layer related filter attribute                               --]
+    [#-- Qualifications are validated on the basis of known layer     --]
+    [#-- filter attributes                                            --]
     [#return
         qualifyEntity(
             state,
-            filter,
+            getEnrichedFilter(filter, getLayerIdsAndNamesForFilter()),
             getQualifierChildren(getRegisteredLayerInputFilterAttributeIds())
         )
     ]

--- a/providers/shared/inputseeders/shared/id.ftl
+++ b/providers/shared/inputseeders/shared/id.ftl
@@ -614,12 +614,13 @@
     [#-- layer related filter attribute                               --]
     [#-- Qualifications are validated on the basis of known layer     --]
     [#-- filter attributes                                            --]
+    [#local enrichedFilter = getEnrichedFilter(filter, getLayerIdsAndNamesForFilter()) ]
+    [#local qualifierChildren = getQualifierChildren(getRegisteredLayerInputFilterAttributeIds()) ]
     [#return
-        qualifyEntity(
-            state,
-            getEnrichedFilter(filter, getLayerIdsAndNamesForFilter()),
-            getQualifierChildren(getRegisteredLayerInputFilterAttributeIds())
-        )
+        qualifyEntity(state, enrichedFilter, qualifierChildren) +
+        {
+            "QualifierState" : qualifyEntity(state, enrichedFilter, qualifierChildren, "annotate")
+        }
     ]
 [/#function]
 


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Re-enable qualification as a step in input processing.

Fixes #1599 

## Motivation and Context
Support qualification across all forms of input. Reverses https://github.com/hamlet-io/engine/pull/1600

For backwards compatibility, ensure input qualification checks for ids and names of layers. Best practice should be to encourage the use of names and long form qualification but a number of existing cmdbs use ids and short form qualifiers.

This PR also adds some longer form alternatives for the `info` and `warn` macros, as well as an alternative `fatal` macro which always stops processing.

## How Has This Been Tested?
Local template generation.

## Related Changes

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- AWS - https://github.com/hamlet-io/engine-plugin-aws/pull/325
- Azure - https://github.com/hamlet-io/engine-plugin-azure/pull/260
- Engine - https://github.com/hamlet-io/engine/pull/1696

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

