### PR TITLE
fix: handle missing domains on products

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -617,7 +617,7 @@
 [#function getDomainObjects certificateObject ]
     [#local result = [] ]
     [#local primaryNotSeen = true]
-    [#local lines = getObjectLineage(domains, certificateObject.Domain) ]
+    [#local lines = getObjectLineage(domains, (certificateObject.Domain)!"") ]
     [#list lines as line]
         [#local name = "" ]
         [#local role = DOMAIN_ROLE_PRIMARY ]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

When a domain hasn't been defined on products handle the missing domain and leave the component to determine how to handle it

## Motivation and Context

This allows you to use minimal configuration when deploying a product and rely on cloud provider hostnames if that is possible


## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

