### PR TITLE
feat(ecs): extend placement strategy support

### DIFF
--- a/providers/shared/attributesets/attributeset.ftl
+++ b/providers/shared/attributesets/attributeset.ftl
@@ -4,6 +4,8 @@
 
 [#assign COMPUTEIMAGE_ATTRIBUTESET_TYPE = "computeimage"]
 
+[#assign CONTTAINERTASK_ATTRIBUTESET_TYPE = "containertask"]
+
 [#assign CONTEXTPATH_ATTRIBUTESET_TYPE = "contextpath"]
 
 [#assign ECS_COMPUTEIMAGE_ATTRIBUTESET_TYPE = "ecs_computeimage"]

--- a/providers/shared/attributesets/containertask/id.ftl
+++ b/providers/shared/attributesets/containertask/id.ftl
@@ -1,0 +1,179 @@
+[#ftl]
+
+[@addAttributeSet
+    type=CONTTAINERTASK_ATTRIBUTESET_TYPE
+    pluralType="ContainerTasks"
+    properties=[
+        {
+                "Type"  : "Description",
+                "Value" : "Descirbes each container that will be used as part of a service or task"
+        }
+    ]
+    attributes=[
+        {
+            "Names" : [ "Extensions", "Fragment", "Container" ],
+            "Description" : "Extensions to invoke as part of component processing",
+            "Types" : ARRAY_OF_STRING_TYPE,
+            "Default" : []
+        },
+        {
+            "Names" : "Cpu",
+            "Types" : NUMBER_TYPE,
+            "Default" : ""
+        },
+        {
+            "Names" : "Links",
+            "SubObjects": true,
+            "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+        },
+        {
+            "Names" : "LocalLogging",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : false
+        },
+        {
+            "Names" : "LogDriver",
+            "Types" : STRING_TYPE,
+            "Values" : ["awslogs", "json-file", "fluentd"],
+            "Default" : "awslogs"
+        },
+        {
+            "Names" : "LogMetrics",
+            "SubObjects" : true,
+            "Children" : logMetricChildrenConfiguration
+        },
+        {
+            "Names" : "Alerts",
+            "SubObjects" : true,
+            "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
+        },
+        {
+            "Names" : "ContainerLogGroup",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : false
+        },
+        {
+            "Names" : "RunCapabilities",
+            "Types" : ARRAY_OF_STRING_TYPE,
+            "Default" : []
+        },
+        {
+            "Names" : "Privileged",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : false
+        },
+        {
+            "Names" : ["MaximumMemory", "MemoryMaximum", "MaxMemory"],
+            "Types" : NUMBER_TYPE,
+            "Description" : "Set to 0 to not set a maximum"
+        },
+        {
+            "Names" : ["MemoryReservation", "Memory", "ReservedMemory"],
+            "Types" : NUMBER_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Ports",
+            "SubObjects" : true,
+            "Children" : [
+                "Container",
+                {
+                    "Names" : "DynamicHostPort",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Names" : "LB",
+                    "Children" : lbChildConfiguration
+                },
+                {
+                    "Names" : "Registry",
+                    "Children" : srvRegChildConfiguration
+                },
+                {
+                    "Names" : "IPAddressGroups",
+                    "Types" : ARRAY_OF_STRING_TYPE,
+                    "Default" : []
+                }
+            ]
+        },
+        {
+            "Names" : "Image",
+            "Description" : "Set the source of the components image",
+            "Children" : [
+                {
+                    "Names" : "Source",
+                    "Description" : "The source of the image",
+                    "Types" : STRING_TYPE,
+                    "Mandatory" : true,
+                    "Values" : [ "registry", "containerregistry" ],
+                    "Default" : "Registry"
+                },
+                {
+                    "Names" : "Source:containerregistry",
+                    "Description" : "A docker container registry to source the image from",
+                    "Children" : [
+                        {
+                            "Names" : "Image",
+                            "Description" : "The docker image that you want to use",
+                            "Types" : STRING_TYPE
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "Names" : "Version",
+            "Types" : STRING_TYPE,
+            "Description" : "Override the version from the deployment unit",
+            "Default" : ""
+        },
+        {
+            "Names" : "ContainerNetworkLinks",
+            "Types" : ARRAY_OF_STRING_TYPE,
+            "Default" : []
+        }
+        {
+            "Names" : "Profiles",
+            "Children" :
+                [
+                    {
+                        "Names" : "Alert",
+                        "Types" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
+        },
+        {
+            "Names" : "RunMode",
+            "Description" : "A per container setting which can be used by the app to determine run mode for a container in a task - defaults to the second half of a dash separated id",
+            "Types" : STRING_TYPE,
+            "Default" : ""
+        },
+        {
+            "Names" : "Ulimits",
+            "Description" : "Linux OS based limits for the container",
+            "SubObjects" : true,
+            "Children" : [
+                {
+                    "Names" : "Name",
+                    "Description" : "The name of the ulimit to apply",
+                    "Types" : STRING_TYPE,
+                    "Mandatory" : true
+                },
+                {
+                    "Names" : "HardLimit",
+                    "Description" : "The OS level hard limit to apply",
+                    "Types" : NUMBER_TYPE,
+                    "Default" : 1024
+                },
+                {
+                    "Names" : "SoftLimit",
+                    "Description" : "The User level limit to apply",
+                    "Types" : NUMBER_TYPE,
+                    "Default" : 1024
+                }
+            ]
+        }
+    ]
+/]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -848,174 +848,6 @@
     }
 ]]
 
-[#assign containerChildrenConfiguration = [
-    {
-        "Names" : [ "Extensions", "Fragment", "Container" ],
-        "Description" : "Extensions to invoke as part of component processing",
-        "Types" : ARRAY_OF_STRING_TYPE,
-        "Default" : []
-    },
-    {
-        "Names" : "Cpu",
-        "Types" : NUMBER_TYPE,
-        "Default" : ""
-    },
-    {
-        "Names" : "Links",
-        "SubObjects": true,
-        "AttributeSet" : LINK_ATTRIBUTESET_TYPE
-    },
-    {
-        "Names" : "LocalLogging",
-        "Types" : BOOLEAN_TYPE,
-        "Default" : false
-    },
-    {
-        "Names" : "LogDriver",
-        "Types" : STRING_TYPE,
-        "Values" : ["awslogs", "json-file", "fluentd"],
-        "Default" : "awslogs"
-    },
-    {
-        "Names" : "LogMetrics",
-        "SubObjects" : true,
-        "Children" : logMetricChildrenConfiguration
-    },
-    {
-        "Names" : "Alerts",
-        "SubObjects" : true,
-        "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
-    },
-    {
-        "Names" : "ContainerLogGroup",
-        "Types" : BOOLEAN_TYPE,
-        "Default" : false
-    },
-    {
-        "Names" : "RunCapabilities",
-        "Types" : ARRAY_OF_STRING_TYPE,
-        "Default" : []
-    },
-    {
-        "Names" : "Privileged",
-        "Types" : BOOLEAN_TYPE,
-        "Default" : false
-    },
-    {
-        "Names" : ["MaximumMemory", "MemoryMaximum", "MaxMemory"],
-        "Types" : NUMBER_TYPE,
-        "Description" : "Set to 0 to not set a maximum"
-    },
-    {
-        "Names" : ["MemoryReservation", "Memory", "ReservedMemory"],
-        "Types" : NUMBER_TYPE,
-        "Mandatory" : true
-    },
-    {
-        "Names" : "Ports",
-        "SubObjects" : true,
-        "Children" : [
-            "Container",
-            {
-                "Names" : "DynamicHostPort",
-                "Types" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Names" : "LB",
-                "Children" : lbChildConfiguration
-            },
-            {
-                "Names" : "Registry",
-                "Children" : srvRegChildConfiguration
-            },
-            {
-                "Names" : "IPAddressGroups",
-                "Types" : ARRAY_OF_STRING_TYPE,
-                "Default" : []
-            }
-        ]
-    },
-    {
-        "Names" : "Image",
-        "Description" : "Set the source of the components image",
-        "Children" : [
-            {
-                "Names" : "Source",
-                "Description" : "The source of the image",
-                "Types" : STRING_TYPE,
-                "Mandatory" : true,
-                "Values" : [ "registry", "containerregistry" ],
-                "Default" : "Registry"
-            },
-            {
-                "Names" : "Source:containerregistry",
-                "Description" : "A docker container registry to source the image from",
-                "Children" : [
-                    {
-                        "Names" : "Image",
-                        "Description" : "The docker image that you want to use",
-                        "Types" : STRING_TYPE
-                    }
-                ]
-            }
-        ]
-    },
-    {
-        "Names" : "Version",
-        "Types" : STRING_TYPE,
-        "Description" : "Override the version from the deployment unit",
-        "Default" : ""
-    },
-    {
-        "Names" : "ContainerNetworkLinks",
-        "Types" : ARRAY_OF_STRING_TYPE,
-        "Default" : []
-    }
-    {
-        "Names" : "Profiles",
-        "Children" :
-            [
-                {
-                    "Names" : "Alert",
-                    "Types" : STRING_TYPE,
-                    "Default" : "default"
-                }
-            ]
-    },
-    {
-        "Names" : "RunMode",
-        "Description" : "A per container setting which can be used by the app to determine run mode for a container in a task - defaults to the second half of a dash separated id",
-        "Types" : STRING_TYPE,
-        "Default" : ""
-    },
-    {
-        "Names" : "Ulimits",
-        "Description" : "Linux OS based limits for the container",
-        "SubObjects" : true,
-        "Children" : [
-            {
-                "Names" : "Name",
-                "Description" : "The name of the ulimit to apply",
-                "Types" : STRING_TYPE,
-                "Mandatory" : true
-            },
-            {
-                "Names" : "HardLimit",
-                "Description" : "The OS level hard limit to apply",
-                "Types" : NUMBER_TYPE,
-                "Default" : 1024
-            },
-            {
-                "Names" : "SoftLimit",
-                "Description" : "The User level limit to apply",
-                "Types" : NUMBER_TYPE,
-                "Default" : 1024
-            }
-        ]
-    }
-]]
-
 [#assign containerHostAttributes = [
     {
         "Names" : [ "Extensions", "Fragment", "Container" ],
@@ -1255,7 +1087,7 @@
     {
         "Names" : "Containers",
         "SubObjects" : true,
-        "Children" : containerChildrenConfiguration
+        "AttributeSet" : CONTTAINERTASK_ATTRIBUTESET_TYPE
     },
     {
         "Names" : "DesiredCount",
@@ -1327,10 +1159,17 @@
         "Children" : [
             {
                 "Names" : "Strategy",
-                "Types" : STRING_TYPE,
-                "Values" : [ "", "daemon"],
+                "Types" : ARRAY_OF_STRING_TYPE,
+                "Values" : [
+                    "spread-multiAZ",
+                    "spread-instance",
+                    "binpack-cpu",
+                    "binpack-memory",
+                    "daemon",
+                    "random"
+                ],
                 "Description" : "How to place containers on the cluster",
-                "Default" : ""
+                "Default" : []
             },
             {
                 "Names" : "DistinctInstance",
@@ -1433,7 +1272,7 @@
     {
         "Names" : "Containers",
         "SubObjects" : true,
-        "Children" : containerChildrenConfiguration
+        "AttributeSet" : CONTTAINERTASK_ATTRIBUTESET_TYPE
     },
     {
         "Names" : "UseTaskRole",


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Extends ecs placement strategies to support different possible options and makes the strategy a list to allow for using multiple strategies combined 
- moves the container definition to an attribute set to highlight consistency and align with new approaches

## Motivation and Context

This provides flexibility in defining host container hosts are chosen and can be useful when reducing costs vs ensuring redundancy 

## How Has This Been Tested?

Tested on development deployment 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

