### PR TITLE
feat(locations): location support

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -228,6 +228,32 @@
         )]
 [/#function]
 
+[#-- Summary occurrence information to provide useful information --]
+[#-- when debugging errors without swamping the output            --]
+[#function getOccurrenceSummary occurrences]
+    [#local result = [] ]
+    [#list asArray(occurrences) as occurrence]
+        [#local result +=
+            [
+                {
+                    "Type" : occurrence.Core.Type,
+                    "Core" : {
+                        "Tier" : occurrence.Core.Tier.Id,
+                        "Component" : occurrence.Core.Component.Id,
+                        "Instance" : occurrence.Core.Instance.Id,
+                        "Version" : occurrence.Core.Version.Id
+                    } +
+                    attributeIfContent("SubComponent", (occurrence.SubComponent.Id)!"")
+                }
+            ]
+        ]
+    [/#list]
+    [#if result?size > 1]
+        [#return result]
+    [/#if]
+    [#return result[0]!{} ]
+[/#function]
+
 [#function constructOccurrenceSettings baseOccurrence type]
 
     [#local occurrence = baseOccurrence]

--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -93,11 +93,11 @@
         }
     ]
 
-    [@fatal
+    [@debug
         message="Getting link Target"
         context=
             {
-                "Occurrence" : occurrence,
+                "Occurrence" : getOccurrenceSummary(occurrence),
                 "Link" : link,
                 "EffectiveLink" : effectiveLink,
                 "ActiveOnly" : activeOnly,
@@ -239,7 +239,7 @@
     [#if targetOccurrences?size > 1]
         [@fatal
             message='Internal error - multiple component matches returned for component "${effectiveLink.Component}"'
-            context=targetOccurrences
+            context=getOccurrenceSummary(targetOccurrences)
             detail=effectiveLink
         /]
         [#return {} ]
@@ -274,7 +274,7 @@
                 [#if subOccurrences?size > 1 ]
                     [@fatal
                         message='Multiple matching subcomponents with id "${effectiveLink.SubComponent}". Use a Type attribute to differentiate them.'
-                        context=subOccurrences
+                        context=getOccurrenceSummary(subOccurrences)
                         detail=effectiveLink
                     /]
                     [#return {} ]
@@ -340,8 +340,8 @@
                     function="getLinkTarget"
                     context=
                         {
-                            "Occurrence" : occurrence,
-                            "TargetOccurrence" : matchedOccurrence,
+                            "Occurrence" : getOccurrenceSummary(occurrence),
+                            "TargetOccurrence" : getOccurrenceSummary(matchedOccurrence),
                             "Link" : link,
                             "EffectiveLink" : effectiveLink
                         }
@@ -372,7 +372,7 @@
         function="getLinkTarget"
         context=
             {
-                "Occurrence" : occurrence,
+                "Occurrence" : getOccurrenceSummary(occurrence),
                 "Link" : link,
                 "EffectiveLink" : effectiveLink
             }
@@ -418,17 +418,6 @@ that doesn't match the link.
 --]
 
 [#function internalGetOccurrences component tier={} link={} parentOccurrence={} parentContexts=[] componentType="" ]
-
-[@fatal
-    message="InternalGetOccurrences"
-    context=
-    {
-        "Component" : component,
-        "Link" : link
-    }
-    detail=internalGetOccurrencesInvocations
-    enabled=false
-/]
 
     [#if !(component?has_content) ]
         [#return [] ]
@@ -804,7 +793,7 @@ that doesn't match the link.
                         [#else]
                             [@fatal
                                 message='Insufficient information to place resource group "${key}". Provider and DeploymentFramework are required'
-                                context=occurrence
+                                context=getOccurrenceSummary(occurrence)
                                 detail=placement
                             /]
                             [#if ! internalGetOccurrencesInvocations?has_content]

--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -693,7 +693,7 @@ that doesn't match the link.
                         getCompositeObject(
                             [
                                 {
-                                    "Names" : ["deployment:Locations"],
+                                    "Names" : ["placement:Locations"],
                                     "Description" : "Locations required by the component",
                                     "SubObjects" : true,
                                     "Children" : [
@@ -709,7 +709,7 @@ that doesn't match the link.
                             deploymentProfileObjects,
                             occurrenceContexts,
                             policyProfileObjects
-                        )["deployment:Locations"] ]
+                        )["placement:Locations"] ]
 
                     [#-- Location targets for the occurrence --]
                     [#local locationTargets = { "_config" : locations } ]

--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -786,7 +786,7 @@ that doesn't match the link.
                                 ) ]
                         [#else]
                             [@fatal
-                                message="Insufficient information to place resource group. Provider and DeploymentFramework are required"
+                                message='Insufficient information to place resource group "${key}". Provider and DeploymentFramework are required'
                                 context=occurrence
                                 detail=placement
                             /]


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add support for Locations on ResourceGroups as a means to determine the placement of resources.

## Motivation and Context
Part of [ADR0007](https://github.com/hamlet-io/architectural-decision-log/blob/main/adr/0007-placement-support.md) implementation.

When determining placements, the resource group id is used as the Location to find the corresponding placement information,
so this means the ids of all resource groups need to be known BEFORE location information is checked.

As a result, when adding a component, any possible resource groups that an implementation might want to use must be
defined. This means that a provider implementer cannot add additional resource groups not already defined when the component was defined.

The existing placement profile approach has been left in place but if present, locations take precedence.

As locations are link based, their introduction increases the chances of creating loops. Code to detect loops has thus
been added when getting Occurrences.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- engine - https://github.com/hamlet-io/engine/pull/1808

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

