### PR TITLE
fix: annotated qualification

### DIFF
--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -2176,7 +2176,7 @@ Qualifiers can be nested, so processing is recursive.
         [/#if]
         [#if annotatedQualifiers?has_content]
             [#local result =
-                entity.Value?has_content?then(
+                entity.Value???then(
                     entity +
                     {
                         "Value" : result

--- a/providers/shared/components/network/id.ftl
+++ b/providers/shared/components/network/id.ftl
@@ -84,12 +84,6 @@
                                         "Names" : "Link",
                                         "Description" : "A link to the s3 bucket destination",
                                         "AttributeSet" : LINK_ATTRIBUTESET_TYPE
-                                    },
-                                    {
-                                        "Names" : "Prefix",
-                                        "Description" : "A prefix for the s3 bucket destination",
-                                        "Types" : STRING_TYPE,
-                                        "Default" : "FlowLogs/"
                                     }
                                 ]
                             },

--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -467,11 +467,11 @@
                                     "Id" :
                                         ((parentOccurrence.Core.Extensions.Id)![tierId, componentId]) + idExtensions,
                                     "RawId" :
-                                        ((parentOccurrence.Core.Extensions.Id)![tierId, componentRawId]) + rawIdExtensions,
+                                        ((parentOccurrence.Core.Extensions.RawId)![tierId, componentRawId]) + rawIdExtensions,
                                     "Name" :
                                         ((parentOccurrence.Core.Extensions.Name)![tierName, componentName]) + nameExtensions,
                                     "RawName" :
-                                        ((parentOccurrence.Core.Extensions.Name)![tierName, componentRawName]) + rawNameExtensions
+                                        ((parentOccurrence.Core.Extensions.RawName)![tierName, componentRawName]) + rawNameExtensions
                                 }
 
                             } +


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Correct a bug when annotating the result of qualification where it was not handling empty strings correctly.

Also remove some redundant config for DNSQuery logging, and correct the formatting of raw names.
 
## Motivation and Context
Increased use of qualifiers surfaced the issue when an empty string was the desired value of an attribute under some circumstances.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

