### PR TITLE
feat(linkref): initial implementation

### DIFF
--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -1935,7 +1935,7 @@ but 50 will be used assuming the Environment is prod;
 
 {
     "Value" : 100,
-    "Qualifiers : [
+    "Qualifiers" : [
         {
             "Filter" : {"Environment" : "prod"},
             "MatchBehaviour" : ONETOONE_FILTER_MATCH_BEHAVIOUR,

--- a/providers/shared/attributesets/links/id.ftl
+++ b/providers/shared/attributesets/links/id.ftl
@@ -10,6 +10,10 @@
         }]
     attributes=[
         {
+            "Names" : "LinkRef",
+            "Type" : STRING_TYPE
+        },
+        {
             "Names" : "IncludeInContext",
             "Description" : "Include the attributes provided by this link in the environment context",
             "Type" : ARRAY_OF_STRING_TYPE
@@ -60,13 +64,11 @@
         },
         {
             "Names" : "Tier",
-            "Type" : STRING_TYPE,
-            "Mandatory" : true
+            "Type" : STRING_TYPE
         },
         {
             "Names" : "Component",
-            "Type" : STRING_TYPE,
-            "Mandatory" : true
+            "Type" : STRING_TYPE
         },
         {
             "Names" : "SubComponent",

--- a/providers/shared/layers/Product/id.ftl
+++ b/providers/shared/layers/Product/id.ftl
@@ -47,6 +47,11 @@
             "AttributeSet" : PLUGIN_ATTRIBUTESET_TYPE
         },
         {
+            "Names" : "LinkRefs",
+            "SubObjects" : true,
+            "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+        },
+        {
             "Names" : "Profiles",
             "Children" : [
                 {

--- a/providers/shared/layers/Solution/id.ftl
+++ b/providers/shared/layers/Solution/id.ftl
@@ -47,6 +47,11 @@
             "AttributeSet" : PLUGIN_ATTRIBUTESET_TYPE
         },
         {
+            "Names" : "LinkRefs",
+            "SubObjects" : true,
+            "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+        },
+        {
             "Names" : "MultiAZ",
             "Types" : BOOLEAN_TYPE
         },

--- a/providers/shared/layers/Tenant/id.ftl
+++ b/providers/shared/layers/Tenant/id.ftl
@@ -47,6 +47,11 @@
             "AttributeSet" : PLUGIN_ATTRIBUTESET_TYPE
         },
         {
+            "Names" : "LinkRefs",
+            "SubObjects" : true,
+            "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+        },
+        {
             "Names" : "Profiles",
             "Children" : [
                 {


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Initial implementation of `linkRefs`.

The actual implementation logic was quite straight forward. It uses recursive logic so nested linkRefs is supported, with detection of circular dependencies included.

A subset of layers currently support the `linkRefs` attribute but adding other simply requires the attribute being added to the layer definition and the layer included in the appropriate place in the layer priority order.

## Motivation and Context
Part of [ADR-0007](https://github.com/hamlet-io/architectural-decision-log/issues/15) implementation.

Also a useful way for modules to expose link based functionality without the consumer needing to know the internal details.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

