### PR TITLE
feat: adds zone based lookup for tiers

### DIFF
--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -507,6 +507,7 @@
 
     [#if groupId?starts_with("_tier") || groupId?starts_with("__tier") ]
         [#local lookupTier = groupId?split(":")[1] ]
+        [#local lookupZone = (groupId?split(":")[2])!"" ]
         [#if ! lookupTier?has_content ]
             [@fatal
                 message="Invalid Tier IP AddressGroup"
@@ -579,9 +580,10 @@
 
                 [#local tierSubnets = []]
                 [#list tierResources as zone,resource ]
-                    [#local tierSubnets += [ resource.subnet.Address ] ]
+                    [#if (lookupZone?has_content && zone == lookupZone) || ! (lookupZone?has_content) ]
+                        [#local tierSubnets += [ resource.subnet.Address ] ]
+                    [/#if]
                 [/#list]
-
                 [#return
                     {
                         "Id" : groupDetailId,


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

adds support for including the zone id as part tier based lookups. If the zone Id is included IPAddress group only that zone tier subnet will be returned

## Motivation and Context

This is allows for finding zone based subnets when deploying zone based resources 

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

