### PR TITLE
fix: duplicate fragment processing

### DIFF
--- a/engine/extension.ftl
+++ b/engine/extension.ftl
@@ -166,11 +166,6 @@
 
         [#-- Legacy support for fragments --]
         [#local fragmentId = id ]
-        [#-- TODO(mfl) Remove check for fragmentList once changes to --
-        [#-- support content intergretation in place --]
-        [#if fragmentList?has_content]
-            [#include fragmentList?ensure_starts_with("/") ]
-        [/#if]
 
         [#local fragments = getFragments()?trim ]
         [#if fragments?has_content]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Remove the direct processing of fragment files.

## Motivation and Context
Input processing now includes fragments in the input state for both composite and dynamic cmdb processing. Currently for composite processing, the fragment is processed twice which can result in errors if the fragment logic is not idempotent.

## How Has This Been Tested?
Local template generation.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

