### PR TITLE
fix: hanlding of 0/0 cidr in ip addr groups

### DIFF
--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -578,7 +578,7 @@
             [#if value?is_hash && value.Enabled!true]
                 [#local isOpen = (value.IsOpen)!false ]
                 [#list asFlattenedArray(value.CIDR![]) as cidrEntry ]
-                    [#if cidrEntry?contains("0.0.0.0")]
+                    [#if cidrEntry == "0.0.0.0" || cidrEntry == "0.0.0.0/0" ]
                         [#local isOpen = true]
                     [#else]
                         [#local cidrs += [cidrEntry] ]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Fixes an issue where the contains match that was used was causing false reports of isOpen cidr ranges.

## Motivation and Context

When using 10.0.0.0/16 it treated this as open where 10.2.0.0/16 was treated as closed. Given that there are only really two cidr options for open have changed it to an == match

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

