### PR TITLE
feat(externalnetwork): SharedKey and BGP Peer

### DIFF
--- a/providers/shared/components/externalnetwork/id.ftl
+++ b/providers/shared/components/externalnetwork/id.ftl
@@ -69,6 +69,21 @@
                         "Names" : "PublicIP",
                         "Description" : "The public IP address of the VPN tunnel",
                         "Types" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "SharedKey",
+                        "Description" : "The shared key to use to establish the VPN",
+                        "Types" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "BGP",
+                        "Children" : [
+                            {
+                                "Names" : "PeerIPAddress",
+                                "Description" : "The BGP Peer address for this connection",
+                                "Types" : STRING_TYPE
+                            }
+                        ]
                     }
                 ]
             },


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)


## Description

- Adds support for defining the SharedKey used for ipsec negotiation
- Adds support for defining the internal IP used for BGP peering across a vpn connection

## Motivation and Context

Extends external network connection configuration to align with other VPN providers 

## How Has This Been Tested?


## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

