### PR TITLE
fix: merge config from input seeders by default

### DIFF
--- a/engine/inputdata/inputsource.ftl
+++ b/engine/inputdata/inputsource.ftl
@@ -803,8 +803,7 @@ which is useful in situations like link processing.
                     result,
                     {
                         class : state[CONFIG_INPUT_PIPELINE_STAGE_CACHE][stage][class]
-                    },
-                    APPEND_COMBINE_BEHAVIOUR
+                    }
                 )
             ]
         [/#if]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

removes an append configuration applied on the input pipeline cache that was causing issues with blueprint merging when arrays are used

## Motivation and Context

When adding solution configuration which overrides a masterdata array the arrays were combined instead of merged/replaced

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

