### PR TITLE
feat: add maintenance windows for ec2 components

### DIFF
--- a/providers/shared/components/bastion/id.ftl
+++ b/providers/shared/components/bastion/id.ftl
@@ -133,6 +133,11 @@
                         "AttributeSet" : OPERATINGSYSTEM_ATTRIBUTESET_TYPE
                     },
                     {
+                        "Names" : "MaintenanceWindow",
+                        "Description" : "A configured window to apply maintenance on instances",
+                        "AttributeSet" : MAINTENANCEWINDOW_ATTRIBUTESET_TYPE
+                    },
+                    {
                         "Names" : "OSPatching",
                         "Description" : "Configuration for scheduled OS Patching",
                         "AttributeSet" : OSPATCHING_ATTRIBUTESET_TYPE

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -1067,6 +1067,11 @@
                 "AttributeSet" : ECS_COMPUTEIMAGE_ATTRIBUTESET_TYPE
             },
             {
+                "Names" : "MaintenanceWindow",
+                "Description" : "A configured window to apply maintenance on instances",
+                "AttributeSet" : MAINTENANCEWINDOW_ATTRIBUTESET_TYPE
+            },
+            {
                 "Names" : "OperatingSystem",
                 "Description" : "The operating system details of the compute instance",
                 "AttributeSet" : OPERATINGSYSTEM_ATTRIBUTESET_TYPE

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -162,6 +162,11 @@
                         "AttributeSet" : COMPUTEIMAGE_ATTRIBUTESET_TYPE
                     },
                     {
+                        "Names" : "MaintenanceWindow",
+                        "Description" : "A configured window to apply maintenance on instances",
+                        "AttributeSet" : MAINTENANCEWINDOW_ATTRIBUTESET_TYPE
+                    },
+                    {
                         "Names" : "OperatingSystem",
                         "Description" : "The operating system details of the compute instance",
                         "AttributeSet" : OPERATINGSYSTEM_ATTRIBUTESET_TYPE

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -149,6 +149,11 @@
                         "AttributeSet" : OPERATINGSYSTEM_ATTRIBUTESET_TYPE
                     },
                     {
+                        "Names" : "MaintenanceWindow",
+                        "Description" : "A configured window to apply maintenance on instances",
+                        "AttributeSet" : MAINTENANCEWINDOW_ATTRIBUTESET_TYPE
+                    },
+                    {
                         "Names" : "OSPatching",
                         "Description" : "Configuration for scheduled OS Patching",
                         "AttributeSet" : OSPATCHING_ATTRIBUTESET_TYPE


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds support for defining maintenance windows on ec2 based components

## Motivation and Context

Allows for integration with scheduled maintenance services like AWS SSM Maintenance Windows

## How Has This Been Tested?

Ongoing

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

