### PR TITLE
fix: allow for multiple module loads in input processing

### DIFF
--- a/engine/module.ftl
+++ b/engine/module.ftl
@@ -50,7 +50,6 @@
 [/#function]
 
 [#-- Loads the module data into the input data --]
-
 [#macro loadModule
     blueprint={}
     settingSets=[]
@@ -76,11 +75,41 @@
 
     [#-- attributeIfContent() returns an empty object if no content --]
     [#assign moduleInputState =
-        attributeIfContent(COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS, commandLineOption) +
-        attributeIfContent(BLUEPRINT_CONFIG_INPUT_CLASS, blueprint) +
-        attributeIfContent(SETTINGS_CONFIG_INPUT_CLASS, formattedModuleSettings) +
-        attributeIfContent(DEFINITIONS_CONFIG_INPUT_CLASS, definitions) +
-        attributeIfContent(STATE_CONFIG_INPUT_CLASS, stackOutputs)
+        attributeIfContent(
+            COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS,
+            mergeObjects(
+                (moduleInputState[COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS])!{},
+                commandLineOption
+            )
+        ) +
+        attributeIfContent(
+            BLUEPRINT_CONFIG_INPUT_CLASS,
+            mergeObjects(
+                (moduleInputState[BLUEPRINT_CONFIG_INPUT_CLASS])!{},
+                blueprint
+            )
+        ) +
+        attributeIfContent(
+            SETTINGS_CONFIG_INPUT_CLASS,
+            mergeObjects(
+                (moduleInputState[SETTINGS_CONFIG_INPUT_CLASS])!{},
+                formattedModuleSettings
+            )
+        ) +
+        attributeIfContent(
+            DEFINITIONS_CONFIG_INPUT_CLASS,
+            mergeObjects(
+                (moduleInputState[DEFINITIONS_CONFIG_INPUT_CLASS])!{},
+                definitions
+            )
+        ) +
+        attributeIfContent(
+            STATE_CONFIG_INPUT_CLASS,
+            combineEntities(
+                (moduleInputState[STATE_CONFIG_INPUT_CLASS])![],
+                stackOutputs
+            )
+        )
     ]
 [/#macro]
 


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Allows for calling loadModule multiple times within a given module. 

## Motivation and Context

This is often used to make modules cleaner from a readability side and to isolate sections of the module

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

