### PR TITLE
refactor: clo/layer access during input processing

### DIFF
--- a/engine/module.ftl
+++ b/engine/module.ftl
@@ -74,16 +74,13 @@
         ]
     [/#list]
 
+    [#-- attributeIfContent() returns an empty object if no content --]
     [#assign moduleInputState =
-        mergeObjects(
-            moduleInputState,
-            {} +
-            attributeIfContent(COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS, commandLineOption) +
-            attributeIfContent(BLUEPRINT_CONFIG_INPUT_CLASS, blueprint) +
-            attributeIfContent(SETTINGS_CONFIG_INPUT_CLASS, formattedModuleSettings) +
-            attributeIfContent(DEFINITIONS_CONFIG_INPUT_CLASS, definitions) +
-            attributeIfContent(STATE_CONFIG_INPUT_CLASS, stackOutputs)
-        )
+        attributeIfContent(COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS, commandLineOption) +
+        attributeIfContent(BLUEPRINT_CONFIG_INPUT_CLASS, blueprint) +
+        attributeIfContent(SETTINGS_CONFIG_INPUT_CLASS, formattedModuleSettings) +
+        attributeIfContent(DEFINITIONS_CONFIG_INPUT_CLASS, definitions) +
+        attributeIfContent(STATE_CONFIG_INPUT_CLASS, stackOutputs)
     ]
 [/#macro]
 

--- a/providers/shared/inputstages/commandlineoptions/id.ftl
+++ b/providers/shared/inputstages/commandlineoptions/id.ftl
@@ -3,4 +3,5 @@
 [@registerInputStage
     id=COMMANDLINEOPTIONS_SHARED_INPUT_STAGE
     description="Command line options"
+    stageState=true
 /]

--- a/providers/shared/inputstages/layer/id.ftl
+++ b/providers/shared/inputstages/layer/id.ftl
@@ -3,4 +3,5 @@
 [@registerInputStage
     id=LAYER_SHARED_INPUT_STAGE
     description="Layer data determination"
+    stageState=true
 /]


### PR DESCRIPTION

## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Refactor input processing to permit access to command line options and layers during input processing. 

For some stages of input stages, the state to that point is saved into the global state, and input state accessor routines have been made aware of whether input processing is in progress in order to use this staged state.

## Motivation and Context
Access to layer information is commonly used in extensions and modules.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

