### PR TITLE
Add standard date functions and (optional) MaintenanceWindow to RDS

### DIFF
--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -689,6 +689,72 @@ are added.
     [#return (end?long - start?long)]
 [/#function]
 
+[#function addDateTime dateTime unit amount]
+    [#switch unit]
+        [#case "dd"]
+            [#local offset=1000*60*60*24]
+            [#break]
+        [#case "hh"]
+            [#local offset=1000*60*60]
+            [#break]
+        [#case "mm"]
+            [#local offset=1000*60]
+            [#break]
+    [/#switch]
+    [#local retval = (dateTime?datetime?long + amount?long*offset?long)?number_to_datetime]
+    [#return retval ]
+[/#function]
+
+[#function showDateTime dateTime format timezone="UTC" ]
+    [#local old_time_zone = .time_zone]
+    [#setting time_zone = timezone]
+    [#local retval = dateTime?datetime?string(format)]
+
+    [#setting time_zone = old_time_zone]
+    [#return retval ]
+[/#function]
+
+[#function convertDayOfWeek2DateTime dayOfWeek timeofDay="00:00" timeZone="UTC"]
+    [#-- 
+    The explicit dates below are used to convert a "dayOfWeek" to a date to allow for date and 
+    TimeZone manipulations.
+    Any date sufficiently far away from leap year impacts can be used 
+    --]
+    [#switch dayOfWeek]
+        [#case "Monday"]
+            [#local startTime = "05-JUL-2021 "+timeofDay+":00 "+timeZone ]
+            [#break]
+        [#case "Tuesday"]
+            [#local startTime = "06-JUL-2021 "+timeofDay+":00 "+timeZone ]
+            [#break]
+        [#case "Wednesday"]
+            [#local startTime = "07-JUL-2021 "+timeofDay+":00 "+timeZone ]
+            [#break]
+        [#case "Thursday"]
+            [#local startTime = "08-JUL-2021 "+timeofDay+":00 "+timeZone ]
+            [#break]
+        [#case "Friday"]
+            [#local startTime = "09-JUL-2021 "+timeofDay+":00 "+timeZone ]
+            [#break]
+        [#case "Saturday"]
+            [#local startTime = "10-JUL-2021 "+timeofDay+":00 "+timeZone ]
+            [#break]
+        [#case "Sunday"]
+            [#local startTime = "11-JUL-2021 "+timeofDay+":00 "+timeZone ]
+            [#break]
+    [/#switch]
+    [#local retval = startTime?datetime("dd-MMM-yyyy HH:mm:ss z") ]
+    [#return retval ]
+[/#function]
+
+[#function testMaintenanceWindow maintWindow requireDay=true requireTime=true requireTZ=true]
+    [#return !(maintWindow.Configured!false) || 
+        (!requireDay || maintWindow.DayOfTheWeek?has_content) &&
+        (!requireTime || maintWindow.TimeOfDay?has_content) &&
+        (!requireTZ || maintWindow.TimeZone?has_content)
+    ]
+[/#function]
+
 [#-- Formulate a composite object based on                                            --]
 [#--   * order precedence - lowest to highest, then                                   --]
 [#--   * qualifiers - less specific to more specific                                  --]

--- a/providers/shared/attributesets/attributeset.ftl
+++ b/providers/shared/attributesets/attributeset.ftl
@@ -21,3 +21,5 @@
 [#assign PLUGIN_ATTRIBUTESET_TYPE = "plugin"]
 
 [#assign VOLUME_ATTRIBUTESET_TYPE = "volume"]
+
+[#assign MAINTENANCEWINDOW_ATTRIBUTESET_TYPE = "maintenancewindow" ]

--- a/providers/shared/attributesets/maintenancewindow/id.ftl
+++ b/providers/shared/attributesets/maintenancewindow/id.ftl
@@ -1,0 +1,34 @@
+[#ftl]
+
+[@addAttributeSet
+    type=MAINTENANCEWINDOW_ATTRIBUTESET_TYPE
+    pluralType="MaintenanceWindows"
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Standard Configuration options to define a maintenance window"
+        }]
+    attributes=[
+        {
+            "Names" : "DayOfTheWeek",
+            "Types" : STRING_TYPE,
+            "Values" : [
+                "Sunday",
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday"
+            ]
+        },
+        {
+            "Names" : "TimeOfDay",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "TimeZone",
+            "Types" : STRING_TYPE
+        }
+     ]
+/]

--- a/providers/shared/components/cache/id.ftl
+++ b/providers/shared/components/cache/id.ftl
@@ -50,6 +50,10 @@
                 ]
             },
             {
+                "Names" : "MaintenanceWindow",
+                "AttributeSet" : MAINTENANCEWINDOW_ATTRIBUTESET_TYPE
+            },
+            {
                 "Names" : "Profiles",
                 "Children" :
                     [

--- a/providers/shared/components/db/id.ftl
+++ b/providers/shared/components/db/id.ftl
@@ -119,6 +119,10 @@
                 ]
             },
             {
+                "Names" : "MaintenanceWindow",
+                "AttributeSet" : MAINTENANCEWINDOW_ATTRIBUTESET_TYPE
+            },
+            {
                 "Names" : "AllowMajorVersionUpgrade",
                 "Description" : "If the EngineVersion paramter is updated allow for major version updates to run",
                 "Types" : BOOLEAN_TYPE,

--- a/providers/shared/components/queuehost/id.ftl
+++ b/providers/shared/components/queuehost/id.ftl
@@ -91,32 +91,7 @@
             },
             {
                 "Names" : "MaintenanceWindow",
-                "Children" : [
-                    {
-                        "Names" : "DayOfTheWeek",
-                        "Types" : STRING_TYPE,
-                        "Values" : [
-                            "Sunday",
-                            "Monday",
-                            "Tuesday",
-                            "Wednesday",
-                            "Thursday",
-                            "Friday",
-                            "Saturday"
-                        ],
-                        "Default" : "Sunday"
-                    },
-                    {
-                        "Names" : "TimeOfDay",
-                        "Types" : STRING_TYPE,
-                        "Default" : "00:00"
-                    },
-                    {
-                        "Names" : "TimeZone",
-                        "Types" : STRING_TYPE,
-                        "Default" : "UTC"
-                    }
-                ]
+                "AttributeSet" : MAINTENANCEWINDOW_ATTRIBUTESET_TYPE
             },
             {
                 "Names" : "AutoMinorUpgrade",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
Standard date manipulation functions added
Standard MaintenanceWindow child added to RDS

## Motivation and Context
Precondition for PR to address https://github.com/hamlet-io/engine/issues/159

## How Has This Been Tested?
Locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- TBA

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- Functionality to be supported within provider plugins for MaintenanceWindow

