### PR TITLE
chore: disable jenkins build of hamlet container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,19 +55,6 @@ pipeline {
                 '''
             }
         }
-
-        stage('Trigger Docker Build') {
-            when {
-                branch 'master'
-            }
-
-            steps {
-                build (
-                    job: '../docker-hamlet/master',
-                    wait: false
-                )
-            }
-        }
     }
 
     post {


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Disable the triggering of the (now missing) hamlet docker container build.


## Motivation and Context
The build is now being done via github actions and the trigger attempt is throwing errors to slack following each commit.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

