### PR TITLE
feat: add management port configuration to compute

### DIFF
--- a/providers/shared/components/bastion/id.ftl
+++ b/providers/shared/components/bastion/id.ftl
@@ -104,6 +104,12 @@
                 "Description" : "Configuration of compute instances used in the component",
                 "Children" : [
                     {
+                        "Names" : "ManagementPorts",
+                        "Description" : "The network ports used for remote management of the instance",
+                        "Types" : ARRAY_OF_STRING_TYPE,
+                        "Default" : [ "ssh" ]
+                    },
+                    {
                         "Names" : "Image",
                         "Description" : "Configures the source of the virtual machine image used for the instance",
                         "AttributeSet" : COMPUTEIMAGE_ATTRIBUTESET_TYPE

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1040,6 +1040,12 @@
         "Description" : "Configuration of compute instances used in the component",
         "Children" : [
             {
+                "Names" : "ManagementPorts",
+                "Description" : "The network ports used for remote management of the instance",
+                "Types" : ARRAY_OF_STRING_TYPE,
+                "Default" : [ "ssh" ]
+            },
+            {
                 "Names" : "Image",
                 "Description" : "Configures the source of the virtual machine image used for the instance",
                 "AttributeSet" : ECS_COMPUTEIMAGE_ATTRIBUTESET_TYPE

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -138,6 +138,12 @@
                 "Description" : "Configuration of compute instances used in the component",
                 "Children" : [
                     {
+                        "Names" : "ManagementPorts",
+                        "Description" : "The network ports used for remote management of the instance",
+                        "Types" : ARRAY_OF_STRING_TYPE,
+                        "Default" : [ "ssh" ]
+                    },
+                    {
                         "Names" : "Image",
                         "Description" : "Configures the source of the virtual machine image used for the instance",
                         "AttributeSet" : COMPUTEIMAGE_ATTRIBUTESET_TYPE

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -110,9 +110,21 @@
                 "Default" : ""
             },
             {
+                "Names" : "StartupTimeout",
+                "Types" : NUMBER_TYPE,
+                "Description" : "The time in seconds to wait for startup configuration to complete",
+                "Default" : 300
+            },
+            {
                 "Names" : "ComputeInstance",
                 "Description" : "Configuration of compute instances used in the component",
                 "Children" : [
+                    {
+                        "Names" : "ManagementPorts",
+                        "Description" : "The network ports used for remote management of the instance",
+                        "Types" : ARRAY_OF_STRING_TYPE,
+                        "Default" : [ "ssh" ]
+                    },
                     {
                         "Names" : "Image",
                         "Description" : "Configures the source of the virtual machine image used for the instance",


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds the ability to configure the management ports for instances deployed as part of components. This accommodates other instance types or OS types that don't just use ssh
- Adds the ability to configure the startup timeout for ec2 provisioning 
- 
## Motivation and Context

Extend the support for other operating systems including windows which uses RDP instead of ssh for management

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

