### PR TITLE
fix: handle missing profiles

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -209,10 +209,26 @@
 
 [#-- Get processor settings --]
 [#function getOccurrenceProfile occurrence solutionProfilesKey profileReferenceType profileNameOverride="" type="" ]
-    [#local profileName = (profileNameOverride?has_content)?then(
-                                    profileNameOverride,
-                                    (occurrence.Configuration.Solution.Profiles[solutionProfilesKey])!"default"
-                                )]
+    [#local profileName = ""]
+    [#if profileNameOverride?has_content]
+        [#local profileName = profileNameOverride ]
+    [/#if]
+
+    [#if ! profileName?has_content ]
+        [#if ((occurrence.Configuration.Solution.Profiles[solutionProfilesKey])!"")?has_content ]
+            [#local profileName = occurrence.Configuration.Solution.Profiles[solutionProfilesKey] ]
+        [#else]
+            [@fatal
+                message="Could not find profile name to use for lookup"
+                context={
+                    "OccurrenceId" : (occurrence.Core.RawId)!"",
+                    "ProfileKey" : solutionProfilesKey,
+                    "NameOverride" : profileNameOverride,
+                    "Type" : type
+                }
+            /]
+        [/#if]
+    [/#if]
 
     [#local profile = (getReferenceData(profileReferenceType)[profileName])!{} ]
 


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description
Adds fatal exception handling for profiles that cannot be found instead of falling to a default. This provides better feedback in development and for users

## Motivation and Context

This change makes profile handling more robust and also provides feedback to users 

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

