### PR TITLE
refactor: use SubComponent in links

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -883,7 +883,7 @@
         } +
         attributeIfTrue("Instance", port.LB.Instance??, port.LB.Instance!"") +
         attributeIfTrue("Version",  port.LB.Version??, port.LB.Version!"") +
-        attributeIfContent("PortMapping",  portMapping)
+        attributeIfContent("SubComponent",  portMapping)
     ]
     [@debug message=targetLinkName context=targetLink enabled=false /]
 
@@ -916,7 +916,7 @@
         } +
         attributeIfTrue("Instance", port.Registry.Instance??, port.Registry.Instance!"") +
         attributeIfTrue("Version",  port.Registry.Version??, port.Registry.Version!"") +
-        attributeIfContent("RegistryService",  registryService)
+        attributeIfContent("SubComponent",  registryService)
     ]
     [@debug message=targetLinkName context=targetLink enabled=false /]
 

--- a/providers/shared/components/baseline/id.ftl
+++ b/providers/shared/components/baseline/id.ftl
@@ -73,24 +73,6 @@
 
     [#list baselineProfile as key,value ]
         [#if baselineComponentNames?seq_contains(key)]
-            [#switch key?lower_case ]
-                [#case "opsdata" ]
-                [#case "appdata" ]
-                    [#local subComponentType = "DataBucket" ]
-                    [#break]
-
-                [#case "encryption" ]
-                [#case "sshkey" ]
-                [#case "cdnoriginkey" ]
-                    [#local subComponentType = "Key" ]
-                    [#break]
-
-                [#default]
-                    [@fatal
-                        message="Unknown baseline subcomponent"
-                        context=key
-                    /]
-            [/#switch]
 
             [#local baselineLink =
                 {
@@ -98,9 +80,9 @@
                     "Name" : "baseline",
                     "Tier" : "mgmt",
                     "Component" : "baseline",
+                    "SubComponent" : value,
                     "Instance" : "",
-                    "Version" : "",
-                    subComponentType : value
+                    "Version" : ""
                 }
             ]
             [#local baselineLinkTarget = getLinkTarget(occurrence, baselineLink, activeOnly, activeRequired )]


### PR DESCRIPTION
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Replace use of component specific keys in links with the more generic "SubComponent" attribute.

## Motivation and Context
Component specific link attributes are deprecated.

## How Has This Been Tested?
Local template generation.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

