### PR TITLE
fix: storage profile volume configuration

### DIFF
--- a/providers/shared/attributesets/volume/id.ftl
+++ b/providers/shared/attributesets/volume/id.ftl
@@ -10,6 +10,12 @@
         }]
     attributes=[
         {
+            "Names" : "Enabled",
+            "Description" : "Should the volume be created",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : true
+        },
+        {
             "Names" : "Device",
             "Description" : "The deivce Id of the volume where the disk will be attached",
             "Types" : STRING_TYPE,

--- a/providers/shared/references/Storage/id.ftl
+++ b/providers/shared/references/Storage/id.ftl
@@ -16,7 +16,7 @@
                 {
                     "Names" : "Volumes",
                     "SubObjects" : true,
-                    "Ref" : VOLUME_ATTRIBUTESET_TYPE
+                    "AttributeSet" : VOLUME_ATTRIBUTESET_TYPE
                 }
             ]
         },
@@ -26,7 +26,7 @@
                 {
                     "Names" : "Volumes",
                     "SubObjects" : true,
-                    "Ref" : VOLUME_ATTRIBUTESET_TYPE
+                    "AttributeSet" : VOLUME_ATTRIBUTESET_TYPE
                 },
                 {
                     "Names" : "Tier",
@@ -46,7 +46,7 @@
                 {
                     "Names" : "Volumes",
                     "SubObjects" : true,
-                    "Ref" : VOLUME_ATTRIBUTESET_TYPE
+                    "AttributeSet" : VOLUME_ATTRIBUTESET_TYPE
                 }
             ]
         },
@@ -56,7 +56,7 @@
                 {
                     "Names" : "Volumes",
                     "SubObjects" : true,
-                    "Ref" : VOLUME_ATTRIBUTESET_TYPE
+                    "AttributeSet" : VOLUME_ATTRIBUTESET_TYPE
                 }
             ]
         },
@@ -69,7 +69,31 @@
                         {
                             "Names" : ["data", "codeontap"],
                             "Description" : "A fixed volume to use for ES Data storage",
-                            "Ref" : VOLUME_ATTRIBUTESET_TYPE
+                            "Children" : [
+                                {
+                                    "Names" : "Enabled",
+                                    "Description" : "Should the volume be created",
+                                    "Types" : BOOLEAN_TYPE,
+                                    "Default" : true
+                                },
+                                {
+                                    "Names" : "Size",
+                                    "Description" : "The size in GB of the volume",
+                                    "Types" : NUMBER_TYPE,
+                                    "Mandatory" : true
+                                },
+                                {
+                                    "Names":  "Type",
+                                    "Description" : "The type of volume to provision - see provider for available types",
+                                    "Types" : STRING_TYPE,
+                                    "Default" : "gp2"
+                                },
+                                {
+                                    "Names" : "Iops",
+                                    "Description" : "For volume types which support provisioned IOPS, this sets the requested IOPS",
+                                    "Types" : NUMBER_TYPE
+                                }
+                            ]
                         }
                     ]
                 }


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Fixes the attribute set configuration for volumes
- Sets a specific profile for elasticsearch which supports a limited subset of volume configuration

## Motivation and Context

Fixes https://github.com/hamlet-io/engine-plugin-aws/issues/338 
The volume configuration wasn't being applied properly due to the incorrect implementation of the Volume attribute set reference

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

