### PR TITLE
fix: get attributes from plugin set

### DIFF
--- a/providers/shared/tasks/install_plugin/id.ftl
+++ b/providers/shared/tasks/install_plugin/id.ftl
@@ -8,5 +8,5 @@
                 "Value" : "Install a hamlet plugin from the source provided"
             }
         ]
-    attributes=getAttributeSet(PLUGIN_ATTRIBUTESET_TYPE)
+    attributes=getAttributeSet(PLUGIN_ATTRIBUTESET_TYPE).Attributes
 /]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

fixes the attributes value provided to the install_plugin task

## Motivation and Context

Plugins now use an attribute set so we need to access the attribute set Attributes to align with the plugin install tak 

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

