### PR TITLE
refactor: remove global security for openapi 2

### DIFF
--- a/engine/openapi.ftl
+++ b/engine/openapi.ftl
@@ -1100,9 +1100,12 @@ is useful to see what the global settings are from a debug perspective
         )
     ]
 
-    [#-- Add the global security --]
-    [#local globalContent +=
-        getSecurity(globalConfiguration, definition, integrations) ]
+    [#-- Add the global security for openapi 3 --]
+    [#-- AWS throws an error if this is provided for openapi 2 --]
+    [#if globalConfiguration.OpenAPI.MajorVersion gte 3]
+        [#local globalContent +=
+            getSecurity(globalConfiguration, definition, integrations) ]
+    [/#if]
 
     [#local paths = {} ]
     [#list (definition.paths!{}) + getAWSProxyPaths(globalConfiguration) as path, pathObject]


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Description
Don't include top level security attribute for openapi 2

## Motivation and Context
AWS previously ignored any global security attribute but now throw an error for openapi 2. They don't throw an error in openapi.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

