### PR TITLE
refactor: remove explicit qualification support

### DIFF
--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -1243,7 +1243,7 @@ are added.
     [#return (configuration.Configured!false) && (configuration.Enabled!false) ]
 [/#function]
 
-[#function getObjectLineage collection end qualifiers...]
+[#function getObjectLineage collection end ]
     [#local result = [] ]
     [#local endingObject = "" ]
     [#list asFlattenedArray(end) as endEntry]
@@ -1261,7 +1261,6 @@ are added.
     [/#list]
 
     [#if endingObject?is_hash]
-        [#local base = getObjectAndQualifiers(endingObject, qualifiers) ]
         [#local parentId =
                 (getCompositeObject(
                     [
@@ -1270,7 +1269,7 @@ are added.
                             "Types" : STRING_TYPE
                         }
                     ],
-                    base
+                    endingObject
                 ).Parent)!"" ]
         [#local parentIds =
                 (getCompositeObject(
@@ -1280,18 +1279,18 @@ are added.
                             "Types" : ARRAY_OF_STRING_TYPE
                         }
                     ],
-                    base
+                    endingObject
                 ).Parents)!arrayIfContent(parentId, parentId) ]
 
         [#if parentIds?has_content]
             [#list parentIds as parentId]
-                [#local lines = getObjectLineage(collection, parentId, qualifiers) ]
+                [#local lines = getObjectLineage(collection, parentId) ]
                 [#list lines as line]
-                    [#local result += [ line + [base] ] ]
+                    [#local result += [ line + [endingObject] ] ]
                 [/#list]
             [/#list]
         [#else]
-            [#local result += [ [base] ] ]
+            [#local result += [ [endingObject] ] ]
         [/#if]
     [/#if]
     [#return result ]

--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -203,79 +203,6 @@
     [/#if]
 [/#function]
 
-[#-- Qualification support --
-
-A qualifier allows the value used for a part of a JSON document to vary depending on
-the context. An example might be varying settings depending on the current environment.
-If no qualifier applies, then a "default" value applies.
-
-Central to the operation of qualification is the idea of a filter. A filter consists of one or
-more values for each of one or more filter attributes. A "MatchBehaviour" is used to compare filters
-for a match.
-
-The current context is represented by the "Context Filter". It is managed dynamically during
-template processing, and contains values such as the current tenant, product, environment etc.
-
-Each qualifier has a filter and a value. If the filter matches the Context Filter,
-then the qualifier value is used to amend the default value which applies if no qualifier matches.
-More than one qualifier may match, in which case they are processed in the order they are defined,
-and the result of one match becomes the default for the next match.
-
-One way to think of filters is in terms of Venn Diagrams. Each filter defines a set of configuration
-entities and if the sets overlap based on the FilterBehaviour, then the qualifier applies. (A similar
-logic is applied for links, where the link filter needs to define a set containing a single,
-"component" configuration entity.)
-
-The way in which the default value is modified is controlled by the "DefaultBehaviour" of the
-qualifier. Typically this means simple values will be replaced and for objects,
-the default value is prefix added to the qualifier value.
-
-One or more qualifiers can be added at any point in the JSON document via a reserved "Qualifiers"
-entity. Where the qualified entity is not itself an object, the desired entity is
-wrapped in an object in order that qualifiers can be attached. In this case, the default value
-should be provided via a "Default" attribute at the same level as the "Qualifiers" attribute.
-
-There is a short form and a long form for qualifiers.
-
-In the short form, the "Qualifiers" entity is an object and each attribute represents a qualifier.
-The attribute name is the value of the filter "Any" attribute, and the MatchBehaviour is "any",
-meaning the value of the Any attribute needs to match one value in any of the attributes of the
-Context Filter. The qualifier value is the value of the attribute. Because object attribute
-processing is not ordered, the short form does not provide fine control in the situation where
-multiple qualifiers match - effectively they need to be independent.
-
-The short form is useful for simple situations such as setting variation based on environment.
-
-In the long form, the "Qualifiers" entity is an array of qualifier objects. Each qualifier object
-must have a "Filter" attribute and a "Value" attribute, as well as optional "MatchBehaviour" and
-"DefaultBehaviour" attributes. By default, the MatchBehaviour is "onetoone", meaning a value of
-each attribute of the qualifier filter must match a value of the same named attribute in the Context
-Filter.
-
-The long form gives full control over the qualification process, and allows ordering of qualifier
-application, depending on the DefaultBehaviour selected.
-
-Note that override (hierarchy) behaviour takes precedence over qualifier (at level variation)
-behaviour.
-
---]
-
-
-[#assign contextFilter = {} ]
-
-[#function getObjectAndQualifiers object qualifiers...]
-    [#local result = [] ]
-    [#if object?is_hash]
-        [#local result += [object] ]
-        [#list asFlattenedArray(qualifiers) as qualifier]
-            [#if ((object.Qualifiers[qualifier])!"")?is_hash]
-                [#local result += [object.Qualifiers[qualifier]] ]
-            [/#if]
-        [/#list]
-    [/#if]
-    [#return result ]
-[/#function]
-
 [#function getOccurrenceCoreTags occurrence={} name="" zone="" propagate=false flatten=false maxTagCount=-1]
     [#return getCfTemplateCoreTags(name, (occurrence.Core.Tier)!"", (occurrence.Core.Component)!"", zone, propagate, flatten, maxTagCount)]
 [/#function]
@@ -540,7 +467,7 @@ behaviour.
     }
 ]]
 
-[#function getPlacementProfile occurrenceProfile qualifiers...]
+[#function getPlacementProfile occurrenceProfile]
     [#local profile = occurrenceProfile]
     [#if !profile?has_content]
         [#local profile = (productObject.Profiles.Placement)!""]
@@ -552,13 +479,6 @@ behaviour.
         [#local profile = DEFAULT_PLACEMENT_PROFILE]
     [/#if]
 
-    [#if profile?is_hash]
-        [#list getObjectAndQualifiers(profile, qualifiers) as option]
-            [#if option.Value??]
-                [#local profile = option.Value]
-            [/#if]
-        [/#list]
-    [/#if]
     [#if profile?is_hash]
         [#local profile = ""]
     [/#if]
@@ -708,10 +628,10 @@ behaviour.
     [#return domainObject.Role == DOMAIN_ROLE_SECONDARY ]
 [/#function]
 
-[#function getDomainObjects certificateObject qualifiers...]
+[#function getDomainObjects certificateObject ]
     [#local result = [] ]
     [#local primaryNotSeen = true]
-    [#local lines = getObjectLineage(domains, certificateObject.Domain, qualifiers) ]
+    [#local lines = getObjectLineage(domains, certificateObject.Domain) ]
     [#list lines as line]
         [#local name = "" ]
         [#local role = DOMAIN_ROLE_PRIMARY ]
@@ -793,17 +713,17 @@ behaviour.
     [#return result]
 [/#function]
 
-[#function getCertificateObject start qualifiers...]
+[#function getCertificateObject start ]
 
     [#local certificateObject =
         getCompositeObject(
             certificateChildConfiguration,
             asFlattenedArray(
-                getObjectAndQualifiers((blueprintObject.CertificateBehaviours)!{}, qualifiers) +
-                getObjectAndQualifiers((tenantObject.CertificateBehaviours)!{}, qualifiers) +
-                getObjectAndQualifiers((productObject.CertificateBehaviours)!{}, qualifiers) +
-                ((getObjectLineage(certificates, [productId, productName], qualifiers)[0])![]) +
-                ((getObjectLineage(certificates, start, qualifiers)[0])![])
+                arrayIfContent((blueprintObject.CertificateBehaviours)!{}, (blueprintObject.CertificateBehaviours)!{}) +
+                arrayIfContent((tenantObject.CertificateBehaviours)!{}, (tenantObject.CertificateBehaviours)!{}) +
+                arrayIfContent((productObject.CertificateBehaviours)!{}, (productObject.CertificateBehaviours)!{}) +
+                ((getObjectLineage(certificates, [productId, productName])[0])![]) +
+                ((getObjectLineage(certificates, start)[0])![])
             )
         )
     ]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -25,7 +25,6 @@
     [#assign shortNamePrefixes = [] ]
     [#assign fullNamePrefixes = [] ]
     [#assign cmdbProductLookupPrefixes = [] ]
-    [#assign segmentQualifiers = [] ]
 
     [#-- Testing --]
     [#assign testCases = getReferenceData(TESTCASE_REFERENCE_TYPE) ]
@@ -165,7 +164,6 @@
         [#assign shortNamePrefixes += [productId] ]
         [#assign fullNamePrefixes += [productName] ]
         [#assign cmdbProductLookupPrefixes += ["shared"] ]
-        [#assign segmentQualifiers += [productName, productId] ]
 
     [/#if]
 
@@ -194,7 +192,6 @@
                 categories[categoryId]!{} ]
             [#assign shortNamePrefixes += [environmentId] ]
             [#assign fullNamePrefixes += [environmentName] ]
-            [#assign segmentQualifiers += [environmentId, environmentName, segmentId, segmentName] ]
 
             [#assign cmdbProductLookupPrefixes +=
                 [

--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -425,7 +425,7 @@
                             occurrenceContexts).Profiles ]
 
                     [#-- Determine placement profile --]
-                    [#local placementProfile = getPlacementProfile(profiles.Placement, segmentQualifiers) ]
+                    [#local placementProfile = getPlacementProfile(profiles.Placement) ]
 
                     [#-- Add resource group placements to the occurrence --]
                     [#list getComponentResourceGroups(type)?keys as key]
@@ -650,7 +650,7 @@
             coreProfileChildConfiguration).Profiles ]
 
     [#-- Determine placement profile --]
-    [#local placementProfile = getPlacementProfile(profiles.Placement, segmentQualifiers) ]
+    [#local placementProfile = getPlacementProfile(profiles.Placement) ]
 
     [#-- Add state attributes for basestate lookup --]
     [#local targetOccurrence +=


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Remove explicit handling of qualification as it is now performed by the input pipeline.

## Motivation and Context
- simplify overall code base by isolating qualification to one place
- make qualification available on any config in the cmdb
- qualification is recursive so the value of one qualifier can itself contain further qualification 

## How Has This Been Tested?
Local template generation

## Related Changes

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- AWS - https://github.com/hamlet-io/engine-plugin-aws/pull/325
- Azure - https://github.com/hamlet-io/engine-plugin-azure/pull/260

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

