### PR TITLE
feat: set districts for deployment groups

### DIFF
--- a/providers/shared/entrances/deployment/entrance.ftl
+++ b/providers/shared/entrances/deployment/entrance.ftl
@@ -31,8 +31,8 @@
     [#list ((deploymentGroupDetails.ResourceSets)!{})?values?filter(s -> s.Enabled ) as resourceSet ]
         [#if getCLODeploymentUnit() == resourceSet["deployment:Unit"] ]
 
-            [#assign groupDeploymentUnits = true]
-            [#assign ignoreDeploymentUnitSubsetInOutputs = true]
+            [#assign groupDeploymentUnits = resourceSet["GroupDeploymentUnit"]]
+            [#assign ignoreDeploymentUnitSubsetInOutputs = resourceSet["GroupDeploymentUnit"]]
 
             [#local contractSubsets = []]
             [#list resourceSet.ResourceLabels as label ]

--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -1736,19 +1736,19 @@
   },
   "DeploymentGroups": {
     "segment": {
-      "Priority": 10,
+      "Priority": 100,
       "Level": "segment",
       "OutputPrefix" : "seg",
       "ResourceSets": {}
     },
     "solution": {
-      "Priority": 100,
+      "Priority": 200,
       "Level": "solution",
       "OutputPrefix" : "soln",
       "ResourceSets": {}
     },
     "application": {
-      "Priority": 200,
+      "Priority": 300,
       "Level": "application",
       "OutputPrefix" : "app",
       "ResourceSets": {}

--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -1738,18 +1738,21 @@
     "segment": {
       "Priority": 100,
       "Level": "segment",
+      "District" : "segment",
       "OutputPrefix" : "seg",
       "ResourceSets": {}
     },
     "solution": {
       "Priority": 200,
       "Level": "solution",
+      "District" : "segment",
       "OutputPrefix" : "soln",
       "ResourceSets": {}
     },
     "application": {
       "Priority": 300,
       "Level": "application",
+      "District" : "segment",
       "OutputPrefix" : "app",
       "ResourceSets": {}
     }

--- a/providers/shared/provider.ftl
+++ b/providers/shared/provider.ftl
@@ -84,6 +84,7 @@
                             "DeploymentUnit" : deploymentUnit,
                             "DeploymentGroup" : deploymentGroupDetails.Name,
                             "DeploymentProvider" : deploymentProvider,
+                            "District" : deploymentGroupDetails.District,
                             "Operations" : deploymentModeDetails.Operations,
                             "CurrentState" : currentState
                         }

--- a/providers/shared/references/DeploymentGroup/id.ftl
+++ b/providers/shared/references/DeploymentGroup/id.ftl
@@ -29,6 +29,12 @@
             "Mandatory" : true
         },
         {
+            "Names" : "District",
+            "Description" : "The id of the district for components included in the deployment group",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
             "Names" : "OutputPrefix",
             "Description" : "Overrides the prefix used when generating outputs - Defaults to the Id of the Group",
             "Types" : STRING_TYPE
@@ -56,10 +62,16 @@
                     "Default" : 5
                 },
                 {
+                    "Names" : "GroupDeploymentUnit",
+                    "Description" : "Does the resource set span all units in the group",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
                     "Names" : "ResourceLabels",
                     "Description" : "The resource labels to include in the subset",
                     "Types" : ARRAY_OF_STRING_TYPE,
-                    "Mandatory" : true
+                    "Default" : []
                 }
             ]
         },

--- a/providers/shared/tasks/manage_deployment/id.ftl
+++ b/providers/shared/tasks/manage_deployment/id.ftl
@@ -20,6 +20,11 @@
             "Mandatory" : true
         },
         {
+            "Names" : "District",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
             "Names" : "Operations",
             "Types" : ARRAY_OF_STRING_TYPE,
             "Mandatory" : true

--- a/providers/shared/views/unitlist/setup.ftl
+++ b/providers/shared/views/unitlist/setup.ftl
@@ -68,23 +68,22 @@
         [/#list]
     [/#list]
 
-    [#-- Add all of the required Resource Sets - Set deployed state to false --]
-    [#if getOutputContent("stages")?has_content ]
-        [#list getOutputContent("stages")?keys as deploymentGroup ]
-            [#local groupDetails = getDeploymentGroupDetails(deploymentGroup)]
 
-            [#list (groupDetails.ResourceSets)?values as resourceSet ]
+    [#-- Add all of the required Resource Sets--]
+    [#list getDeploymentGroups()?keys as deploymentGroup ]
+        [#local groupDetails = getDeploymentGroupDetails(deploymentGroup)]
 
-                [#local deploymentUnit = resourceSet["deployment:Unit"] ]
+        [#list (groupDetails.ResourceSets)?values as resourceSet ]
 
-                [@createResourceSetManagementContractStep
-                    deploymentGroup=deploymentGroup
-                    deploymentUnit=deploymentUnit
-                    currentState=getDeploymentUnitStates(deploymentGroup, deploymentUnit)
-                                    ?seq_contains(true)?then("deployed", "notdeployed")
-                /]
-            [/#list]
+            [#local deploymentUnit = resourceSet["deployment:Unit"] ]
+
+            [@createResourceSetManagementContractStep
+                deploymentGroup=deploymentGroup
+                deploymentUnit=deploymentUnit
+                currentState=getDeploymentUnitStates(deploymentGroup, deploymentUnit)
+                                ?seq_contains(true)?then("deployed", "notdeployed")
+            /]
         [/#list]
-    [/#if]
+    [/#list]
 
 [/#macro]

--- a/providers/sharedtest/inputseeders/sharedtest/id.ftl
+++ b/providers/sharedtest/inputseeders/sharedtest/id.ftl
@@ -26,6 +26,7 @@
                 "DeploymentGroups" : {
                     "internal" : {
                         "Priority" : 500,
+                        "District" : "segment",
                         "Level" : "solution",
                         "ResourceSets" : {}
                     }


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds a district property to deployment groups to scope the deployments included as part of the group
- Includes district details in the management contract
- Includes all deployment groups in the management contract instead of filtering on those that have created outputs
- Adds support for resource sets that do not act as subsets and instead are treated as standalone deployment units
- reorder default deployment group priorities to accommodate other groups

## Motivation and Context

This allows for discovering and listing all available deployments across the hamlet districts and to select which ones you want to use

## How Has This Been Tested?

Tested locally and on development environment

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

