### PR TITLE
refactor: warnings for occurrence links

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -209,6 +209,17 @@
     [#return getOccurrenceChildren(occurrence)?has_content ]
 [/#function]
 
+[#function occurrencesInSameDeployment occurrenceA occurrenceB]
+    [#return
+        getOccurrenceDeploymentUnit(occurrenceA) == getOccurrenceDeploymentUnit(occurrenceB) &&
+        ( getOccurrenceDeploymentGroup(occurrenceA) == getOccurrenceDeploymentGroup(occurrenceB) ||
+            (
+                getOccurrenceDeploymentGroup(occurrenceB) == "" &&
+                occurrenceA.Core.Component.RawId == occurrenceB.Core.Component.RawId
+            )
+        )]
+[/#function]
+
 [#function constructOccurrenceSettings baseOccurrence type]
 
     [#local occurrence = baseOccurrence]

--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -275,12 +275,27 @@
 
             [#-- Determine if deployed --]
             [#local isDeployed = isOccurrenceDeployed(potentialOccurrence)]
+            [#local sameDeployment = occurrencesInSameDeployment(occurrence, potentialOccurrence)]
+            [#local isEnabled = (potentialOccurrence.Configuration.Solution.Enabled)!true]
 
             [#-- Always warn if linking to an inactive component --]
-            [#if !isDeployed && !activeRequired ]
+            [#if isEnabled && !sameDeployment && !isDeployed && !activeRequired ]
+
                 [@warn
-                    message="link occurrence not deployed - ${occurrence.Core.Name} -> ${potentialOccurrence.Core.Name}"
+                    message="link occurrence not deployed - ${occurrence.Core.RawName} -> ${potentialOccurrence.Core.RawName}"
                     detail="A link was made to an occurrence which has not been deployed"
+                    context={
+                        "Link" : link,
+                        "EffectiveInstance" : instanceToMatch,
+                        "EffectiveVersion" : versionToMatch
+                    }
+                /]
+            [/#if]
+
+            [#if !isEnabled ]
+                [@warn
+                    message="link occurrence is not enabled - ${occurrence.Core.RawName} -> ${potentialOccurrence.Core.RawName}"
+                    detail="A link was made to an occurrence that is not enabled"
                     context={
                         "Link" : link,
                         "EffectiveInstance" : instanceToMatch,


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

- Adds a check to see if linked occurrences are in the same deployment and doesn't raise a warning if they
- Adds an extra check to see if the occurrence is enabled or not and raises a warning if it is

## Motivation and Context

Removes warnings that can't be fixed ( i.e. an occurrence that is being deployed at the same time as the linking occurrence ) and makes it more obvious why a link had an issue

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

