### PR TITLE
feat!: extend testing tooling

### DIFF
--- a/providers/shared/references/TestCase/id.ftl
+++ b/providers/shared/references/TestCase/id.ftl
@@ -106,14 +106,34 @@
             "Description" : "Tool based tests - linters etc",
             "Children" : [
                 {
-                    "Names" : "CFNLint",
-                    "Types" : BOOLEAN_TYPE,
-                    "Default" : false
+                    "Names" : "cfn-lint",
+                    "Description" : "Run cfn-lint on the file - https://github.com/aws-cloudformation/cfn-lint",
+                    "Children" : [
+                        {
+                            "Names" : "IgnoreChecks",
+                            "Description" : "A list of checks to ignore in cfn-lint",
+                            "Type" : ARRAY_OF_STRING_TYPE,
+                            "Default" : []
+                        }
+                    ]
                 },
                 {
-                    "Names" : "CFNNag",
-                    "Types" : BOOLEAN_TYPE,
-                    "Default" : false
+                    "Names" : "checkov",
+                    "Description" : "Run checkov on the file - https://github.com/bridgecrewio/checkov",
+                    "Children" : [
+                        {
+                            "Names" : "Framework",
+                            "Description" : "The framework of the file to run testing against",
+                            "Values": ["cloudformation", "arm"],
+                            "Default" : "cloudformation"
+                        },
+                        {
+                            "Names" : "SkipChecks",
+                            "Description" : "A list of checks to skip in checkov",
+                            "Type" : ARRAY_OF_STRING_TYPE,
+                            "Default" : []
+                        }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Description

- Extends the cfn-lint structure to support ignoring checks
- Updates the name to align with the tool name rather than a different structure
- Adds support for checkov as a testing tool with support for both arm and cloudformation
- Removes support for CFNNag as it has been removed from the cli

## Motivation and Context

These changes are aimed at making testing easier to use and removes the need for additional software installation that was required for the cfn_nag tooling 

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- Anyone currently using `CFNLint: true` will now need to use `cfn-lint: {}` instead
- All use of `CFNNag` in testcases will need to be replaced with the appropriate configuration for `checkov`

