### PR TITLE
refactor(directory): set default ip access policy

### DIFF
--- a/providers/shared/components/directory/id.ftl
+++ b/providers/shared/components/directory/id.ftl
@@ -25,7 +25,7 @@
             {
                 "Names" : "IPAddressGroups",
                 "Types" : ARRAY_OF_STRING_TYPE,
-                "Default" : []
+                "Default" : [ "_localnet" ]
             },
             {
                 "Names" : "ShortName",


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

Sets the default IP Access control to the local network. The default policy was using public access

## Motivation and Context

Aligns with standard security policies to ensure the 0.0.0.0/0 is only used when required 

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

