### PR TITLE
feat: add named ip address groups

### DIFF
--- a/providers/shared/references/IPAddressGroup/id.ftl
+++ b/providers/shared/references/IPAddressGroup/id.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[@addReference 
+[@addReference
     type=IPADDRESSGROUP_REFERENCE_TYPE
     pluralType="IPAddressGroups"
     properties=[


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds support for referencing inbuilt named prefix groups in IPAddressGroups
- Defaults group to closed when handling missing tier configuration - mostly a security best practice thing

## Motivation and Context

In providers like Azure there are a collection of Prefix references that map to Azure Services or Generic IP Collections ( Internet, VirtualNetwork etc. ). When using them in Azure they can be used in the same places that CIDR ranges can be used. 

This aligns the concept of the Named prefix groups with our IPAddress Groups 

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

