### PR TITLE
feat: subscription, hostingplatform and dnszone components

### DIFF
--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -286,7 +286,7 @@
                     },
                     {
                         "Names" : "TargetComponentTypes",
-                        "Description" : "Enable at rest encryption",
+                        "Description" : "Supported types for targetted components",
                         "Types" : ARRAY_OF_STRING_TYPE,
                         "Mandatory" : true
                     }

--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -50,11 +50,14 @@
 
     [#-- Resource groups --]
     [#list [DEFAULT_RESOURCE_GROUP] + asArray(additionalResourceGroups) as resourceGroup]
-        [@addResourceGroupInformation
+        [@internalMergeComponentConfiguration
             type=type
-            attributes=[]
-            provider=""
-            resourceGroup=resourceGroup
+            configuration=
+                {
+                    "ResourceGroups" : {
+                        resourceGroup : {}
+                    }
+                }
         /]
     [/#list]
 
@@ -220,11 +223,18 @@
 [#macro addResourceGroupInformation type attributes provider resourceGroup services=[] prefixed=true locations={} ]
 
     [#-- Ensure resource group is known - it should have been registered when the component was registered --]
-    [#if !(componentConfiguration[type].ResourceGroups[resourceGroup])?? ]
+    [#if !componentConfiguration[type]?? ]
         [@fatal
-            message='Internal error - attempt to provide information for unkwown ResourceGroup "${resourceGroup}" on component type "${type}"'
+            message='Internal error - attempt to add ResourceGroup information for provider "${provider}" on unknown component type "${type}"'
         /]
         [#return]
+    [#else]
+        [#if !componentConfiguration[type].ResourceGroups[resourceGroup]?? ]
+            [@fatal
+                message='Internal error - attempt to provide information for unknown ResourceGroup "${resourceGroup}" on component type "${type}" for provider "${provider}"'
+            /]
+            [#return]
+        [/#if]
     [/#if]
 
     [#if provider == SHARED_ATTRIBUTES ]

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -15,7 +15,7 @@
             componentId=parentOccurrence.Core.Component.RawId
             instanceId=parentOccurrence.Core.Instance.Id
             versionId=parentOccurrence.Core.Version.Id
-            subComponentId=occurrence.Core.SubComponent.Id
+            subComponentId=occurrence.Core.SubComponent.RawId
             subInstanceId=occurrence.Core.Instance.Id
             subVersionId=occurrence.Core.Version.Id
             occurrence=occurrence
@@ -39,7 +39,7 @@
         [#local componentId = parentOccurrence.Core.Component.RawId ]
         [#local instanceId = parentOccurrence.Core.Instance.Id ]
         [#local versionId = parentOccurrence.Core.Version.Id ]
-        [#local subComponentId = occurrence.Core.SubComponent.Id ]
+        [#local subComponentId = occurrence.Core.SubComponent.RawId ]
         [#local subComponentType = occurrence.Core.Type ]
         [#local subInstanceId = occurrence.Core.Instance.Id ]
         [#local subVersionId = occurrence.Core.Version.Id ]
@@ -134,12 +134,12 @@
 [/#function]
 
 [#function getOccurrenceDeploymentUnit occurrence]
-    [#local solution = occurrence.Configuration.Solution ]
+    [#local solution = (occurrence.Configuration.Solution)!{} ]
     [#return getDeploymentUnitId(solution) ]
 [/#function]
 
 [#function getOccurrenceDeploymentGroup occurrence]
-    [#local solution = occurrence.Configuration.Solution ]
+    [#local solution = (occurrence.Configuration.Solution)!{} ]
     [#return solution["deployment:Group"]!"" ]
 [/#function]
 
@@ -197,8 +197,16 @@
     [#return (occurrence.Configuration.Solution)!{} ]
 [/#function]
 
+[#function getOccurrenceLocations occurrence ]
+    [#return (occurrence.Configuration.Locations)!{} ]
+[/#function]
+
 [#function getOccurrenceResources occurrence ]
     [#return (occurrence.State.Resources)!{} ]
+[/#function]
+
+[#function getOccurrenceAttributes occurrence ]
+    [#return (occurrence.State.Attributes)!{} ]
 [/#function]
 
 [#function getOccurrenceChildren occurrence]
@@ -324,114 +332,191 @@
     [#return occurrence]
 [/#function]
 
+[#--
+Attribute extension
+
+Attribute extension is designed to permit providers to supplement any attributes
+defined in the shared provider. It is done in a way that permits multiple
+providers to extend the attributes simultaneously, but with extensions specific
+to the provider easily identified.
+
+A provider has two options - enrich an existing attribute or add namespaced attributes.
+
+** Attribute enrichment **
+
+If the name of the extension matches one of the names of the existing attributes,
+the attribute maintains its existing name, and the extension configuration is
+merged with the existing attribute configuration.
+
+Where the existing attribute has children, the extension is also expected to have
+children and attribute extension is recursively applied to each child.
+
+Where the extension provides possible values, any unique values are added to
+the existing attribute values. By default these values are prefixed based on the
+provided prefix attribute (a colon is used as a separator). However if the
+extension value starts with the provided disablePrefix, the disablePrefix is stripped.
+This allows a provider to contribute sharable as well as provider specific values.
+
+If the extension provides a default value, it will be merged with any existing
+value.
+
+If the extension provides an attribute set, this overrides any children definition
+currently on the existing attribute.
+
+** Namespaced attribute addition **
+
+If the extension names do not overlap those of the existing attributes, the extension
+is added to the list of attributes. All the extension names has the provided prefix
+added. Any Values or Default value are NOT prefixed, as they are defined within an
+already prefixed attribute.
+
+--]
 [#function extendAttributes attributes=[] extensions=[] prefix="" disablePrefix="shared:" ]
 
-    [#local result = []]
-    [#local prefix = prefix?ensure_ends_with(":")]
+    [#if ! extensions?has_content]
+        [#-- Nothing to do --]
+        [#return attributes]
+    [/#if]
 
-    [#if extensions?has_content]
-        [#list attributes as attribute]
+    [#local result = [] ]
+    [#local prefix = prefix?ensure_ends_with(":") ]
 
-            [#local attributeExtension =
-                extensions
-                ?filter(e -> asArray(attribute.Names)
-                ?seq_contains(e.Names))![]]
+    [#-- First extend existing attributes --]
+    [#list asArray(attributes) as attribute]
 
-            [#if attributeExtension?has_content]
-                [#local attributeExtension = attributeExtension?first]
-                [#if (attribute.Children![])?has_content]
-                    [#if (attributeExtension.Children![])?has_content]
-                        [#local result += [
-                            mergeObjects(
-                                attribute,
-                                {
-                                    "Children" : extendAttributes(
-                                                    attribute.Children,
-                                                    attributeExtension.Children,
-                                                    prefix)
-                                }
-                            )
-                        ]]
-                    [#else]
-                        [@fatal
-                            message="Attribute Extension missing children."
-                            context={
-                                "Attribute" : attribute,
-                                "Extension" : attributeExtension
-                            }
-                        /]
-                    [/#if]
-                [#else]
+        [#-- Check if any of the extensions have a name matching one of the existing attribute names --]
+        [#local attributeExtensions =
+            asArray(extensions)?filter(
+                e ->
+                    getArrayIntersection(
+                        asArray(attribute.Names),
+                        asArray(e.Names)
+                    )?has_content
+            )
+        ]
 
-                    [#local extendedAttributes = {}]
-                    [#local extendedValues = (attribute.Values)![]]
-                    [#list (attributeExtension.Values)![] as extensionValue]
+        [#-- At most one extension should match the existing attribute --]
+        [#if attributeExtensions?size > 1]
+            [@warning
+                message="Multiple attribute extensions match attribute"
+                context={
+                    "Attribute" : attribute,
+                    "MatchingExtensions" : attributeExtensions
+                }
+            /]
+        [/#if]
 
-                        [#if extensionValue?is_string ]
-                            [#local extendedValues +=
-                                [
-                                    extensionValue?starts_with(disablePrefix)?then(
-                                        extensionValue?remove_beginning(disablePrefix),
-                                        extensionValue?ensure_starts_with(prefix)
-                                    )
-                                ]]
-                        [#else ]
-                            [#local extendedValues += extensionValue ]
-                        [/#if]
-
-                        [#local extendedAttributes += {
-                            "Values" : getUniqueArrayElements(extendedValues)
-                        }]
-
-                    [/#list]
-
-                    [#if ((attributeExtension.Default)!"")?has_content ]
-                        [#local extendedAttributes += {
-                            "Default" : attributeExtension.Default
-                        } ]
-                    [/#if]
-
-                    [#if ((attributeExtension.AttributeSet)![])?has_content ]
-                        [#local extendedAttributes += {
-                            "AttributeSet" : attributeExtension.AttributeSet,
-                            "Children" : []
-                        }]
-                    [/#if]
-
+        [#if attributeExtensions?has_content]
+            [#local attributeExtension = attributeExtensions?first]
+            [#if (attribute.Children![])?has_content]
+                [#-- Recursively extend child definitions --]
+                [#if (attributeExtension.Children![])?has_content]
                     [#local result += [
                         mergeObjects(
                             attribute,
-                            extendedAttributes
-                        )]]
+                            {
+                                "Children" : extendAttributes(
+                                                attribute.Children,
+                                                attributeExtension.Children,
+                                                prefix)
+                            }
+                        )
+                    ]]
+                [#else]
+                    [@fatal
+                        message="Attribute Extension missing children."
+                        context={
+                            "Attribute" : attribute,
+                            "Extension" : attributeExtension
+                        }
+                    /]
                 [/#if]
             [#else]
-                [#local result += [attribute]]
-            [/#if]
-        [/#list]
 
-        [#local additionalAttributes = []]
-        [#list extensions as extension ]
-            [#list asArray(extension.Names) as name ]
-                [#if ! asFlattenedArray(attributes?map( a -> a.Names ))?seq_contains(name) ]
+                [#local extendedAttributes = {}]
+                [#local extendedValues = (attribute.Values)![]]
 
-                    [#local additionalAttributes = combineEntities(
-                                                        additionalAttributes,
-                                                        addPrefixToAttributes(
-                                                            [ extension ],
-                                                            prefix,
-                                                            true,
-                                                            false,
-                                                            false
-                                                        ),
-                                                        APPEND_COMBINE_BEHAVIOUR)]
+                [#-- Check for extra values --]
+                [#list (attributeExtension.Values)![] as extensionValue]
+
+                    [#if extensionValue?is_string ]
+                        [#-- If extension value starts with the disable prefix, --]
+                        [#-- value is shared so strip prefix, otherwise         --]
+                        [#-- force extension value to be prefixed               --]
+                        [#local extendedValues +=
+                            [
+                                extensionValue?starts_with(disablePrefix)?then(
+                                    extensionValue?remove_beginning(disablePrefix),
+                                    extensionValue?ensure_starts_with(prefix)
+                                )
+                            ]]
+                    [#else ]
+                        [#local extendedValues += extensionValue ]
+                    [/#if]
+
+                    [#-- At least one extended value so update the values list --]
+                    [#local extendedAttributes += {
+                        "Values" : getUniqueArrayElements(extendedValues)
+                    }]
+
+                [/#list]
+
+                [#-- Check for different default --]
+                [#if ((attributeExtension.Default)!"")?has_content ]
+                    [#local extendedAttributes += {
+                        "Default" : attributeExtension.Default
+                    } ]
                 [/#if]
-            [/#list]
-        [/#list]
-        [#local result = combineEntities(result, additionalAttributes, APPEND_COMBINE_BEHAVIOUR)]
 
-    [#else]
-        [#return attributes]
-    [/#if]
+                [#-- Extension has extra attributes defined via an attribute set --]
+                [#if ((attributeExtension.AttributeSet)![])?has_content ]
+                    [#local extendedAttributes += {
+                        "AttributeSet" : attributeExtension.AttributeSet,
+                        "Children" : []
+                    }]
+                [/#if]
+
+                [#local result += [
+                    mergeObjects(
+                        attribute,
+                        extendedAttributes
+                    )]]
+            [/#if]
+        [#else]
+            [#local result += [attribute]]
+        [/#if]
+    [/#list]
+
+    [#-- Deal with any new attributes contributed by the extensions --]
+    [#local additionalAttributes = [] ]
+    [#list extensions as extension ]
+
+        [#-- Check if the extension has a name matching one of the existing attribute names --]
+        [#-- If it does, it will already have been processed                                --]
+        [#if !
+            asArray(attributes)?filter(
+                a ->
+                    getArrayIntersection(
+                        asArray(extension.Names),
+                        asArray(a.Names)
+                    )?has_content
+            )?has_content
+        ]
+            [#-- The provided extension names will be prefixed. Any values or default are --]
+            [#-- NOT prefixed given that the extension names are prefixed.                --]
+            [#local additionalAttributes +=
+                addPrefixToAttributes(
+                    [ extension ],
+                    prefix,
+                    true,
+                    false,
+                    false
+                )
+            ]
+        [/#if]
+    [/#list]
+    [#local result += additionalAttributes ]
+
     [#return result]
 [/#function]
 
@@ -440,20 +525,23 @@
 
     [#list getComponentResourceGroups(occurrence.Core.Type) as key, value]
         [#local placement = (occurrence.State.ResourceGroups[key].Placement)!{}]
+        [#local provider = placement.Provider!"" ]
 
         [#if (value.Extensions![])?has_content]
             [#local extendedSharedAttributes =
                 extendAttributes(
-                    value.Attributes[SHARED_ATTRIBUTES]![],
-                    value.Extensions[placement.Provider]![],
-                    placement.Provider)]
+                    (value.Attributes[SHARED_ATTRIBUTES])![],
+                    (value.Extensions[provider])![],
+                    provider)]
         [#else]
-            [#local extendedSharedAttributes = (value.Attributes[SHARED_ATTRIBUTES]![])]
+            [#local extendedSharedAttributes = (value.Attributes[SHARED_ATTRIBUTES])![] ]
         [/#if]
 
-        [#local attributes = combineEntities(attributes, extendedSharedAttributes, APPEND_COMBINE_BEHAVIOUR)]
-        [#local attributes = combineEntities(attributes, (value.Attributes[DEPLOYMENT_ATTRIBUTES]![]), APPEND_COMBINE_BEHAVIOUR )]
-        [#local attributes = combineEntities(attributes, (value.Attributes[placement.Provider!""]![]), APPEND_COMBINE_BEHAVIOUR )]
+        [#local attributes +=
+            extendedSharedAttributes +
+            ((value.Attributes[DEPLOYMENT_ATTRIBUTES])![]) +
+            ((value.Attributes[provider])![])
+        ]
 
     [/#list]
     [#return attributes]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -3,6 +3,8 @@
 [#-- Shared Provider Configurations --]
 [@includeSharedComponentConfiguration component="shared" /]
 [@includeSharedComponentConfiguration component="baseline" /]
+[@includeSharedComponentConfiguration component="s3" /]
+[@includeSharedComponentConfiguration component="ec2" /]
 
 [#-- Temporary AWS stuff --]
 [#if getLoaderProviders()?seq_contains("aws") ]

--- a/providers/shared/components/adaptor/id.ftl
+++ b/providers/shared/components/adaptor/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=ADAPTOR_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addComponent
     type=ADAPTOR_COMPONENT_TYPE
     properties=
@@ -112,3 +107,9 @@
             }
         ]
 /]
+
+[@addComponentDeployment
+    type=ADAPTOR_COMPONENT_TYPE
+    defaultGroup="application"
+/]
+

--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -45,12 +45,6 @@ object.
 "documentation, the others redirect to the primary."
 ] ]
 
-[@addComponentDeployment
-    type=APIGATEWAY_COMPONENT_TYPE
-    defaultGroup="application"
-    defaultPriority=50
-/]
-
 [@addComponent
     type=APIGATEWAY_COMPONENT_TYPE
     properties=
@@ -329,4 +323,10 @@ object.
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=APIGATEWAY_COMPONENT_TYPE
+    defaultGroup="application"
+    defaultPriority=50
 /]

--- a/providers/shared/components/apiusageplan/id.ftl
+++ b/providers/shared/components/apiusageplan/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=APIGATEWAY_USAGEPLAN_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addComponent
     type=APIGATEWAY_USAGEPLAN_COMPONENT_TYPE
     properties=
@@ -30,4 +25,9 @@
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=APIGATEWAY_USAGEPLAN_COMPONENT_TYPE
+    defaultGroup="application"
 /]

--- a/providers/shared/components/baseline/id.ftl
+++ b/providers/shared/components/baseline/id.ftl
@@ -99,14 +99,6 @@
     [#return baselineLinkTargets ]
 [/#function]
 
-[@addComponentDeployment
-    type=BASELINE_COMPONENT_TYPE
-    lockAttributes=true
-    defaultUnit="baseline"
-    defaultPriority=1
-    defaultGroup="segment"
-/]
-
 [@addComponent
     type=BASELINE_COMPONENT_TYPE
     properties=
@@ -134,6 +126,14 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=BASELINE_COMPONENT_TYPE
+    lockAttributes=true
+    defaultUnit="baseline"
+    defaultPriority=1
+    defaultGroup="segment"
 /]
 
 [@addChildComponent

--- a/providers/shared/components/bastion/id.ftl
+++ b/providers/shared/components/bastion/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=BASTION_COMPONENT_TYPE
-    defaultGroup="segment"
-/]
-
 [@addComponent
     type=BASTION_COMPONENT_TYPE
     properties=
@@ -158,4 +153,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=BASTION_COMPONENT_TYPE
+    defaultGroup="segment"
 /]

--- a/providers/shared/components/cache/id.ftl
+++ b/providers/shared/components/cache/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=CACHE_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=CACHE_COMPONENT_TYPE
     properties=
@@ -103,4 +98,9 @@
                 "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=CACHE_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/cdn/id.ftl
+++ b/providers/shared/components/cdn/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=CDN_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=CDN_COMPONENT_TYPE
     properties=
@@ -106,8 +101,13 @@
                 ]
             }
         ]
+        additionalResourceGroups=[DNS_RESOURCE_GROUP]
 /]
 
+[@addComponentDeployment
+    type=CDN_COMPONENT_TYPE
+    defaultGroup="solution"
+/]
 
 [@addChildComponent
     type=CDN_ROUTE_COMPONENT_TYPE

--- a/providers/shared/components/cdn/id.ftl
+++ b/providers/shared/components/cdn/id.ftl
@@ -101,7 +101,6 @@
                 ]
             }
         ]
-        additionalResourceGroups=[DNS_RESOURCE_GROUP]
 /]
 
 [@addComponentDeployment

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -84,6 +84,8 @@
 
 [#assign HEALTHCHECK_COMPONENT_TYPE = "healthcheck" ]
 
+[#assign HOSTING_PLATFORM_COMPONENT_TYPE = "hostingplatform"]
+
 [#assign INTERNALTEST_COMPONENT_TYPE = "internaltest" ]
 
 [#assign LAMBDA_COMPONENT_TYPE = "lambda"]
@@ -131,6 +133,8 @@
 
 [#assign SQS_COMPONENT_TYPE = "sqs"]
 
+[#assign SUBSCRIPTION_COMPONENT_TYPE = "subscription"]
+
 [#assign TEMPLATE_COMPONENT_TYPE = "template"]
 
 [#assign TOPIC_COMPONENT_TYPE = "topic"]
@@ -142,6 +146,8 @@
 [#assign USERPOOL_CLIENT_COMPONENT_TYPE = "userpoolclient" ]
 [#assign USERPOOL_AUTHPROVIDER_COMPONENT_TYPE = "userpoolauthprovider" ]
 [#assign USERPOOL_RESOURCE_COMPONENT_TYPE = "userpoolresource" ]
+
+[#assign DNS_ZONE_COMPONENT_TYPE = "dnszone"]
 
 [#assign
     logWatcherChildrenConfiguration = [

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=COMPUTECLUSTER_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addComponent
     type=COMPUTECLUSTER_COMPONENT_TYPE
     properties=
@@ -192,4 +187,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=COMPUTECLUSTER_COMPONENT_TYPE
+    defaultGroup="application"
 /]

--- a/providers/shared/components/configstore/id.ftl
+++ b/providers/shared/components/configstore/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=CONFIGSTORE_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=CONFIGSTORE_COMPONENT_TYPE
     properties=
@@ -33,6 +28,11 @@
                 "Default" : false
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=CONFIGSTORE_COMPONENT_TYPE
+    defaultGroup="solution"
 /]
 
 [@addChildComponent

--- a/providers/shared/components/containerhost/id.ftl
+++ b/providers/shared/components/containerhost/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=CONTAINERHOST_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=CONTAINERHOST_COMPONENT_TYPE
     properties=
@@ -21,4 +16,9 @@
         }
     ] +
     containerHostAttributes
+/]
+
+[@addComponentDeployment
+    type=CONTAINERHOST_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/containerservice/id.ftl
+++ b/providers/shared/components/containerservice/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=CONTAINERSERVICE_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addComponent
     type=CONTAINERSERVICE_COMPONENT_TYPE
     properties=
@@ -15,4 +10,9 @@
             }
         ]
     attributes=containerServiceAttributes
+/]
+
+[@addComponentDeployment
+    type=CONTAINERSERVICE_COMPONENT_TYPE
+    defaultGroup="application"
 /]

--- a/providers/shared/components/containertask/id.ftl
+++ b/providers/shared/components/containertask/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=CONTAINERTASK_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addComponent
     type=CONTAINERTASK_COMPONENT_TYPE
     properties=
@@ -15,4 +10,9 @@
             }
         ]
     attributes=containerTaskAttributes
+/]
+
+[@addComponentDeployment
+    type=CONTAINERTASK_COMPONENT_TYPE
+    defaultGroup="application"
 /]

--- a/providers/shared/components/contenthub/id.ftl
+++ b/providers/shared/components/contenthub/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=CONTENTHUB_HUB_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addComponent
     type=CONTENTHUB_HUB_COMPONENT_TYPE
     properties=
@@ -37,4 +32,9 @@
                 "Default" : ""
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=CONTENTHUB_HUB_COMPONENT_TYPE
+    defaultGroup="application"
 /]

--- a/providers/shared/components/contentnode/id.ftl
+++ b/providers/shared/components/contentnode/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=CONTENTHUB_NODE_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addComponent
     type=CONTENTHUB_NODE_COMPONENT_TYPE
     properties=
@@ -57,4 +52,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=CONTENTHUB_NODE_COMPONENT_TYPE
+    defaultGroup="application"
 /]

--- a/providers/shared/components/correspondent/id.ftl
+++ b/providers/shared/components/correspondent/id.ftl
@@ -1,11 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=CORRESPONDENT_COMPONENT_TYPE
-    defaultGroup="solution"
-    defaultPriority=70
-/]
-
 [@addComponent
     type=CORRESPONDENT_COMPONENT_TYPE
     properties=
@@ -23,4 +17,10 @@
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=CORRESPONDENT_COMPONENT_TYPE
+    defaultGroup="solution"
+    defaultPriority=70
 /]

--- a/providers/shared/components/datafeed/id.ftl
+++ b/providers/shared/components/datafeed/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=DATAFEED_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=DATAFEED_COMPONENT_TYPE
     properties=
@@ -165,4 +160,9 @@
                 "Children" : logWatcherChildrenConfiguration
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=DATAFEED_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/datapipeline/id.ftl
+++ b/providers/shared/components/datapipeline/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=DATAPIPELINE_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addComponent
     type=DATAPIPELINE_COMPONENT_TYPE
     properties=
@@ -100,4 +95,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=DATAPIPELINE_COMPONENT_TYPE
+    defaultGroup="application"
 /]

--- a/providers/shared/components/dataset/id.ftl
+++ b/providers/shared/components/dataset/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=DATASET_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addComponent
     type=DATASET_COMPONENT_TYPE
     properties=
@@ -70,4 +65,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=DATASET_COMPONENT_TYPE
+    defaultGroup="application"
 /]

--- a/providers/shared/components/datavolume/id.ftl
+++ b/providers/shared/components/datavolume/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=DATAVOLUME_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=DATAVOLUME_COMPONENT_TYPE
     properties=
@@ -73,4 +68,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=DATAVOLUME_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/db/id.ftl
+++ b/providers/shared/components/db/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=DB_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=DB_COMPONENT_TYPE
     properties=
@@ -270,4 +265,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=DB_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/directory/id.ftl
+++ b/providers/shared/components/directory/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=DIRECTORY_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=DIRECTORY_COMPONENT_TYPE
     properties=
@@ -107,4 +102,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=DIRECTORY_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/dnszone/id.ftl
+++ b/providers/shared/components/dnszone/id.ftl
@@ -1,0 +1,25 @@
+[#ftl]
+
+[@addComponentDeployment
+    type=DNS_ZONE_COMPONENT_TYPE
+    defaultGroup="solution"
+/]
+
+[@addComponent
+    type=DNS_ZONE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "DNS Zone"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "external:ProviderId",
+                "Description" : "The provider identifier for the DNS zone",
+                "Types" : STRING_TYPE
+            }
+        ]
+/]

--- a/providers/shared/components/dnszone/id.ftl
+++ b/providers/shared/components/dnszone/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=DNS_ZONE_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=DNS_ZONE_COMPONENT_TYPE
     properties=
@@ -22,4 +17,9 @@
                 "Types" : STRING_TYPE
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=DNS_ZONE_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=EC2_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=EC2_COMPONENT_TYPE
     properties=
@@ -174,4 +169,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=EC2_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/ecs/id.ftl
+++ b/providers/shared/components/ecs/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=ECS_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=ECS_COMPONENT_TYPE
     properties=
@@ -18,8 +13,8 @@
 /]
 
 [@addComponentDeployment
-    type=ECS_SERVICE_COMPONENT_TYPE
-    defaultGroup="application"
+    type=ECS_COMPONENT_TYPE
+    defaultGroup="solution"
 /]
 
 [@addChildComponent
@@ -38,7 +33,7 @@
 /]
 
 [@addComponentDeployment
-    type=ECS_TASK_COMPONENT_TYPE
+    type=ECS_SERVICE_COMPONENT_TYPE
     defaultGroup="application"
 /]
 
@@ -55,4 +50,9 @@
             }
         ]
     attributes=containerTaskAttributes
+/]
+
+[@addComponentDeployment
+    type=ECS_TASK_COMPONENT_TYPE
+    defaultGroup="application"
 /]

--- a/providers/shared/components/efs/id.ftl
+++ b/providers/shared/components/efs/id.ftl
@@ -1,11 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=EFS_COMPONENT_TYPE
-    defaultGroup="solution"
-    defaultPriority=50
-/]
-
 [@addComponent
     type=EFS_COMPONENT_TYPE
     properties=
@@ -43,6 +37,12 @@
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=EFS_COMPONENT_TYPE
+    defaultGroup="solution"
+    defaultPriority=50
 /]
 
 [@addChildComponent

--- a/providers/shared/components/es/id.ftl
+++ b/providers/shared/components/es/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=ES_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=ES_COMPONENT_TYPE
     properties=
@@ -124,4 +119,9 @@
                 "Default" : false
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=ES_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/externalnetwork/id.ftl
+++ b/providers/shared/components/externalnetwork/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=EXTERNALNETWORK_COMPONENT_TYPE
-    defaultGroup="segment"
-/]
-
 [@addComponent
     type=EXTERNALNETWORK_COMPONENT_TYPE
     properties=
@@ -43,6 +38,11 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=EXTERNALNETWORK_COMPONENT_TYPE
+    defaultGroup="segment"
 /]
 
 [@addChildComponent

--- a/providers/shared/components/externalservice/id.ftl
+++ b/providers/shared/components/externalservice/id.ftl
@@ -12,21 +12,6 @@
     attributes=[]
 /]
 
-[@addChildComponent
-    type=EXTERNALSERVICE_ENDPOINT_COMPONENT_TYPE
-    properties=
-        [
-            {
-                "Type"  : "Description",
-                "Value" : "An endpoint of an external serivce normally an IP address or collection"
-            }
-        ]
-    attributes=[]
-    parent=EXTERNALSERVICE_COMPONENT_TYPE
-    childAttribute="Endpoints"
-    linkAttributes="Endpoint"
-/]
-
 [@addResourceGroupInformation
     type=EXTERNALSERVICE_COMPONENT_TYPE
     attributes=[
@@ -65,6 +50,20 @@
     ]
 /]
 
+[@addChildComponent
+    type=EXTERNALSERVICE_ENDPOINT_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "An endpoint of an external serivce normally an IP address or collection"
+            }
+        ]
+    attributes=[]
+    parent=EXTERNALSERVICE_COMPONENT_TYPE
+    childAttribute="Endpoints"
+    linkAttributes="Endpoint"
+/]
 
 [@addResourceGroupInformation
     type=EXTERNALSERVICE_ENDPOINT_COMPONENT_TYPE

--- a/providers/shared/components/federatedrole/id.ftl
+++ b/providers/shared/components/federatedrole/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=FEDERATEDROLE_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=FEDERATEDROLE_COMPONENT_TYPE
     properties=
@@ -43,6 +38,10 @@
         ]
 /]
 
+[@addComponentDeployment
+    type=FEDERATEDROLE_COMPONENT_TYPE
+    defaultGroup="solution"
+/]
 
 [@addChildComponent
     type=FEDERATEDROLE_ASSIGNMENT_COMPONENT_TYPE

--- a/providers/shared/components/filetransfer/id.ftl
+++ b/providers/shared/components/filetransfer/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=FILETRANSFER_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=FILETRANSFER_COMPONENT_TYPE
     properties=
@@ -57,4 +52,9 @@
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=FILETRANSFER_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/firewall/id.ftl
+++ b/providers/shared/components/firewall/id.ftl
@@ -1,11 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=FIREWALL_COMPONENT_TYPE
-    defaultGroup="segment"
-    defaultPriority=60
-/]
-
 [@addComponent
     type=FIREWALL_COMPONENT_TYPE
     properties=
@@ -82,6 +76,12 @@
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=FIREWALL_COMPONENT_TYPE
+    defaultGroup="segment"
+    defaultPriority=60
 /]
 
 [@addChildComponent

--- a/providers/shared/components/gateway/id.ftl
+++ b/providers/shared/components/gateway/id.ftl
@@ -1,11 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=NETWORK_GATEWAY_COMPONENT_TYPE
-    defaultGroup="segment"
-    defaultPriority=50
-/]
-
 [@addComponent
     type=NETWORK_GATEWAY_COMPONENT_TYPE
     properties=
@@ -115,6 +109,12 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=NETWORK_GATEWAY_COMPONENT_TYPE
+    defaultGroup="segment"
+    defaultPriority=50
 /]
 
 [@addChildComponent

--- a/providers/shared/components/globaldb/id.ftl
+++ b/providers/shared/components/globaldb/id.ftl
@@ -1,11 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=GLOBALDB_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
-
 [@addComponent
     type=GLOBALDB_COMPONENT_TYPE
     properties=
@@ -112,4 +106,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=GLOBALDB_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/healthcheck/id.ftl
+++ b/providers/shared/components/healthcheck/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=HEALTHCHECK_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addComponent
     type=HEALTHCHECK_COMPONENT_TYPE
     properties=
@@ -227,4 +222,9 @@
             "Default" : [ "_all" ]
         }
     ]
+/]
+
+[@addComponentDeployment
+    type=HEALTHCHECK_COMPONENT_TYPE
+    defaultGroup="application"
 /]

--- a/providers/shared/components/hostingplatform/id.ftl
+++ b/providers/shared/components/hostingplatform/id.ftl
@@ -1,0 +1,39 @@
+[#ftl]
+
+[@addComponentDeployment
+    type=HOSTING_PLATFORM_COMPONENT_TYPE
+    defaultGroup="solution"
+/]
+
+[@addComponent
+    type=HOSTING_PLATFORM_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A place where resources can physically be deployed"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Description" : "Engine will determine what attributes the platform exposes",
+                "Types" : STRING_TYPE,
+                "Values" : ["region"],
+                "Default" : "region",
+                "Mandatory" : true
+            },
+            {
+                "Names" : "Engine:region",
+                "Description" : "Placement of resources within a region",
+                "Children" : [
+                    {
+                        "Names" : "Region",
+                        "Types" : STRING_TYPE,
+                        "Mandatory" : true
+                    }
+                ]
+            }
+        ]
+/]

--- a/providers/shared/components/hostingplatform/id.ftl
+++ b/providers/shared/components/hostingplatform/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=HOSTING_PLATFORM_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=HOSTING_PLATFORM_COMPONENT_TYPE
     properties=
@@ -36,4 +31,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=HOSTING_PLATFORM_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -22,11 +22,6 @@
         ]
 /]
 
-[@addComponentDeployment
-    type=LAMBDA_FUNCTION_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addChildComponent
     type=LAMBDA_FUNCTION_COMPONENT_TYPE
     properties=
@@ -257,4 +252,9 @@
     parent=LAMBDA_COMPONENT_TYPE
     childAttribute="Functions"
     linkAttributes="Function"
+/]
+
+[@addComponentDeployment
+    type=LAMBDA_FUNCTION_COMPONENT_TYPE
+    defaultGroup="application"
 /]

--- a/providers/shared/components/lb/id.ftl
+++ b/providers/shared/components/lb/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=LB_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=LB_COMPONENT_TYPE
     properties=
@@ -73,6 +68,11 @@
                 "Children" : wafChildConfiguration
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=LB_COMPONENT_TYPE
+    defaultGroup="solution"
 /]
 
 [@addChildComponent

--- a/providers/shared/components/mobileapp/id.ftl
+++ b/providers/shared/components/mobileapp/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=MOBILEAPP_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addComponent
     type=MOBILEAPP_COMPONENT_TYPE
     properties=
@@ -77,4 +72,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=MOBILEAPP_COMPONENT_TYPE
+    defaultGroup="application"
 /]

--- a/providers/shared/components/mobilenotifier/id.ftl
+++ b/providers/shared/components/mobilenotifier/id.ftl
@@ -3,11 +3,6 @@
 [#-- Engines --]
 [#assign MOBILENOTIFIER_SMS_ENGINE = "SMS" ]
 
-[@addComponentDeployment
-    type=MOBILENOTIFIER_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=MOBILENOTIFIER_COMPONENT_TYPE
     properties=
@@ -51,6 +46,11 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=MOBILENOTIFIER_COMPONENT_TYPE
+    defaultGroup="solution"
 /]
 
 [@addChildComponent

--- a/providers/shared/components/mta/id.ftl
+++ b/providers/shared/components/mta/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=MTA_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=MTA_COMPONENT_TYPE
     properties=
@@ -37,6 +32,10 @@
         ]
 /]
 
+[@addComponentDeployment
+    type=MTA_COMPONENT_TYPE
+    defaultGroup="solution"
+/]
 
 [@addChildComponent
     type=MTA_RULE_COMPONENT_TYPE

--- a/providers/shared/components/network/id.ftl
+++ b/providers/shared/components/network/id.ftl
@@ -1,12 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=NETWORK_COMPONENT_TYPE
-    defaultGroup="segment"
-    defaultPriority=20
-/]
-
-
 [@addComponent
     type=NETWORK_COMPONENT_TYPE
     properties=
@@ -143,6 +136,12 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=NETWORK_COMPONENT_TYPE
+    defaultGroup="segment"
+    defaultPriority=20
 /]
 
 [@addChildComponent

--- a/providers/shared/components/objectsql/id.ftl
+++ b/providers/shared/components/objectsql/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=OBJECTSQL_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=OBJECTSQL_COMPONENT_TYPE
     properties=
@@ -38,4 +33,9 @@
                 "Default" : -1
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=OBJECTSQL_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/privateservice/id.ftl
+++ b/providers/shared/components/privateservice/id.ftl
@@ -1,11 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=PRIVATE_SERVICE_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
-
 [@addComponent
     type=PRIVATE_SERVICE_COMPONENT_TYPE
     properties=
@@ -62,4 +56,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=PRIVATE_SERVICE_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/queuehost/id.ftl
+++ b/providers/shared/components/queuehost/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=QUEUEHOST_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=QUEUEHOST_COMPONENT_TYPE
     properties=
@@ -125,4 +120,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=QUEUEHOST_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/router/id.ftl
+++ b/providers/shared/components/router/id.ftl
@@ -1,11 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=NETWORK_ROUTER_COMPONENT_TYPE
-    defaultGroup="segment"
-/]
-
-
 [@addComponent
     type=NETWORK_ROUTER_COMPONENT_TYPE
     properties=
@@ -46,6 +40,11 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=NETWORK_ROUTER_COMPONENT_TYPE
+    defaultGroup="segment"
 /]
 
 [@addChildComponent

--- a/providers/shared/components/s3/id.ftl
+++ b/providers/shared/components/s3/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=S3_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=S3_COMPONENT_TYPE
     properties=
@@ -191,4 +186,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=S3_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/secretstore/id.ftl
+++ b/providers/shared/components/secretstore/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=SECRETSTORE_COMPONENT_TYPE
-    defaultGroup="segment"
-/]
-
 [@addComponent
     type=SECRETSTORE_COMPONENT_TYPE
     properties=[
@@ -22,6 +17,11 @@
             "Mandatory" : true
         }
     ]
+/]
+
+[@addComponentDeployment
+    type=SECRETSTORE_COMPONENT_TYPE
+    defaultGroup="segment"
 /]
 
 [@addChildComponent

--- a/providers/shared/components/serviceregistry/id.ftl
+++ b/providers/shared/components/serviceregistry/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=SERVICE_REGISTRY_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=SERVICE_REGISTRY_COMPONENT_TYPE
     properties=
@@ -34,6 +29,11 @@
                 "Children" : domainNameChildConfiguration
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=SERVICE_REGISTRY_COMPONENT_TYPE
+    defaultGroup="solution"
 /]
 
 [@addChildComponent

--- a/providers/shared/components/spa/id.ftl
+++ b/providers/shared/components/spa/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=SPA_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addComponent
     type=SPA_COMPONENT_TYPE
     properties=
@@ -93,4 +88,9 @@
                 ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=SPA_COMPONENT_TYPE
+    defaultGroup="application"
 /]

--- a/providers/shared/components/sqs/id.ftl
+++ b/providers/shared/components/sqs/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=SQS_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=SQS_COMPONENT_TYPE
     properties=
@@ -83,4 +78,9 @@
                     ]
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=SQS_COMPONENT_TYPE
+    defaultGroup="solution"
 /]

--- a/providers/shared/components/subscription/id.ftl
+++ b/providers/shared/components/subscription/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=SUBSCRIPTION_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=SUBSCRIPTION_COMPONENT_TYPE
     properties=
@@ -15,6 +10,11 @@
             }
         ]
     attributes=[]
+/]
+
+[@addComponentDeployment
+    type=SUBSCRIPTION_COMPONENT_TYPE
+    defaultGroup="solution"
 /]
 
 [@addResourceGroupInformation

--- a/providers/shared/components/subscription/id.ftl
+++ b/providers/shared/components/subscription/id.ftl
@@ -1,0 +1,54 @@
+[#ftl]
+
+[@addComponentDeployment
+    type=SUBSCRIPTION_COMPONENT_TYPE
+    defaultGroup="solution"
+/]
+
+[@addComponent
+    type=SUBSCRIPTION_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "Primary unit for hosting of resources"
+            }
+        ]
+    attributes=[]
+/]
+
+[@addResourceGroupInformation
+    type=SUBSCRIPTION_COMPONENT_TYPE
+    attributes=
+        [
+            {
+                "Names" : "external:Provider",
+                "Description" : "The provider owning the subscription",
+                "Types" : STRING_TYPE
+            },
+            {
+                "Names" : "external:ProviderId",
+                "Description" : "The provider identifier for the subscription",
+                "Types" : STRING_TYPE
+            },
+            {
+                "Names" : "external:DeploymentFramework",
+                "Description" : "The default deployment framework for the subscription",
+                "Types" : STRING_TYPE
+            }
+        ]
+    provider=SHARED_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=[
+        SHARED_EXTERNAL_SERVICE
+    ]
+    locations={
+        [#-- A link to a subscription is required if not importing the provider --]
+        DEFAULT_RESOURCE_GROUP : {
+            "Mandatory" : false,
+            "TargetComponentTypes" : [
+                SUBSCRIPTION_COMPONENT_TYPE
+            ]
+        }
+    }
+/]

--- a/providers/shared/components/subscription/state.ftl
+++ b/providers/shared/components/subscription/state.ftl
@@ -1,0 +1,41 @@
+[#ftl]
+
+[#macro shared_subscription_default_state occurrence parent={} ]
+    [#local core = getOccurrenceCore(occurrence) ]
+    [#local solution = getOccurrenceSolution(occurrence) ]
+    [#local locations = getOccurrenceLocations(occurrence) ]
+
+    [#-- Combine any placement attributes with explicitly provided values --]
+    [#local attributes =
+        ((locations[DEFAULT_RESOURCE_GROUP].Attributes)!{}) +
+        attributeIfContent(
+            "PROVIDER",
+            solution["external:Provider"]!""
+        ) +
+        attributeIfContent(
+            "ACCOUNT",
+            solution["external:ProviderId"]!""
+        ) +
+        attributeIfContent(
+            "DEPLOYMENT_FRAMEWORK",
+            solution["external:DeploymentFramework"]!""
+        )
+    ]
+
+    [#assign componentState =
+        {
+            "Resources" : {
+                "external" : {
+                    "Id" : formatResourceId(SHARED_EXTERNAL_RESOURCE_TYPE, core.Id),
+                    "Type" : SHARED_EXTERNAL_RESOURCE_TYPE,
+                    "Deployed" : attributes["PROVIDER"]?has_content
+                }
+            },
+            "Attributes" : attributes,
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#macro]

--- a/providers/shared/components/template/id.ftl
+++ b/providers/shared/components/template/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=TEMPLATE_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addComponent
     type=TEMPLATE_COMPONENT_TYPE
     properties=
@@ -122,3 +117,9 @@
             }
         ]
 /]
+
+[@addComponentDeployment
+    type=TEMPLATE_COMPONENT_TYPE
+    defaultGroup="application"
+/]
+

--- a/providers/shared/components/topic/id.ftl
+++ b/providers/shared/components/topic/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=TOPIC_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=TOPIC_COMPONENT_TYPE
     properties=
@@ -35,6 +30,10 @@
         ]
 /]
 
+[@addComponentDeployment
+    type=TOPIC_COMPONENT_TYPE
+    defaultGroup="solution"
+/]
 
 [@addChildComponent
     type=TOPIC_SUBSCRIPTION_COMPONENT_TYPE

--- a/providers/shared/components/user/id.ftl
+++ b/providers/shared/components/user/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=USER_COMPONENT_TYPE
-    defaultGroup="application"
-/]
-
 [@addComponent
     type=USER_COMPONENT_TYPE
     properties=
@@ -87,4 +82,9 @@
             }
         ]
     dependencies=[APIGATEWAY_COMPONENT_TYPE]
+/]
+
+[@addComponentDeployment
+    type=USER_COMPONENT_TYPE
+    defaultGroup="application"
 /]

--- a/providers/shared/components/userpool/id.ftl
+++ b/providers/shared/components/userpool/id.ftl
@@ -1,10 +1,5 @@
 [#ftl]
 
-[@addComponentDeployment
-    type=USERPOOL_COMPONENT_TYPE
-    defaultGroup="solution"
-/]
-
 [@addComponent
     type=USERPOOL_COMPONENT_TYPE
     properties=
@@ -234,6 +229,11 @@
                 "Default" : "code"
             }
         ]
+/]
+
+[@addComponentDeployment
+    type=USERPOOL_COMPONENT_TYPE
+    defaultGroup="solution"
 /]
 
 [@addChildComponent
@@ -537,7 +537,6 @@
     childAttribute="AuthProviders"
     linkAttributes="AuthProvider"
 /]
-
 
 [@addChildComponent
     parent=USERPOOL_COMPONENT_TYPE


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add support for new `subscription`, `hostingplatform` and `dnszone` components.

## Motivation and Context
Part of [ADR0007](https://github.com/hamlet-io/architectural-decision-log/blob/main/adr/0007-placement-support.md) implementation.

- Add shared definition of these new components
- Add preliminary changes to support `Locations`
  - accessor methods for location information on components and occurrences
  - ability to capture the errors generated by `getCompositeObject()` so alternate actions to generating fatal errors can be supported, mainly so the context of the errors can be better explained
  - More extensive commenting of the process for attribute extension and some refactoring of the implementation
- new component attributes support import of externally defined resources in readiness for the introduction of `Locations`.
- Support for an explicit Type attribute on components rather than relying on the name of a child attribute
  - makes config more explicit
  - permits a flatter JSON file
  - in line with similar changes to links with the removal of subcomponent specific attributes

Subsequent PRs will add explicit support for Locations.
## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

