### PR TITLE
fix: getDomainObjects parameters

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -730,7 +730,7 @@
     [#return
         certificateObject +
         {
-            "Domains" : getDomainObjects(certificateObject, qualifiers)
+            "Domains" : getDomainObjects(certificateObject)
         }
     ]
 [/#function]


### PR DESCRIPTION

## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Correct call to `getDomainObjects` to remove qualifier support.

## Motivation and Context
Tests failing

## How Has This Been Tested?
Should have been detected as part of testing https://github.com/hamlet-io/engine/pull/1696.
AWS test suite run locally and confiurmed that exception no longer being raised.


## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

