### PR TITLE
feat: add a correspondent component

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -36,6 +36,8 @@
 [#assign CONTENTHUB_HUB_COMPONENT_TYPE = "contenthub"]
 [#assign CONTENTHUB_NODE_COMPONENT_TYPE = "contentnode"]
 
+[#assign CORRESPONDENT_COMPONENT_TYPE = "correspondent"]
+
 [#assign DATAFEED_COMPONENT_TYPE = "datafeed" ]
 
 [#assign DATAPIPELINE_COMPONENT_TYPE = "datapipeline"]

--- a/providers/shared/components/correspondent/id.ftl
+++ b/providers/shared/components/correspondent/id.ftl
@@ -1,0 +1,36 @@
+[#ftl]
+
+[@addComponentDeployment
+    type=CORRESPONDENT_COMPONENT_TYPE
+    defaultGroup="solution"
+    defaultPriority=70
+/]
+
+[@addComponent
+    type=CORRESPONDENT_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "An outbound and inbound marketing communications service such as AWS Pinpoint"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "Profiles",
+                "Children" : [
+                    {
+                        "Names" : "Logging",
+                        "Types" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
+            },
+            {
+                "Names" : "Links",
+                "SubObjects" : true,
+                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+            }
+        ]
+/]

--- a/providers/shared/components/correspondent/id.ftl
+++ b/providers/shared/components/correspondent/id.ftl
@@ -18,16 +18,6 @@
     attributes=
         [
             {
-                "Names" : "Profiles",
-                "Children" : [
-                    {
-                        "Names" : "Logging",
-                        "Types" : STRING_TYPE,
-                        "Default" : "default"
-                    }
-                ]
-            },
-            {
                 "Names" : "Links",
                 "SubObjects" : true,
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE

--- a/providers/shared/components/firewall/id.ftl
+++ b/providers/shared/components/firewall/id.ftl
@@ -75,7 +75,7 @@
                         ]
                     }
                 ]
-            }
+            },
             {
                 "Names" : "Links",
                 "SubObjects" : true,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Adds the definition for a correspondent component such as AWS Pinpoint
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows creating a component for marketing communication such as push, email or SMS notifications
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Schema generation testing
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- hamlet-io/engine-plugin-aws#391

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

