### PR TITLE
fix: qualification of layer data

### DIFF
--- a/engine/inputdata/inputsource.ftl
+++ b/engine/inputdata/inputsource.ftl
@@ -352,8 +352,9 @@ to filter the data returned
     ]
 [/#macro]
 
-[#function getRegisteredLayerInputFilterAttributeIds]
-    [#return layerInputFilterAttributes?keys?sort]
+[#-- Return registered attribute ids in the provided filter --]
+[#function getRegisteredLayerInputFilterAttributeIds filter]
+    [#return layerInputFilterAttributes?keys?sort?filter(k -> isFilterAttribute(filter, k)) ]
 [/#function]
 
 [#-- Manage input state --]
@@ -366,7 +367,7 @@ to filter the data returned
 [#assign FRAGMENTS_CONFIG_INPUT_CLASS = "Fragments" ]
 [#assign STATE_CONFIG_INPUT_CLASS = "State" ]
 [#assign LOADER_CONFIG_INPUT_CLASS = "Loader" ]
-[#assign LAYERS_CONFIG_INPUT_CLASS = "Layers" ]
+[#assign ACTIVE_LAYERS_CONFIG_INPUT_CLASS = "ActiveLayers" ]
 
 [#-- Cache of stage data for situations where back --]
 [#-- referencing is need in subsequent stages      --]
@@ -397,8 +398,8 @@ to filter the data returned
     [#return getInputState()[STATE_CONFIG_INPUT_CLASS]![] ]
 [/#function]
 
-[#function getLayers ]
-    [#return getInputState()[LAYERS_CONFIG_INPUT_CLASS]![] ]
+[#function getActiveLayers ]
+    [#return getInputState()[ACTIVE_LAYERS_CONFIG_INPUT_CLASS]!{} ]
 [/#function]
 
 [#function getLoader ]

--- a/engine/module.ftl
+++ b/engine/module.ftl
@@ -3,11 +3,11 @@
 [#-- modules allow loading input data using the engine itself --]
 [#assign moduleConfiguration = {}]
 
-[#function getActiveModulesFromLayers  ]
+[#function getActiveModulesFromLayers layersState ]
 
     [#local modules = [] ]
 
-    [#local possibleModules = asFlattenedArray(getActiveLayerAttributes( [ "Modules" ] )) ]
+    [#local possibleModules = asFlattenedArray(getActiveLayerAttributes( [ "Modules" ], ["*"], [], layersState )) ]
 
     [#list possibleModules as moduleInstance ]
         [#list moduleInstance?values as module ]

--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -481,7 +481,7 @@
                                 getCLODeploymentGroup(),
                                 getCLODeploymentUnit(),
                                 subset,
-                                getCommandLineOptions().Layers[ACCOUNT_LAYER_TYPE],
+                                getActiveLayer(ACCOUNT_LAYER_TYPE).Name!"",
                                 contentIfContent(
                                     getCLOSegmentRegion(),
                                     getProductLayerRegion()
@@ -517,7 +517,7 @@
             "deploymentFramework"    : getCLODeploymentFramework(),
             "deploymentUnit"         : getCLODeploymentUnit(),
             "deploymentGroup"        : getCLODeploymentGroup(),
-            "account"                : getCommandLineOptions().Layers[ACCOUNT_LAYER_TYPE],
+            "account"                : getActiveLayer(ACCOUNT_LAYER_TYPE).Name!"",
             "accountRegion"          : contentIfContent(getCLOAccountRegion(), getAccountLayerRegion()),
             "region"                 : contentIfContent(getCLOSegmentRegion(),getProductLayerRegion()),
             "requestReference"       : getCLORequestReference(),

--- a/engine/provider.ftl
+++ b/engine/provider.ftl
@@ -27,10 +27,10 @@
     [/#if]
 [/#macro]
 
-[#function getActivePluginsFromLayers  ]
+[#function getActivePluginsFromLayers  layersState ]
 
     [#local plugins = [] ]
-    [#local possiblePlugins = asFlattenedArray(getActiveLayerAttributes( [ "Plugins" ] )) ]
+    [#local possiblePlugins = asFlattenedArray(getActiveLayerAttributes( [ "Plugins" ], ["*"], [], layersState )) ]
 
     [#list possiblePlugins as pluginInstance ]
         [#list pluginInstance as id, plugin ]
@@ -154,46 +154,6 @@
             id=plugin.Id
             ref=(definedPluginState.ref)!plugin.Source
         /]
-    [/#list]
-    [#return result]
-[/#function]
-
-[#function getPluginsFromLayers pluginState ]
-    [#local result = [] ]
-    [#local definedPlugins = getActivePluginsFromLayers() ]
-
-    [#list definedPlugins?sort_by("Priority") as plugin]
-        [#local pluginRequired = plugin.Required]
-
-        [#local definedPluginState = (pluginState["Plugins"][plugin.Id])!{} ]
-
-        [#if pluginRequired && !(definedPluginState?has_content) && plugin.Source != "local" ]
-            [@fatal
-                message="Plugin setup not complete"
-                detail="A plugin was required but plugin setup has not been run"
-                context=plugin
-            /]
-        [/#if]
-
-
-        [#local pluginProviderMarker = providerMarkers?filter(
-                                            marker -> marker.Path?keep_after_last("/") == plugin.Name ) ]
-
-        [#if !(pluginProviderMarker?has_content) && pluginRequired  ]
-            [@fatal
-                message="Unable to load required provider"
-                detail="The provider could not be found in the local state - please load hamlet plugins"
-                context=plugin
-            /]
-            [#continue]
-        [/#if]
-
-        [@addPluginMetadata
-            id=plugin.Id
-            ref=(definedPluginState.ref)!plugin.Source
-        /]
-
-        [#local result += [plugin] ]
     [/#list]
     [#return result]
 [/#function]

--- a/providers/shared/components/shared/setup.ftl
+++ b/providers/shared/components/shared/setup.ftl
@@ -110,7 +110,7 @@
                                     getCLODeploymentGroup(),
                                     getCLODeploymentUnit(),
                                     outputMapping["Subset"],
-                                    getCommandLineOptions().Layers[ACCOUNT_LAYER_TYPE],
+                                    getActiveLayer(ACCOUNT_LAYER_TYPE).Name!"",
                                     getCLOSegmentRegion(),
                                     getCLOAccountRegion(),
                                     "primary"


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Permit the use of qualification within layer data.

Rework the handling of layers to permit their data to provide the filter inputs (Id, Name) to their own qualification.

Layer data is processed once to work out the values to use when filtering it, then a second time to work out the effects of qualification on the remaining configuration data.

As part of the refactoring, the active state of layers in now part of the input state and calls to `getActiveLayers` now returns the data in the input state.


## Motivation and Context
Readiness preparation for [ADR0007](https://github.com/hamlet-io/architectural-decision-log/blob/main/adr/0007-placement-support.md)
Fixes #1714 

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

