### PR TITLE
feat: subcomponent linking

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -224,6 +224,7 @@
                     "Name" : formatName(occurrence.Core.Extensions.Name),
                     "RawName" : formatName(occurrence.Core.Extensions.RawName),
                     "TypedName" : formatName(occurrence.Core.Extensions.Name, type),
+                    "TypedRawName" : formatName(occurrence.Core.Extensions.RawName, type),
                     "FullName" : formatSegmentFullName(occurrence.Core.Extensions.Name),
                     "RawFullName" : formatSegmentFullName(occurrence.Core.Extensions.RawName),
                     "TypedFullName" : formatSegmentFullName(occurrence.Core.Extensions.Name, type),

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -40,11 +40,12 @@
         [#local instanceId = parentOccurrence.Core.Instance.Id ]
         [#local versionId = parentOccurrence.Core.Version.Id ]
         [#local subComponentId = occurrence.Core.SubComponent.Id ]
+        [#local subComponentType = occurrence.Core.Type ]
         [#local subInstanceId = occurrence.Core.Instance.Id ]
         [#local subVersionId = occurrence.Core.Version.Id ]
 
         [#local occurrenceDetails =
-            (occurrenceCache[tierId][componentId][instanceId][versionId]["SubComponents"][subComponentId][subInstanceId][subVersionId])!{} ]
+            (occurrenceCache[tierId][componentId][instanceId][versionId]["SubComponents"][subComponentId][subComponentType][subInstanceId][subVersionId])!{} ]
     [#else]
         [#local tierId = occurrence.Core.Tier.Id ]
         [#local componentId = occurrence.Core.Component.RawId ]

--- a/providers/shared/attributesets/links/id.ftl
+++ b/providers/shared/attributesets/links/id.ftl
@@ -69,6 +69,10 @@
             "Mandatory" : true
         },
         {
+            "Names" : "SubComponent",
+            "Type" : STRING_TYPE
+        },
+        {
             "Names" : "Instance",
             "Type" : STRING_TYPE
         },


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Introduce a `SubComponent` attribute on links that will replace the use of component type specific link attributes. For now, either will work.

Also expand the checking of component types and the use of the `Type` attribute, particularly as a check on the type of the expected link target and to differentiate between subcomponents with the same id
but different types.

During testing, a bug was discovered in the cacheing of occurrences which wasn't type aware. This has been added to support the subcomponent linking changes.

## Motivation and Context
- avoid an ever growing list of subcomponent attributes
- more stable link schema
- aligns with 

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

