### PR TITLE
refactor: only assemble settings in pregen

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -1125,7 +1125,10 @@
             r'   "' + environment + r'" ' +
             r'   "' + segment + r'" ' +
             r'   "' + buildUnit + r'" ' +
-            r'   "' + createZip?c + r'" || exit $?'
+            r'   "' + createZip?c + r'" || exit $?',
+            r'# refresh settings to include new build file',
+            r'',
+            r'assemble_settings "${GENERATION_DATA_DIR}" "${COMPOSITE_SETTINGS}"'
         ]
     ]
 [/#function]
@@ -1155,7 +1158,10 @@
             r'   "' + buildUnit + r'" ' +
             r'   "' + registryHost + r'" ' +
             r'   "' + registryProvider + r'" ' +
-            r'   "' + region + r'" || exit $? '
+            r'   "' + region + r'" || exit $? ',
+            r'# refresh settings to include new build file',
+            r'',
+            r'assemble_settings "${GENERATION_DATA_DIR}" "${COMPOSITE_SETTINGS}"'
         ]
     ]
 [/#function]


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

moves the assemble settings function call for registry pulls into the functions used in pregeneration. This allows the pull function to be used for other purposes

## Motivation and Context
This allows the bash function to be used as a more general image management tool 

## How Has This Been Tested?

tested locally

## Related Changes

https://github.com/hamlet-io/executor-bash/pull/229 

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

