### PR TITLE
refactor: add Hostname as an alternate to Certificate

### DIFF
--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -149,7 +149,7 @@ object.
                 ]
             },
             {
-                "Names" : "Certificate",
+                "Names" : [ "Certificate", "Hostname" ],
                 "Children" : certificateChildConfiguration
             },
             {

--- a/providers/shared/components/cdn/id.ftl
+++ b/providers/shared/components/cdn/id.ftl
@@ -87,7 +87,7 @@
                 "Default" : []
             },
             {
-                "Names" : "Certificate",
+                "Names" : [ "Certificate", "Hostname" ],
                 "Children" : certificateChildConfiguration
             },
             {

--- a/providers/shared/components/filetransfer/id.ftl
+++ b/providers/shared/components/filetransfer/id.ftl
@@ -28,7 +28,7 @@
                 "Default" : []
             },
             {
-                "Names" : "Certificate",
+                "Names" : [ "Certificate", "Hostname" ],
                 "Children" : certificateChildConfiguration
             },
             {

--- a/providers/shared/components/lb/id.ftl
+++ b/providers/shared/components/lb/id.ftl
@@ -86,7 +86,7 @@
                 "Default" : [ "_localnet" ]
             },
             {
-                "Names" : "Certificate",
+                "Names" : [ "Certificate", "Hostname" ],
                 "Children" : certificateChildConfiguration
             },
             {

--- a/providers/shared/components/mta/id.ftl
+++ b/providers/shared/components/mta/id.ftl
@@ -24,7 +24,7 @@
                 "Mandatory" : true
             },
             {
-                "Names" : "Certificate",
+                "Names" : [ "Certificate", "Hostname" ],
                 "Description" : "Configure the domain(s) associated with this MTA",
                 "Children" : certificateChildConfiguration
             },

--- a/providers/shared/components/userpool/id.ftl
+++ b/providers/shared/components/userpool/id.ftl
@@ -203,7 +203,7 @@
                 "Description" : "Provision a managed endpoint for login and oauth endpoints",
                 "Children" : [
                     {
-                        "Names" : "Certificate",
+                        "Names" : [ "Certificate", "Hostname" ],
                         "Children" : certificateChildConfiguration
                     }
                 ]


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
adds an alternate name on all Certificate Configuration sections as Hostname.

## Motivation and Context

This aligns more with the configuration that the configuration offers to the user with the Certificate lookup we perform within the engine a consumer of this configuration

## How Has This Been Tested?

tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

