### PR TITLE
refactor: remove direct references to region

### DIFF
--- a/legacy/account/account_console.ftl
+++ b/legacy/account/account_console.ftl
@@ -110,7 +110,7 @@
                         r'  create|update)',
                         r'      info "Cleaning documents which might not have been created by CFN"',
                         r'      cleanup_ssm_document' +
-                        r'      "' + region + r'" ' +
+                        r'      "' + regionId + r'" ' +
                         r'      "' + consoleSSMDocumentName + r'" ',
                         r'      ;;',
                         r'esac'

--- a/legacy/account/account_ecs.ftl
+++ b/legacy/account/account_ecs.ftl
@@ -16,7 +16,7 @@
 
     [#assign ecsAccountCommands = [] ]
     [#list ecsAccountSettings as setting,state ]
-        [#assign ecsAccountCommands += [ r'manage_ecs_account_settings "' + region + r'" "' + setting + r'" "' + state?then("enabled", "disabled") + r'"' ]]
+        [#assign ecsAccountCommands += [ r'manage_ecs_account_settings "' + regionId + r'" "' + setting + r'" "' + state?then("enabled", "disabled") + r'"' ]]
     [/#list]
 
     [#if deploymentSubsetRequired("epilogue", true)]

--- a/legacy/account/account_s3.ftl
+++ b/legacy/account/account_s3.ftl
@@ -24,7 +24,7 @@
                                 s3ReplicationConfigurationPermission(bucketId) ]
 
                 [#if encryption ]
-                   [#local replicaionPolicies +=  s3EncryptionReadPermission(kmsKeyId, bucketName, "*", region)]
+                   [#local replicaionPolicies +=  s3EncryptionReadPermission(kmsKeyId, bucketName, "*", regionId)]
                 [/#if]
 
                 [#local rolePolicies =

--- a/legacy/account/account_sms.ftl
+++ b/legacy/account/account_sms.ftl
@@ -114,7 +114,7 @@
                     "      info \"Applying SMS account settings ...\"",
                     "      #",
                     "      update_sms_account_attributes" +
-                    "      \"" + region + "\" " +
+                    "      \"" + regionId + "\" " +
                     "      \"$\{tmpdir}/cli-" +
                                smsResourceId + "-" + smsCliCommand + ".json\" || return $?"
                 ] +

--- a/legacy/account/account_volumeencrypt.ftl
+++ b/legacy/account/account_volumeencrypt.ftl
@@ -36,7 +36,7 @@
                         r'  create|update)',
                         r'      info "Managing EBS Volume Encryption state..."',
                         r'      manage_ec2_volume_encryption' +
-                        r'      "' + region + r'" ' +
+                        r'      "' + regionId + r'" ' +
                         r'      "true"' +
                         r'      "' + volumeEncryptKmsKeyArn + r'"'
                     ] +
@@ -51,7 +51,7 @@
                         r' delete)',
                         r'      info "Managing EBS Volume Encryption state..."',
                         r'      manage_ec2_volume_encryption' +
-                        r'      "' + region + r'" ' +
+                        r'      "' + regionId + r'" ' +
                         r'      "false"' +
                         r'      "alias/aws/ebs"'
                         r'      ;;',


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Replace references to the command line option `region` with references to the `regionId` global variable set in setContext.

## Motivation and Context
There is a mix of use of `region` and `regionId` reflecting the fact that the composite assembly process initialises `region` while
`getContext` populates regionId.

With dynamic loading, references to region need to be made more dynamic so removal of direct references to the input value is the first step in preparing for this.

Once all known uses are modified, the variables used to pass in the layer values will be changed which will hopefully flush out any unidentified uses via null/missing exceptions.

## How Has This Been Tested?
The change is straightforward but the most efficient way to confirm is the running of templates in the normal course of business and rapidly addressing any exceptions.

There are a number of situations where `region` is actually a local variable in a function so global replace isn't an option.

## Related Changes
- https://github.com/hamlet-io/engine-plugin-aws/pull/349
- https://github.com/hamlet-io/engine-plugin-azure/pull/267

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

