### PR TITLE
fix: use workspace for engine dir

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Run Tests
         env:
+          GENERATION_ENGINE_DIR: ${{github.workspace }}
           GENERATION_PLUGIN_DIRS: ${{ github.workspace }}
           TEST_OUTPUT_DIR: ${{ github.workspace }}/hamlet_tests
         run: |


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Adds the engine dir as the workspace when running testing. This ensures that the local contents are being used instead of the latest version

## Motivation and Context

stops issues where changes are made to the engine that need to be tested

## How Has This Been Tested?

Will be tested by this PR

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

