### PR TITLE
fix: handle tests across sub components deployment

### DIFF
--- a/providers/shared/components/shared/setup.ftl
+++ b/providers/shared/components/shared/setup.ftl
@@ -67,196 +67,201 @@
     [#local allOccurrences = asFlattenedArray( [ occurrence, occurrence.Occurrences![] ], true )]
     [#list allOccurrences as occurrence ]
 
-        [#local solution = occurrence.Configuration.Solution ]
-        [#local componentType = occurrence.Core.Type ]
+        [#if getOccurrenceDeploymentUnit(occurrence) == getCLODeploymentUnit() &&
+                getOccurrenceDeploymentGroup(occurrence) == getCLODeploymentGroup() ]
 
-        [#local testProfileNames = (solution.Profiles.Testing)![] ]
+            [#local solution = occurrence.Configuration.Solution ]
+            [#local componentType = occurrence.Core.Type ]
 
-        [#local testCaseNames = []]
-        [#list testProfileNames as testProfileName ]
-            [#if (testProfiles[testProfileName]!{})?? ]
-                [#local testProfileDetail = testProfiles[testProfileName] ]
+            [#local testProfileNames = (solution.Profiles.Testing)![] ]
 
-                [#if testProfileDetail["*"]?? ]
-                    [#local testCaseNames += testProfileDetail["*"].TestCases ]
+            [#local testCaseNames = []]
+            [#list testProfileNames as testProfileName ]
+                [#if (testProfiles[testProfileName]!{})?? ]
+                    [#local testProfileDetail = testProfiles[testProfileName] ]
+
+                    [#if testProfileDetail["*"]?? ]
+                        [#local testCaseNames += testProfileDetail["*"].TestCases ]
+                    [/#if]
+
+                    [#if testProfileDetail[componentType]??]
+                        [#local testCaseNames += testProfileDetail[componentType].TestCases ]
+                    [/#if]
                 [/#if]
+            [/#list]
 
-                [#if testProfileDetail[componentType]??]
-                    [#local testCaseNames += testProfileDetail[componentType].TestCases ]
-                [/#if]
-            [/#if]
-        [/#list]
+            [#local testCaseNames = getUniqueArrayElements(testCaseNames) ]
 
-        [#local testCaseNames = getUniqueArrayElements(testCaseNames) ]
+            [#local tests = {} ]
+            [#list testCaseNames as testCaseName ]
+                [#local testCaseFullName = concatenate(
+                                                [
+                                                    getOccurrenceDeploymentUnit(occurrence),
+                                                    (occurrence.Core.ShortTypedName),
+                                                    testCaseName
+                                                ],
+                                                "_"
+                                            )?replace("-", "_")]
+                [#if testCases[testCaseName]?? ]
+                    [#local testCase = testCases[testCaseName] ]
 
-        [#local tests = {} ]
-        [#list testCaseNames as testCaseName ]
-            [#local testCaseFullName = concatenate(
-                                            [
-                                                getOccurrenceDeploymentUnit(occurrence),
-                                                (occurrence.Core.ShortTypedName),
-                                                testCaseName
-                                            ],
-                                            "_"
-                                        )?replace("-", "_")]
-            [#if testCases[testCaseName]?? ]
-                [#local testCase = testCases[testCaseName] ]
+                    [#local outputProviders = combineEntities(
+                                                    getLoaderProviders(),
+                                                    [ SHARED_PROVIDER],
+                                                    UNIQUE_COMBINE_BEHAVIOUR
+                                                )]
 
-                [#local outputProviders = combineEntities(
-                                                getLoaderProviders(),
-                                                [ SHARED_PROVIDER],
-                                                UNIQUE_COMBINE_BEHAVIOUR
-                                            )]
+                    [#local outputMapping = getGenerationContractStepOutputMappingFromSuffix( outputProviders, testCase.OutputSuffix)]
+                    [#local filePrefix = getOutputFilePrefix(
+                                            "deployment"
+                                            getCLODeploymentGroup(),
+                                            getCLODeploymentUnit(),
+                                            outputMapping["Subset"],
+                                            getActiveLayer(ACCOUNT_LAYER_TYPE).Name!"",
+                                            getCLOSegmentRegion(),
+                                            getCLOAccountRegion(),
+                                            "primary"
+                                    )]
 
-                [#local outputMapping = getGenerationContractStepOutputMappingFromSuffix( outputProviders, testCase.OutputSuffix)]
-                [#local filePrefix = getOutputFilePrefix(
-                                        "deployment"
-                                        getCLODeploymentGroup(),
-                                        getCLODeploymentUnit(),
-                                        outputMapping["Subset"],
-                                        getActiveLayer(ACCOUNT_LAYER_TYPE).Name!"",
-                                        getCLOSegmentRegion(),
-                                        getCLOAccountRegion(),
-                                        "primary"
-                                )]
+                    [#local outputFileName = formatName(filePrefix, outputMapping["OutputSuffix"]) ]
 
-                [#local outputFileName = formatName(filePrefix, outputMapping["OutputSuffix"]) ]
-
-                [#local tests = mergeObjects(
-                    tests,
-                    {
-                        testCaseFullName  : {
-                            "filename" : outputFileName,
-                            "cfn_lint" : testCase.Tools.CFNLint,
-                            "cfn_nag"  : testCase.Tools.CFNNag
-                        }
-                    }
-                )]
-
-                [#list (testCase.Structural.JSON.Match)!{} as id,matchTest ]
-                    [#local tests = combineEntities(tests,
+                    [#local tests = mergeObjects(
+                        tests,
                         {
-                            testCaseFullName : {
-                                "json_structure" : {
-                                    "match" : [
-                                        {
-                                            "path" : matchTest.Path,
-                                            "value" : matchTest.Value
-                                        }
-                                    ]
-                                }
+                            testCaseFullName  : {
+                                "filename" : outputFileName,
+                                "cfn_lint" : testCase.Tools.CFNLint,
+                                "cfn_nag"  : testCase.Tools.CFNNag
                             }
-                        },
-                        APPEND_COMBINE_BEHAVIOUR
+                        }
                     )]
-                [/#list]
 
-                [#list (testCase.Structural.JSON.Length)!{} as id,legnthTest ]
-                    [#local tests = combineEntities(tests,
-                        {
-                            testCaseFullName : {
-                                "json_structure"  : {
-                                    "length" : [
+                    [#list (testCase.Structural.JSON.Match)!{} as id,matchTest ]
+                        [#local tests = combineEntities(tests,
+                            {
+                                testCaseFullName : {
+                                    "json_structure" : {
+                                        "match" : [
                                             {
-                                                "path" : legnthTest.Path,
-                                                "value" : legnthTest.Count
+                                                "path" : matchTest.Path,
+                                                "value" : matchTest.Value
                                             }
-                                    ]
+                                        ]
+                                    }
                                 }
-                            }
-                        },
-                        APPEND_COMBINE_BEHAVIOUR
-                    )]
-                [/#list]
-
-                [#if testCase.Structural.JSON.Exists?has_content ]
-                    [#local existPaths = []]
-                    [#list testCase.Structural.JSON.Exists as path ]
-                        [#local existPaths += [
-                                {
-                                    "path" : path
-                                }
-                            ]
-                        ]
+                            },
+                            APPEND_COMBINE_BEHAVIOUR
+                        )]
                     [/#list]
-                    [#local tests = mergeObjects(
-                        tests,
-                        {
-                            testCaseFullName  : {
-                                "json_structure" : {
-                                    "exists" : existPaths
-                                }
-                            }
-                        }
-                    )]
-                [/#if]
 
-                [#if testCase.Structural.JSON.NotEmpty?has_content ]
-                    [#local notEmtpyPaths = []]
-                    [#list testCase.Structural.JSON.NotEmpty as path ]
-                        [#local notEmtpyPaths += [
-                                {
-                                    "path" : path
+                    [#list (testCase.Structural.JSON.Length)!{} as id,legnthTest ]
+                        [#local tests = combineEntities(tests,
+                            {
+                                testCaseFullName : {
+                                    "json_structure"  : {
+                                        "length" : [
+                                                {
+                                                    "path" : legnthTest.Path,
+                                                    "value" : legnthTest.Count
+                                                }
+                                        ]
+                                    }
                                 }
-                            ]
-                        ]
+                            },
+                            APPEND_COMBINE_BEHAVIOUR
+                        )]
                     [/#list]
-                    [#local tests = mergeObjects(
-                        tests,
-                        {
-                            testCaseFullName  : {
-                                "json_structure" : {
-                                    "not_empty" : notEmtpyPaths
-                                }
-                            }
-                        }
-                    )]
-                [/#if]
 
-                [#list (testCase.Structural.CFN.Resource)!{} as id,CFNResourceTest ]
-                    [#local tests = combineEntities(tests,
-                        {
-                            testCaseFullName : {
-                                "cfn_structure"  : {
-                                    "resource" : [
-                                        {
-                                            "id" : CFNResourceTest.Name,
-                                            "type" : CFNResourceTest.Type
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        APPEND_COMBINE_BEHAVIOUR
-                    )]
-                [/#list]
-
-                [#if testCase.Structural.CFN.Output?has_content ]
-                    [#local cfnOutputPaths = []]
-                    [#list testCase.Structural.CFN.Output as path ]
-                        [#local cfnOutputPaths += [
-                                {
-                                    "id" : path
-                                }
+                    [#if testCase.Structural.JSON.Exists?has_content ]
+                        [#local existPaths = []]
+                        [#list testCase.Structural.JSON.Exists as path ]
+                            [#local existPaths += [
+                                    {
+                                        "path" : path
+                                    }
+                                ]
                             ]
-                        ]
-                    [/#list]
-                    [#local tests = mergeObjects(
-                        tests,
-                        {
-                            testCaseFullName  : {
-                                "cfn_structure" : {
-                                    "output" : cfnOutputPaths
+                        [/#list]
+                        [#local tests = mergeObjects(
+                            tests,
+                            {
+                                testCaseFullName  : {
+                                    "json_structure" : {
+                                        "exists" : existPaths
+                                    }
                                 }
                             }
-                        }
-                    )]
-                [/#if]
-            [/#if]
-        [/#list]
+                        )]
+                    [/#if]
 
-        [@addToDefaultJsonOutput
-            content=tests
-        /]
+                    [#if testCase.Structural.JSON.NotEmpty?has_content ]
+                        [#local notEmtpyPaths = []]
+                        [#list testCase.Structural.JSON.NotEmpty as path ]
+                            [#local notEmtpyPaths += [
+                                    {
+                                        "path" : path
+                                    }
+                                ]
+                            ]
+                        [/#list]
+                        [#local tests = mergeObjects(
+                            tests,
+                            {
+                                testCaseFullName  : {
+                                    "json_structure" : {
+                                        "not_empty" : notEmtpyPaths
+                                    }
+                                }
+                            }
+                        )]
+                    [/#if]
+
+                    [#list (testCase.Structural.CFN.Resource)!{} as id,CFNResourceTest ]
+                        [#local tests = combineEntities(tests,
+                            {
+                                testCaseFullName : {
+                                    "cfn_structure"  : {
+                                        "resource" : [
+                                            {
+                                                "id" : CFNResourceTest.Name,
+                                                "type" : CFNResourceTest.Type
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            APPEND_COMBINE_BEHAVIOUR
+                        )]
+                    [/#list]
+
+                    [#if testCase.Structural.CFN.Output?has_content ]
+                        [#local cfnOutputPaths = []]
+                        [#list testCase.Structural.CFN.Output as path ]
+                            [#local cfnOutputPaths += [
+                                    {
+                                        "id" : path
+                                    }
+                                ]
+                            ]
+                        [/#list]
+                        [#local tests = mergeObjects(
+                            tests,
+                            {
+                                testCaseFullName  : {
+                                    "cfn_structure" : {
+                                        "output" : cfnOutputPaths
+                                    }
+                                }
+                            }
+                        )]
+                    [/#if]
+                [/#if]
+            [/#list]
+
+
+            [@addToDefaultJsonOutput
+                content=tests
+            /]
+        [/#if]
     [/#list]
 [/#macro]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

fixes an issue when subcomponent deployments have different deployment units or groups defined and test cases were created across all units

## Motivation and Context

Test cases are generated based on deployment outputs so when dealing with components which have multiple deployments all test cases were being included across the different deployments. As a result the test cases would fail when checking for content

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

