### PR TITLE
feat: IANA IP protocol number mappings

### DIFF
--- a/providers/shared/components/id.ftl
+++ b/providers/shared/components/id.ftl
@@ -92,6 +92,7 @@
 [#assign URL_ATTRIBUTE_TYPE = "url" ]
 [#assign DNS_ATTRIBUTE_TYPE = "dns" ]
 [#assign NAME_ATTRIBUTE_TYPE = "name" ]
+[#assign INTERFACE_ATTRIBUTE_TYPE = "interface"]
 [#assign IP_ADDRESS_ATTRIBUTE_TYPE = "ip" ]
 [#assign ALLOCATION_ATTRIBUTE_TYPE = "id" ]
 [#assign CANONICAL_ID_ATTRIBUTE_TYPE = "canonicalid" ]

--- a/providers/shared/references/Port/id.ftl
+++ b/providers/shared/references/Port/id.ftl
@@ -1,5 +1,32 @@
 [#ftl]
 
+[#function getIANAIPProtocolNumber port ]
+    [#switch (port.IPProtocol)?lower_case ]
+        [#case "tcp" ]
+            [#return 6]
+            [#break]
+        [#case "udp"]
+            [#return 17]
+            [#break]
+        [#case "icmp"]
+            [#return 1]
+            [#break]
+        [#case "gre"]
+            [#return 47]
+            [#break]
+        [#case "esp"]
+            [#return 50]
+            [#break]
+        [#case "ah"]
+            [#return 51]
+            [#break]
+        [#case "ipv6-icmp"]
+            [#return 58]
+            [#break]
+    [/#switch]
+    [#return ""]
+[/#function]
+
 [@addReference
     type=PORT_REFERENCE_TYPE
     pluralType="Ports"


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Small helper function to provide the IANA protocol numbers based on our Port IP Protocol values
- Adds interface attribute type

## Motivation and Context

To avoid confusion about protocol names some cloud provider templates require the protocol number instead of the name

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

