### PR TITLE
feat: add tagging control on layers

### DIFF
--- a/providers/shared/layers/Account/id.ftl
+++ b/providers/shared/layers/Account/id.ftl
@@ -438,6 +438,12 @@
                     "Default" : []
                 }
             ]
+        },
+        {
+            "Names" : "TagSet",
+            "Description" : "The TagSet to apply",
+            "Type" : STRING_TYPE,
+            "Default" : "default"
         }
     ]
 /]

--- a/providers/shared/layers/Environment/id.ftl
+++ b/providers/shared/layers/Environment/id.ftl
@@ -168,6 +168,12 @@
         {
             "Names" : "OSPatching",
             "AttributeSet" : OSPATCHING_ATTRIBUTESET_TYPE
+        },
+        {
+            "Names" : "TagSet",
+            "Description" : "The TagSet to apply",
+            "Type" : STRING_TYPE,
+            "Default" : "default"
         }
     ]
 /]

--- a/providers/shared/layers/Product/id.ftl
+++ b/providers/shared/layers/Product/id.ftl
@@ -127,6 +127,12 @@
             "Names" : "PlacementProfiles",
             "SubObjects" : true,
             "Children" : placementProfileConfiguration
+        },
+        {
+            "Names" : "TagSet",
+            "Description" : "The TagSet to apply",
+            "Type" : STRING_TYPE,
+            "Default" : "default"
         }
     ]
 /]

--- a/providers/shared/layers/Segment/id.ftl
+++ b/providers/shared/layers/Segment/id.ftl
@@ -249,6 +249,12 @@
                     "Types" : [ NUMBER_TYPE, STRING_TYPE ]
                 }
             ]
+        },
+        {
+            "Names" : "TagSet",
+            "Description" : "The TagSet to apply",
+            "Type" : STRING_TYPE,
+            "Default" : "default"
         }
     ]
 /]

--- a/providers/shared/layers/Tenant/id.ftl
+++ b/providers/shared/layers/Tenant/id.ftl
@@ -89,6 +89,12 @@
             "Names" : "PlacementProfiles",
             "SubObjects" : true,
             "Children" : placementProfileConfiguration
+        },
+        {
+            "Names" : "TagSet",
+            "Description" : "The TagSet to apply",
+            "Type" : STRING_TYPE,
+            "Default" : "default"
         }
     ]
 /]

--- a/providers/shared/references/TagSet/id.ftl
+++ b/providers/shared/references/TagSet/id.ftl
@@ -1,0 +1,56 @@
+[#ftl]
+
+[@addReference
+    type=TAGSET_REFERENCE_TYPE
+    pluralType="TagSets"
+    properties=[
+        {
+                "Type"  : "Description",
+                "Value" : "Defines tag metadata that will be applied to resources"
+        }]
+    attributes=[
+        {
+            "Names" : "Include",
+            "Description" : "Tags that will be included based on the context of your deployment",
+            "Children"  : [
+                {
+                    "Names" : "References",
+                    "Description" : "Include deployment and configuration references",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : true
+                }
+                {
+                    "Names" : "Layers",
+                    "Description" : "Include the layers that the occurrence belongs to",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Names" : "Solution",
+                    "Description" : "Include details of the solution the occurrence belongs to",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : true
+                }
+                {
+                    "Names" : "Name",
+                    "Description" : "The name of the component",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : true
+                }
+            ]
+        },
+        {
+            "Names" : "Additional",
+            "Description": "Extra tags that will be included",
+            "Subobjects" : true,
+            "Children" : [
+                {
+                    "Names" : "Value",
+                    "Description" : "The value of the tag to apply",
+                    "Types" : STRING_TYPE,
+                    "Mandatory" : true
+                }
+            ]
+        }
+    ]
+/]

--- a/providers/shared/references/reference.ftl
+++ b/providers/shared/references/reference.ftl
@@ -50,6 +50,7 @@
 [#assign SECURITYPROFILE_REFERENCE_TYPE = "SecurityProfile" ]
 [#assign NETWORKPROFILE_REFERENCE_TYPE = "NetworkProfile" ]
 [#assign SERVICEROLE_REFERENCE_TYPE = "ServiceRole" ]
+[#assign TAGSET_REFERENCE_TYPE = "TagSet"]
 
 [#assign TESTCASE_REFERENCE_TYPE = "TestCase" ]
 [#assign TESTPROFILE_REFERENCE_TYPE = "TestProfile" ]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds the TagSet Reference type which is used to define the tags that should be applied to resources
- Adds the TagSet configuration to each of the layers

## Motivation and Context

Adds support for #1540   to allow for users to control the tags applied to their resources

## How Has This Been Tested?

Tested locally ( still in draft ) 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

