### PR TITLE
refactor: set explicit typed profile attributes

### DIFF
--- a/providers/shared/attributesets/attributeset.ftl
+++ b/providers/shared/attributesets/attributeset.ftl
@@ -15,3 +15,5 @@
 [#assign OPERATINGSYSTEM_ATTRIBUTESET_TYPE = "operatingsystem" ]
 
 [#assign OSPATCHING_ATTRIBUTESET_TYPE = "ospatching"]
+
+[#assign VOLUME_ATTRIBUTESET_TYPE = "volume"]

--- a/providers/shared/attributesets/volume/id.ftl
+++ b/providers/shared/attributesets/volume/id.ftl
@@ -1,0 +1,41 @@
+[#ftl]
+
+[@addAttributeSet
+    type=VOLUME_ATTRIBUTESET_TYPE
+    pluralType="Volumes"
+    properties=[
+        {
+                "Type"  : "Description",
+                "Value" : "Defines the standard configuration of a storage volume"
+        }]
+    attributes=[
+        {
+            "Names" : "Device",
+            "Description" : "The deivce Id of the volume where the disk will be attached",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "MountPath",
+            "Description" : "An OS path where the disk will be mounted",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "Size",
+            "Description" : "The size in GB of the volume",
+            "Types" : NUMBER_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names":  "Type",
+            "Description" : "The type of volume to provision - see provider for available types",
+            "Types" : STRING_TYPE,
+            "Default" : "gp2"
+        },
+        {
+            "Names" : "Iops",
+            "Description" : "For volume types which support provisioned IOPS, this sets the requested IOPS",
+            "Types" : NUMBER_TYPE
+        }
+    ]
+/]

--- a/providers/shared/references/BootstrapProfile/id.ftl
+++ b/providers/shared/references/BootstrapProfile/id.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[@addReference 
+[@addReference
     type=BOOTSTRAPPROFILE_REFERENCE_TYPE
     pluralType="BootstrapProfiles"
     properties=[
@@ -11,13 +11,46 @@
         ]
     attributes=[
         {
-            "Names" : "*",
+            "Names" : ["bastion", "Bastion", "ssh"],
             "Description" : "The component type the profile applies to",
             "Children" : [
                 {
-                    "Names" : "Bootstraps",
+                    "Names" : "BootStraps",
                     "Types" : ARRAY_OF_STRING_TYPE,
-                    "Mandatory" : true
+                    "Default" : []
+                }
+            ]
+        },
+        {
+            "Names" : ["computecluster", "ComputeCluster"],
+            "Description" : "The component type the profile applies to",
+            "Children" : [
+                {
+                    "Names" : "BootStraps",
+                    "Types" : ARRAY_OF_STRING_TYPE,
+                    "Default" : []
+                }
+            ]
+        },
+        {
+            "Names" : ["ec2", "EC2" ],
+            "Description" : "The component type the profile applies to",
+            "Children" : [
+                {
+                    "Names" : "BootStraps",
+                    "Types" : ARRAY_OF_STRING_TYPE,
+                    "Default" : []
+                }
+            ]
+        },
+        {
+            "Names" : ["ecs", "ECS"],
+            "Description" : "The component type the profile applies to",
+            "Children" : [
+                {
+                    "Names" : "BootStraps",
+                    "Types" : ARRAY_OF_STRING_TYPE,
+                    "Default" : []
                 }
             ]
         }

--- a/providers/shared/references/LogFileProfile/id.ftl
+++ b/providers/shared/references/LogFileProfile/id.ftl
@@ -1,17 +1,47 @@
 [#ftl]
 
-[@addReference 
+[@addReference
     type=LOGFILEPROFILE_REFERENCE_TYPE
     pluralType="LogFileProfiles"
     properties=[
             {
                 "Type"  : "Description",
-                "Value" : "A collectio of log file groups based on component type" 
+                "Value" : "A collectio of log file groups based on component type"
             }
         ]
     attributes=[
         {
-            "Names" : "*",
+            "Names" : ["bastion", "ssh", "Bastion"],
+            "Description" : "The component type the profile applies to",
+            "Children" : [
+                {
+                    "Names" : "LogFileGroups",
+                    "Types" : ARRAY_OF_STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : ["computecluster", "ComputeCluster"],
+            "Description" : "The component type the profile applies to",
+            "Children" : [
+                {
+                    "Names" : "LogFileGroups",
+                    "Types" : ARRAY_OF_STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : ["ec2", "EC2"],
+            "Description" : "The component type the profile applies to",
+            "Children" : [
+                {
+                    "Names" : "LogFileGroups",
+                    "Types" : ARRAY_OF_STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : ["ecs", "ECS"],
             "Description" : "The component type the profile applies to",
             "Children" : [
                 {

--- a/providers/shared/references/Processor/id.ftl
+++ b/providers/shared/references/Processor/id.ftl
@@ -40,7 +40,7 @@
         ]
     attributes=[
         {
-            "Names" : "NAT",
+            "Names" : ["nat", "NAT"],
             "Children" : [
                 {
                     "Names" : "Processor",
@@ -49,7 +49,7 @@
             ]
         },
         {
-            "Names" : [ "bastion", "SSH" ],
+            "Names" : ["bastion", "SSH"],
             "Children" : [
                 {
                     "Names" : "Processor",
@@ -58,7 +58,7 @@
             ]
         },
         {
-            "Names" : "EC2",
+            "Names" : ["ec2", "EC2"],
             "Children" : [
                 {
                     "Names" : "Processor",
@@ -67,7 +67,7 @@
             ]
         },
         {
-            "Names" : "ECS",
+            "Names" : ["ecs", "ECS"],
             "Children" : [
                 {
                     "Names" : "Processor",
@@ -81,7 +81,7 @@
             "Children" : nodeCountChildConfiguration
         },
         {
-            "Names" : "ComputeCluster",
+            "Names" : ["computecluster", "ComputeCluster" ],
             "Children" : [
                 {
                     "Names" : "Processor",
@@ -91,7 +91,7 @@
             nodeCountChildConfiguration
         },
         {
-            "Names" : [ "db", "RDS" ],
+            "Names" : [ "db", "DB", "rds", "RDS" ],
             "Children" : [
                 {
                     "Names" : "Processor",
@@ -101,7 +101,7 @@
             nodeCountChildConfiguration
         },
         {
-            "Names" : [ "cache", "ElastiCache" ],
+            "Names" : ["cache", "ElastiCache"],
             "Children" : [
                 {
                     "Names" : "Processor",
@@ -115,7 +115,7 @@
             ]
         },
         {
-            "Names" : [ "es", "ElasticSearch" ],
+            "Names" : ["es", "ElasticSearch"],
             "Children" : [
                 {
                     "Names" : [ "Processor", "DataNodeProcessor" ],
@@ -143,15 +143,15 @@
             ]
         },
         {
-            "Names" : "service",
+            "Names" : ["service", "Service"],
             "Children" : nodeCountChildConfiguration
         },
         {
-            "Names" : "containerservice",
+            "Names" : ["containerservice", "ContainerService" ],
             "Children" : nodeCountChildConfiguration
         },
         {
-            "Names" : "EMR",
+            "Names" : ["emr", "EMR"],
             "Children" : [
                 {
                     "Names" : "Processor",

--- a/providers/shared/references/Storage/id.ftl
+++ b/providers/shared/references/Storage/id.ftl
@@ -6,42 +6,98 @@
     properties=[
             {
                 "Type"  : "Description",
-                "Value" : "A block volume storage configuration"
+                "Value" : "Storage configuration for components"
             }
         ]
     attributes=[
         {
-            "Names" : "*",
+            "Names" : ["bastion", "Bastion"],
             "Children" : [
                 {
                     "Names" : "Volumes",
                     "SubObjects" : true,
+                    "Ref" : VOLUME_ATTRIBUTESET_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : ["computecluster", "ComputeCluster"],
+            "Children" : [
+                {
+                    "Names" : "Volumes",
+                    "SubObjects" : true,
+                    "Ref" : VOLUME_ATTRIBUTESET_TYPE
+                },
+                {
+                    "Names" : "Tier",
+                    "Description" : "The storage tier to use for all volumes",
+                    "Types" : STRING_TYPE
+                },
+                {
+                    "Names" : "Replication",
+                    "Description": "The type of storage replication to use",
+                    "Types" : STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : ["ec2", "EC2"],
+            "Children" : [
+                {
+                    "Names" : "Volumes",
+                    "SubObjects" : true,
+                    "Ref" : VOLUME_ATTRIBUTESET_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : ["ecs", "ECS"],
+            "Children" : [
+                {
+                    "Names" : "Volumes",
+                    "SubObjects" : true,
+                    "Ref" : VOLUME_ATTRIBUTESET_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : ["es", "ElasticSearch"],
+            "Children" : [
+                {
+                    "Names" : "Volumes",
                     "Children" : [
                         {
-                            "Names" : "Device",
-                            "Types" : STRING_TYPE,
-                            "Mandatory" : true
-                        },
-                        {
-                            "Names" : "MountPath",
-                            "Types" : STRING_TYPE,
-                            "Description" : "The OS path to mount the volume"
-                        },
-                        {
-                            "Names" : "Size",
-                            "Types" : NUMBER_TYPE,
-                            "Mandatory" : true
-                        },
-                        {
-                            "Names":  "Type",
-                            "Types" : STRING_TYPE,
-                            "Default" : "gp2"
-                        },
-                        {
-                            "Names" : "Iops",
-                            "Types" : NUMBER_TYPE
+                            "Names" : ["data", "codeontap"],
+                            "Description" : "A fixed volume to use for ES Data storage",
+                            "Ref" : VOLUME_ATTRIBUTESET_TYPE
                         }
                     ]
+                }
+            ]
+        },
+        {
+            "Names" : ["storageAccount"],
+            "Description" : "Azure Storage Account configuration",
+            "Children" : [
+                {
+                    "Names" : "Tier",
+                    "Types" : STRING_TYPE
+                },
+                {
+                    "Names" : "Type",
+                    "Types" : STRING_TYPE
+                },
+                {
+                    "Names" : "Replication",
+                    "Types" : STRING_TYPE
+                },
+                {
+                    "Names": "AccessTier",
+                    "Types" : STRING_TYPE
+                },
+                {
+                    "Names" : "HnsEnabled",
+                    "Types" : BOOLEAN_TYPE
                 }
             ]
         }


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

- adds explicit attributes for the typed profiles that align with component type values along with the older cased values that are used in the existing profiles
- adds an attribute set for volume configuration that is used across the different component type storage profiles

## Motivation and Context

This makes it easier to configure profiles and makes it easier to understand what is available when configuring the profiles

## How Has This Been Tested?

Tested locally and with aws and azure provider test suites 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

