### PR TITLE
refactor: wildcard behaviour of getCompositeObject

### DIFF
--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -1038,8 +1038,10 @@ are added.
 
     [#-- Either no attribute configuration has been provided or a name wildcard was encountered --]
     [#list candidates as object]
-        [#-- TODO(mfl) Should this be a merge? Doing so would represent a change in behaviour --]
-        [#local result += removeObjectAttributes(object, explicitAttributes) ]
+        [#-- Previously object addition was used to generate the result but this was changed  --]
+        [#-- to a merge to permit multiple candidates to contribute to the value of top level --]
+        [#-- attribute that have object values                                                --]
+        [#local result = mergeObjects(result, removeObjectAttributes(object, explicitAttributes)) ]
     [/#list]
     [#return result ]
 [/#function]

--- a/engine/openapi.ftl
+++ b/engine/openapi.ftl
@@ -627,6 +627,11 @@ thus adding to the requirements specified in the definition itself.
 A security attribute is explicitly written out every time so technically
 the method security attribute will always override the global one, but it
 is useful to see what the global settings are from a debug perspective
+
+Security configuration can be provided both globally and per method, both
+within the openapi specification and in the configuration (via the Patterns
+attribute). Thus this function accepts a list of definition and configuration
+objects.
 --]
 [#function getSecurity globalConfiguration definitionObjects configurationObjects ]
 


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
At present, the name wildcard processing of `getCompositeObject()` uses freemarker object addition. This means that only one object can contribute the content for any top level attribute.

This change replaces this with the use of `mergeObjects()`. The change will only affect top level attributes with an object value. The effect is that multiple input objects can contribute to the overall value.

A small documentation update for openapi processing is also included.

## Motivation and Context
The driver for the change is the use of modules to provide default settings content which can then be supplemented with explicit settings, an example being the provision of default api gateway integrations in a
module.

## How Has This Been Tested?
Local template processing

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

