### PR TITLE
refactor: standardise profile lookups

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -210,7 +210,7 @@
 [#-- Get processor settings --]
 [#function getOccurrenceProfile occurrence solutionProfilesKey profileReferenceType profileNameOverride="" type="" ]
     [#local profileName = (profileNameOverride?has_content)?then(
-                                    proceprofileNameOverridessorProfileName,
+                                    profileNameOverride,
                                     (occurrence.Configuration.Solution.Profiles[solutionProfilesKey])!"default"
                                 )]
 

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -37,12 +37,6 @@
     [#-- Categories --]
     [#assign categories = getReferenceData(CATEGORY_REFERENCE_TYPE) ]
 
-    [#-- Storage Profiles --]
-    [#assign storage = getReferenceData(STORAGE_REFERENCE_TYPE) ]
-
-    [#-- Processor Profiles --]
-    [#assign processors = getReferenceData(PROCESSOR_REFERENCE_TYPE) ]
-
     [#-- ComputeProvider Profiles --]
     [@addReferenceData type=COMPUTEPROVIDER_REFERENCE_TYPE base=blueprintObject /]
 
@@ -58,9 +52,6 @@
     [#-- Log File Groups --]
     [#assign logFileGroups = getReferenceData(LOGFILEGROUP_REFERENCE_TYPE) ]
 
-    [#-- Log File Profiles --]
-    [#assign logFileProfiles = getReferenceData(LOGFILEPROFILE_REFERENCE_TYPE) ]
-
     [#-- CORS Profiles --]
     [#assign CORSProfiles = getReferenceData(CORSPROFILE_REFERENCE_TYPE) ]
 
@@ -70,20 +61,11 @@
     [#-- Bootstraps --]
     [#assign bootstraps = getReferenceData(BOOTSTRAP_REFERENCE_TYPE, true) ]
 
-    [#-- Bootstrap Profiles--]
-    [#assign bootstrapProfiles = getReferenceData(BOOTSTRAPPROFILE_REFERENCE_TYPE, true) ]
-
-    [#-- Security Profiles --]
-    [#assign securityProfiles = getReferenceData(SECURITYPROFILE_REFERENCE_TYPE) ]
-
-    [#-- Network Profiles --]
-    [#assign networkProfiles = getReferenceData(NETWORKPROFILE_REFERENCE_TYPE) ]
+    [#-- Log Filters --]
+    [#assign logFilters = getReferenceData(LOGFILTER_REFERENCE_TYPE) ]
 
     [#-- Baseline Profiles --]
     [#assign baselineProfiles = getReferenceData(BASELINEPROFILE_REFERENCE_TYPE) ]
-
-    [#-- Log Filters --]
-    [#assign logFilters = getReferenceData(LOGFILTER_REFERENCE_TYPE) ]
 
     [#-- Network Endpoint Groups --]
     [#assign networkEndpointGroups = getReferenceData(NETWORKENDPOINTGROUP_REFERENCE_TYPE) ]

--- a/providers/shared/components/bastion/id.ftl
+++ b/providers/shared/components/bastion/id.ftl
@@ -59,6 +59,19 @@
                         },
                         {
                             "Names" : "Logging",
+                            "Description" : "A profile to define where logs are forwarded to from this component",
+                            "Types" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
+                            "Names" : "LogFile",
+                            "Description" : "A profile which specifies the logfiles to collect from the compute instance",
+                            "Types" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
+                            "Names" : "Bootstrap",
+                            "Description" : "A profile to include additional bootstrap sources as part of the instance startup",
                             "Types" : STRING_TYPE,
                             "Default" : "default"
                         }

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -913,6 +913,19 @@
                 },
                 {
                     "Names" : "Logging",
+                    "Description" : "profile to define where logs are forwarded to from this component",
+                    "Types" : STRING_TYPE,
+                    "Default" : "default"
+                },
+                {
+                    "Names" : "LogFile",
+                    "Description" : "Defines the logfile profile which sets the log files to collect from the compute instance",
+                    "Types" : STRING_TYPE,
+                    "Default" : "default"
+                },
+                {
+                    "Names" : "Bootstrap",
+                    "Description" : "A profile to include additional bootstrap sources as part of the instance startup",
                     "Types" : STRING_TYPE,
                     "Default" : "default"
                 }

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -48,6 +48,19 @@
                         },
                         {
                             "Names" : "Logging",
+                            "Description" : "profile to define where logs are forwarded to from this component",
+                            "Types" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
+                            "Names" : "LogFile",
+                            "Description" : "Defines the logfile profile which sets the log files to collect from the compute instance",
+                            "Types" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
+                            "Names" : "Bootstrap",
+                            "Description" : "A profile to include additional bootstrap sources as part of the instance startup",
                             "Types" : STRING_TYPE,
                             "Default" : "default"
                         }

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -58,6 +58,19 @@
                         },
                         {
                             "Names" : "Logging",
+                            "Description" : "profile to define where logs are forwarded to from this component",
+                            "Types" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
+                            "Names" : "LogFile",
+                            "Description" : "Defines the logfile profile which sets the log files to collect from the compute instance",
+                            "Types" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
+                            "Names" : "Bootstrap",
+                            "Description" : "A profile to include additional bootstrap sources as part of the instance startup",
                             "Types" : STRING_TYPE,
                             "Default" : "default"
                         }


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

- Adds a standard function and process for looking up profiles assigned to components

Profiles essentially have two lookup configurations
- Typed: which breaks the profile into typed sections within a profile. This is generally based on the component type or the tier component name of a component
- Explicit: which applies the same profile to all components

The generic function supports both types and uses the lookup process to find the appropriate profile

- Adds some additional profiles found during this update to the ec2 components
- Removes some of the global variables from setContext to reduce the scoping issues with global vars

## Motivation and Context

When working with profiles it was difficult to figure out where they were used and how they could be modified. This creates standard ways to configure profiles to make this easier

## How Has This Been Tested?

Tested locally and with test suite

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- https://github.com/hamlet-io/engine-plugin-aws/pull/330
- https://github.com/hamlet-io/engine-plugin-azure/pull/261

### Consumer Actions:

- None

