### PR TITLE
fix(cdn): include links in route config

### DIFF
--- a/providers/shared/components/cdn/id.ftl
+++ b/providers/shared/components/cdn/id.ftl
@@ -128,6 +128,11 @@
             "Mandatory" : true
         },
         {
+            "Names" : "Links",
+            "SubObjects" : true,
+            "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+        },
+        {
             "Names" : "Origin",
             "Children" : [
                 {


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Adds the links attribute to CDN routes. This was expected to be in the AWS cdn route setup but was missing

## Motivation and Context

Setup processing expected links to be defined on routes

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

