### PR TITLE
fix: permit the mocking of empty values

### DIFF
--- a/engine/inputdata/inputsource.ftl
+++ b/engine/inputdata/inputsource.ftl
@@ -823,7 +823,7 @@ which is useful in situations like link processing.
 [/#function]
 
 [#-- Get combined class cache data for one or more stages --]
-[#function getConfigPipelineClassCacheForStages state class stages=[] ]
+[#function getConfigPipelineClassCacheForStages state class stages=[] behaviour=MERGE_COMBINE_BEHAVIOUR ]
     [#local result = {} ]
     [#list asArray(stages) as stage]
         [#if (state[CONFIG_INPUT_PIPELINE_STAGE_CACHE][stage][class])?? ]
@@ -832,7 +832,8 @@ which is useful in situations like link processing.
                     result,
                     {
                         class : state[CONFIG_INPUT_PIPELINE_STAGE_CACHE][stage][class]
-                    }
+                    },
+                    behaviour
                 )
             ]
         [/#if]

--- a/engine/module.ftl
+++ b/engine/module.ftl
@@ -49,7 +49,13 @@
     ]
 [/#function]
 
-[#-- Loads the module data into the input data --]
+[#-- Loads the module data into the input data      --]
+[#-- Note that a module may choose to call this     --]
+[#-- macro multiple times so we need to ensure      --]
+[#-- any pre-existing moduleInputState is preserved --]
+[#-- For state, the order to the calls should be    --]
+[#-- Highest priority first given the way output    --]
+[#-- searching is performed                         --]
 [#macro loadModule
     blueprint={}
     settingSets=[]
@@ -107,7 +113,8 @@
             STATE_CONFIG_INPUT_CLASS,
             combineEntities(
                 (moduleInputState[STATE_CONFIG_INPUT_CLASS])![],
-                stackOutputs
+                stackOutputs,
+                APPEND_COMBINE_BEHAVIOUR
             )
         )
     ]

--- a/providers/shared/views/unitlist/setup.ftl
+++ b/providers/shared/views/unitlist/setup.ftl
@@ -7,6 +7,11 @@
     [#-- Using this state we then create a contract step using the _orphan deployment mode to decide what to do --]
     [#list getState() as pointSet ]
 
+        [#if !pointSet.Account?? || !pointSet.Region?? || !pointSet.DeploymentUnit?? ]
+            [@fatal message="Missing mandatory attributes on stack outputs - Account, Region and DeploymentUnit required." context=pointSet /]
+            [#continue]
+        [/#if]
+
         [#local deploymentUnit = pointSet.DeploymentUnit ]
 
         [#local deploymentGroups = []]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Description
Permit the use of a "marker" value of `hamlet:empty` to signify that the value of a stack output should be an empty string. 

The marker value is converted to lower case so any preference for casing can be used - all lower case recommended.

Correct several bugs related to the handling of fixture and mock stack outputs, mainly related to appending rather than merging stack outputs.

Note that when providing mock stack outputs, Account, Region, and DeploymentUnit must also be provided e.g.

    ```
    stackOutputs=[
        {
            "Account" : "0123456789",
            "Region" : "mock-region-1",
            "DeploymentUnit" : "aws-cdn-spa-base",
            "cfXwebXcdnspabase": "hamlet:empty"
        }
    ]
    ```
## Motivation and Context

Fixes #1753 

This is used during testing to ensure that legacy stack outputs can be simulated. The empty value is treated as a missing output rather than always being present.

## How Has This Been Tested?
Local testing with the branch being developed to address #1134 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

