### PR TITLE
feat: client vpn component

### DIFF
--- a/providers/shared/components/clientvpn/id.ftl
+++ b/providers/shared/components/clientvpn/id.ftl
@@ -1,0 +1,163 @@
+[#ftl]
+
+[@addComponent
+    type=CLIENTVPN_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "A client based VPN service"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : [ "Extensions", "Fragment", "Container" ],
+                "Description" : "Extensions to invoke as part of component processing",
+                "Types" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
+                "Names" : "Links",
+                "SubObjects" : true,
+                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+            },
+            {
+                "Names" : "Profiles",
+                "Children" :
+                    [
+                        {
+                            "Names" : "Network",
+                            "Types" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
+                            "Names" : "Logging",
+                            "Description" : "profile to define where logs are forwarded to from this component",
+                            "Types" : STRING_TYPE,
+                            "Default" : "default"
+                        }
+                    ]
+            },
+            {
+                "Names" : "Logging",
+                "Description" : "Enable client connection logging",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "Network",
+                "Children" : [
+                    {
+                        "Names" : "ClientCIDR",
+                        "Description" : "The CIDR Address Range used for vpn clients",
+                        "Types" : STRING_TYPE,
+                        "Mandatory" : true
+                    },
+                    {
+                        "Names" : "ManageDNS",
+                        "Description" : "Should the VPN control the DNS resolution of the client",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "SplitTunnel",
+                        "Description" : "Only route specific traffic over the tunnel",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "Destinations",
+                        "Description" : "Where VPN Clients can route to",
+                        "Children" : [
+                            {
+                                "Names" : "IPAddressGroups",
+                                "Description" : "A list of IP address Groups the VPN can access",
+                                "Types" : ARRAY_OF_STRING_TYPE,
+                                "Default" : [ "_localnet" ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "Names" : "Authentication",
+                "Description" : "Configure authentication for the VPN",
+                "Children" : [
+                    {
+                        "Names" : "Provider",
+                        "Description" : "The details of the authentication provider",
+                        "Children" : [
+                            {
+                                "Names" : "Link",
+                                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "MutualTLS",
+                        "Description" : "Require MutualTLS for VPN client connections",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : false
+                    }
+                ]
+            },
+            {
+                "Names" : "AuthorisationRules",
+                "Description" : "Authorisation rules to apply on VPN Connections",
+                "SubObjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Condition",
+                        "Description" : "The condition of the rule",
+                        "Values" : [ "allclients", "group" ],
+                        "Types" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "condition:Group",
+                        "Children" : [
+                            {
+                                "Names" : "GroupId",
+                                "Description" : "The Id of the group from the provider to apply the condition to",
+                                "Types" : STRING_TYPE
+                            }
+                        ]
+                    }
+                    {
+                        "Names" : "Destinations",
+                        "Description" : "Where VPN clients that match this rule can access",
+                        "Children" : [
+                            {
+                                "Names" : "IPAddressGroups",
+                                "Description" : "A list of IP address Groups the VPN can access",
+                                "Types" : ARRAY_OF_STRING_TYPE,
+                                "Default" : [ "_localnet" ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "Names" : "Port",
+                "Description" : "The Id of the port reference to use for the public VPN connection",
+                "Types" : STRING_TYPE,
+                "Default" : "https"
+            },
+            {
+                "Names" : "SelfServicePortal",
+                "Description" : "Enable the use of a self service portal for VPN Setup",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "Certificate",
+                "Description" : "The certificate hostname to use for the clientVPN",
+                "Children" : certificateChildConfiguration
+            }
+        ]
+/]
+
+[@addComponentDeployment
+    type=CLIENTVPN_COMPONENT_TYPE
+    defaultGroup="segment"
+/]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -24,6 +24,8 @@
 [#assign CDN_COMPONENT_TYPE = "cdn"]
 [#assign CDN_ROUTE_COMPONENT_TYPE = "cdnroute" ]
 
+[#assign CLIENTVPN_COMPONENT_TYPE = "clientvpn" ]
+
 [#assign COMPUTECLUSTER_COMPONENT_TYPE = "computecluster"]
 
 [#assign CONFIGSTORE_COMPONENT_TYPE = "configstore" ]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)


## Description

- Adds the definition of a new clientvpn component which is designed for point to site based VPN connections

## Motivation and Context

This defines a new network level component for client based vpns. These VPN's are often used by users to access private network instead of a SiteToSite vpn which is aimed at connecting to private networks together 

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

