### PR TITLE
feat: include layer and reference in info

### DIFF
--- a/engine/inputdata/layer.ftl
+++ b/engine/inputdata/layer.ftl
@@ -74,6 +74,10 @@
     [/#if]
 [/#function]
 
+[#function getAllLayerConfiguration ]
+    [#return layerConfiguration ]
+[/#function]
+
 [#-- Return the layer input filter attributes --]
 [#function getLayerInputFilterAttributes type ]
     [#local attributeValue = (getLayerConfiguration(type).InputFilterAttributes[0].Id)!"" ]
@@ -309,4 +313,3 @@
 
     [#return results + asArray(default) ]
 [/#function]
-

--- a/engine/inputdata/reference.ftl
+++ b/engine/inputdata/reference.ftl
@@ -8,6 +8,14 @@
 [#assign referenceConfiguration = {} ]
 [#assign referenceData = {}]
 
+[#function getReferenceConfiguration type="" ]
+    [#if type?has_content]
+        [#return (referenceConfiguration[type])!{}]
+    [#else]
+        [#return referenceConfiguration]
+    [/#if]
+[/#function]
+
 [#-- Macros to assemble the component configuration --]
 [#macro addReference type pluralType properties attributes ]
     [#local configuration = {
@@ -37,6 +45,16 @@
         /]
     [/#if]
 [/#macro]
+
+[#function getAllReferenceData ]
+    [#local result = {}]
+    [#list getReferenceConfiguration()?keys as type ]
+        [#local result += {
+            type: getReferenceData(type)
+        }]
+    [/#list]
+    [#return result]
+[/#function]
 
 [#function getReferenceData type ignoreMissing=false]
     [#local referenceConfig = referenceConfiguration[type]!{}]

--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -175,6 +175,10 @@
 
     [@initialiseJsonOutput name="providers" /]
     [@initialiseJsonOutput name="entrances" /]
+    [@initialiseJsonOutput name="referencetypes" /]
+    [@initialiseJsonOutput name="referencedata" /]
+    [@initialiseJsonOutput name="layertypes" /]
+    [@initialiseJsonOutput name="layerdata" /]
 
     [@processFlows
         level=level
@@ -192,25 +196,20 @@
                 "ConfigurationReference" : getCLOConfigurationReference()
             },
             "Providers" : getOutputContent("providers")?values,
-            "Entrances" : getOutputContent("entrances")?values
+            "Entrances" : getOutputContent("entrances")?values,
+            "ReferenceTypes" : getOutputContent("referencetypes")?values,
+            "ReferenceData" : asFlattenedArray(getOutputContent("referencedata")?values),
+            "LayerTypes" : getOutputContent("layertypes")?values,
+            "LayerData" : getOutputContent("layerdata")?values
         }
     ]
 [/#function]
 
-[#macro infoProvider id details ]
+[#macro infoContent type id details ]
     [@mergeWithJsonOutput
-        name="providers"
+        name=type
         content={
             id : details
-        }
-    /]
-[/#macro]
-
-[#macro infoEntrance id details ]
-    [@mergeWithJsonOutput
-        name="entrances"
-        content={
-            id :  details
         }
     /]
 [/#macro]

--- a/providers/shared/views/info/setup.ftl
+++ b/providers/shared/views/info/setup.ftl
@@ -11,6 +11,7 @@
     [@includeAllComponentDefinitionConfiguration providersList /]
     [@includeAllViewConfiguration providersList /]
 
+    [#-- Provider details --]
     [#list providerDictionary as id,provider ]
         [#local providerLocation = ""]
         [#list providerMarkers as providerMarker ]
@@ -29,12 +30,14 @@
             }
         ]
 
-        [@infoProvider
+        [@infoContent
+            type="providers"
             id=id
             details=providerDetails
         /]
     [/#list]
 
+    [#-- Entrances --]
     [#list getEntranceTypes() as type ]
         [#local entranceProperties = getEntranceProperties(type)]
         [#local entranceDescription = entranceProperties?filter( prop -> prop.Type == "Description")?map( prop -> prop.Value )?join(' ') ]
@@ -44,10 +47,87 @@
             "Description" : entranceDescription,
             "CommandLineOptions" : getEntranceCommandLineOptions(type)
         }]
-        [@infoEntrance
+        [@infoContent
+            type="entrances"
             id=type
             details=entranceDetails
         /]
+    [/#list]
+
+    [#-- References --]
+    [#list getReferenceConfiguration() as type,referenceConfig ]
+        [#local referenceConfigDescription = referenceConfig.Properties?filter( prop -> prop.Type == "Description")?map( prop -> prop.Value )?join(' ') ]
+
+        [#local referenceTypeDetails = {
+            "Type" : referenceConfig.Type.Singular,
+            "PluralType" : referenceConfig.Type.Plural,
+            "Description" : referenceConfigDescription,
+            "Attributes" : referenceConfig.Attributes
+        }]
+
+        [@infoContent
+            type="referencetypes"
+            id=type
+            details=referenceTypeDetails
+        /]
 
     [/#list]
+
+    [#list getAllReferenceData() as type, data ]
+        [#local referenceDataDetails = []]
+        [#list data as id,content ]
+
+            [#local referenceDataDetails = combineEntities(
+                referenceDataDetails,
+                [
+                    {
+                        "Type" : type,
+                        "Id" : id,
+                        "Properties" : content
+                    }
+                ],
+                APPEND_COMBINE_BEHAVIOUR
+            )]
+        [/#list]
+
+        [@infoContent
+            type="referencedata"
+            id=type
+            details=referenceDataDetails
+        /]
+    [/#list]
+
+    [#-- Layers --]
+    [#list getAllLayerConfiguration() as type,layerConfig ]
+        [#local layerConfigDescription = layerConfig.Properties?filter( prop -> prop.Type == "Description")?map( prop -> prop.Value )?join(' ') ]
+
+        [#local layerTypeDetails = {
+            "Type" : layerConfig.Type,
+            "ReferenceLookupType" : (layerConfig.ReferenceLookupType)!"",
+            "Description" : layerConfigDescription,
+            "Attributes" : layerConfig.Attributes
+        }]
+
+        [@infoContent
+            type="layertypes"
+            id=type
+            details=layerTypeDetails
+        /]
+
+        [#list (getBlueprint()[layerConfig.ReferenceLookupType])!{} as layerId,layerData ]
+
+            [#local layerDataDetails = {
+                "Type" : type,
+                "Id" : layerId,
+                "Properties" : layerData
+            }]
+
+            [@infoContent
+                type="layerdata"
+                id=layerId
+                details=layerDataDetails
+            /]
+        [/#list]
+    [/#list]
+
 [/#macro]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)


## Description

- Extends the info output to include reference and layer data
- Includes both the configured instances of each type along with their type data
- Adds methods to access all of instances of reference or layer data

## Motivation and Context

Allows for determining the end result of the overlays, overrides and different sources for reference and layer information

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

