### PR TITLE
feat: add firewall component

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -72,6 +72,9 @@
 
 [#assign FILETRANSFER_COMPONENT_TYPE = "filetransfer"]
 
+[#assign FIREWALL_COMPONENT_TYPE = "firewall"]
+[#assign FIREWALL_RULE_COMPONENT_TYPE = "firewallrule"]
+
 [#assign GLOBALDB_COMPONENT_TYPE = "globaldb" ]
 
 [#assign HEALTHCHECK_COMPONENT_TYPE = "healthcheck" ]

--- a/providers/shared/components/firewall/id.ftl
+++ b/providers/shared/components/firewall/id.ftl
@@ -1,0 +1,219 @@
+[#ftl]
+
+[@addComponentDeployment
+    type=FIREWALL_COMPONENT_TYPE
+    defaultGroup="segment"
+    defaultPriority=60
+/]
+
+[@addComponent
+    type=FIREWALL_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A network security service to filter inbound and outbound traffic"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Types" : STRING_TYPE,
+                "Values" : [ "network" ],
+                "Required" : true
+            },
+            {
+                "Names" : "Logging",
+                "Description" : "Configure where logs are directed",
+                "Children" : [
+                    {
+                        "Names" : "Events",
+                        "Description" : "The log events to capture on the firewall",
+                        "Values" : [ "all", "alert-only" ],
+                        "Default" : "alert-only"
+                    },
+                    {
+                        "Names" : "DestinationType",
+                        "Description" : "The destination to forward logs to",
+                        "Values" : [ "log", "s3", "datafeed" ],
+                        "Default" : "log"
+                    },
+                    {
+                        "Names" : "destinationType:s3",
+                        "Description" : "Specific configuration for S3 logging",
+                        "Children" : [
+                            {
+                                "Names" : "Link",
+                                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+                            },
+                            {
+                                "Names" : "Prefix",
+                                "Description" : "A prefix to append to logs",
+                                "AttributeSet" : CONTEXTPATH_ATTRIBUTESET_TYPE
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "destinationType:datafeed",
+                        "Description" : "Specific configuration for datafeed logging",
+                        "Children" : [
+                            {
+                                "Names" : "Link",
+                                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+                            }
+                        ]
+                    }
+                ]
+            }
+            {
+                "Names" : "Links",
+                "SubObjects" : true,
+                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=FIREWALL_RULE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A firewall policy rule applied by the firewall"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "segment"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "Active",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "Action",
+                "Description" : "The action to perform on a match of this rule",
+                "Values" : [ "pass", "drop", "inspect", "alert", "monitor" ]
+            },
+            {
+                "Names" : "Type",
+                "Description" : "The type of rule to be applied",
+                "Types" : STRING_TYPE,
+                "Values" : [ "NetworkTuple", "HostFilter", "NetworkComplex" ],
+                "Default" : "NetworkTuple"
+            },
+            {
+                "Names" : "NetworkTuple",
+                "Description" : "Rule configuration for the networkTuple rule type",
+                "Children" : [
+                    {
+                        "Names" : "Source",
+                        "Description" : "The details of the network traffic source",
+                        "Children" : [
+                            {
+                                "Names" : "Port",
+                                "Description" : "The name of the Port reference",
+                                "Types" : STRING_TYPE,
+                                "Default" : "any"
+                            },
+                            {
+                                "Names" : "IPAddressGroups",
+                                "Description" : "The IP address group names for the source",
+                                "Types" : ARRAY_OF_STRING_TYPE,
+                                "Default" : [ "_global" ]
+                            },
+                            {
+                                "Names" : "Links",
+                                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "Destination",
+                        "Description" : "The details of the network traffic destinations",
+                        "Children" : [
+                            {
+                                "Names" : "Port",
+                                "Description" : "The name of the Port reference",
+                                "Types" : STRING_TYPE
+                            },
+                            {
+                                "Names" : "IPAddressGroups",
+                                "Description" : "The IP address group names for the source",
+                                "Types" : ARRAY_OF_STRING_TYPE
+                            },
+                            {
+                                "Names" : "Links",
+                                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "Names" : "HostFilter",
+                "Description" : "Filter traffic based on Host requested",
+                "Children" : [
+                    {
+                        "Names" : "LinkEndpoints",
+                        "Description" : "Links to components for Host endpoints",
+                        "SubObjects" : true,
+                        "Children" : [
+                            {
+                                "Names" : "Link",
+                                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+                            },
+                            {
+                                "Names" : "Attribute",
+                                "Description" : "The link Attribute to get the host from",
+                                "Types" : STRING_TYPE,
+                                "Default" : "FQDN"
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "Hosts",
+                        "Description" : "A collection of hosts to include use *. for wilcard domains",
+                        "Types" : ARRAY_OF_STRING_TYPE
+                    }
+                ]
+            },
+            {
+                "Names" : "NetworkComplex",
+                "Description" : "Complex network rule matching",
+                "Children" : [
+                    {
+                        "Names" : "Extensions",
+                        "Description" : "A list of extensions to use for rule generation",
+                        "Types" : ARRAY_OF_STRING_TYPE
+                    },
+                    {
+                        "Names" : "Links",
+                        "Description" : "Links to be used as part of the extension",
+                        "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+                    },
+                    {
+                        "Names" : "IPAddressGroups",
+                        "Description" : "A collection of IP AddressGroups to use during complex processing",
+                        "Types" : ARRAY_OF_STRING_TYPE
+                    },
+                    {
+                        "Names" : "Ports",
+                        "Description" : "A collection of ports to use during complex processing",
+                        "Types" : ARRAY_OF_STRING_TYPE
+                    }
+                ]
+            }
+        ]
+    parent=FIREWALL_COMPONENT_TYPE
+    childAttribute="Rules"
+    linkAttributes="Rule"
+/]


### PR DESCRIPTION

## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

adds the definition for a firewall component which provides network level traffic inspection for both inbound and/or outbound flows

## Motivation and Context

This allows for the implementation of network level packet inspection of traffic coming into and out of private networks. The firewall component should cover the configuration of different firewall engines, including network and DNS level firewall implementations

## How Has This Been Tested?

Schema generation testing

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

