### PR TITLE
feat(firewall): routing destination support

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -76,6 +76,7 @@
 
 [#assign FIREWALL_COMPONENT_TYPE = "firewall"]
 [#assign FIREWALL_RULE_COMPONENT_TYPE = "firewallrule"]
+[#assign FIREWALL_DESTINATION_COMPONENT_TYPE = "firewalldestination"]
 
 [#assign GLOBALDB_COMPONENT_TYPE = "globaldb" ]
 

--- a/providers/shared/components/firewall/id.ftl
+++ b/providers/shared/components/firewall/id.ftl
@@ -247,3 +247,44 @@
     childAttribute="Rules"
     linkAttributes="Rule"
 /]
+
+[@addChildComponent
+    type=FIREWALL_DESTINATION_COMPONENT_TYPE
+    parent=FIREWALL_COMPONENT_TYPE
+    childAttribute="Destinations"
+    linkAttributes="Destination"
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A network destination offerred by the firewall"
+            },
+            {
+                "Type" : "Providers",
+                "Value" : [ "aws" ]
+            },
+            {
+                "Type" : "ComponentLevel",
+                "Value" : "segment"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "Active",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
+                "Names" : "IPAddressGroups",
+                "Description" : "An IP Address Group reference",
+                "Types" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
+                "Names" : "Links",
+                "SubObjects" : true,
+                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+            }
+        ]
+/]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

adds support for firewalls to add routes into existing route tables using their destination sub component

## Motivation and Context

Allows for firewalls to follow the same pattern that we have in place for gateways where they offer their destinations to route tables

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

