### PR TITLE
feat: template output suffixes for mapping

### DIFF
--- a/providers/shared/components/template/id.ftl
+++ b/providers/shared/components/template/id.ftl
@@ -48,6 +48,12 @@
                 "SubObjects" : true,
                 "Children" : [
                     {
+                        "Names" : "IdSuffix",
+                        "Description" : "An additional suffix that will be included along with the template Id for the output - Allows for mapping multiple resource attributes",
+                        "Types" : STRING_TYPE,
+                        "Default" : ""
+                    },
+                    {
                         "Names" : "TemplateOutputKey",
                         "Description" : "The name of the template output you want to map to an attribte",
                         "Types" : STRING_TYPE,


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- adds support for defining suffixes on outputs pulled from nested templates

## Motivation and Context

Adding suffixes allows for outputs from multiple resources within the template into hamlet outputs. Since templates can range in complexity this allows for broader support for collecting outputs

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

