### PR TITLE
feat: skip image pull during generation

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -1109,22 +1109,26 @@
 
     [#return
         [
-            r'get_url_image_to_registry ' +
-            r'   "' + sourceURL + r'" ' +
-            r'   "' + expectedImageHash + r'" ' +
-            r'   "' + imageFormat + r'" ' +
-            r'   "' + region + r'" ' +
-            r'   "' + registryBucket + r'" ' +
-            r'   "' + registryPrefix + r'" ' +
-            r'   "' + registryFile + r'" ' +
-            r'   "' + product + r'" ' +
-            r'   "' + environment + r'" ' +
-            r'   "' + segment + r'" ' +
-            r'   "' + buildUnit + r'" ' +
-            r'   "' + createZip?c + r'" || exit $?',
-            r'# refresh settings to include new build file',
+            r'if [[ "${HAMLET_SKIP_IMAGE_PULL}" != "true" ]]; then',
+            r'   get_url_image_to_registry ' +
+            r'     "' + sourceURL + r'" ' +
+            r'     "' + expectedImageHash + r'" ' +
+            r'     "' + imageFormat + r'" ' +
+            r'     "' + region + r'" ' +
+            r'     "' + registryBucket + r'" ' +
+            r'     "' + registryPrefix + r'" ' +
+            r'     "' + registryFile + r'" ' +
+            r'     "' + product + r'" ' +
+            r'     "' + environment + r'" ' +
+            r'     "' + segment + r'" ' +
+            r'     "' + buildUnit + r'" ' +
+            r'     "' + createZip?c + r'" || exit $?',
+            r'   # refresh settings to include new build file',
             r'',
-            r'assemble_settings "${GENERATION_DATA_DIR}" "${COMPOSITE_SETTINGS}"'
+            r'   assemble_settings "${GENERATION_DATA_DIR}" "${COMPOSITE_SETTINGS}"'
+            r'else',
+            r'   info "Skipping image pull as HAMLET_SKIP_IMAGE_PULL is set"',
+            r'fi'
         ]
     ]
 [/#function]
@@ -1145,7 +1149,8 @@
 
     [#return
         [
-            r'get_image_from_container_registry' +
+            r'if [[ "${HAMLET_SKIP_IMAGE_PULL}" != "true" ]]; then',
+            r'  get_image_from_container_registry' +
             r'   "' + sourceImage + r'" ' +
             r'   "' + imageFormat + r'" ' +
             r'   "' + product + r'" ' +
@@ -1155,9 +1160,12 @@
             r'   "' + registryHost + r'" ' +
             r'   "' + registryProvider + r'" ' +
             r'   "' + region + r'" || exit $? ',
-            r'# refresh settings to include new build file',
+            r'   # refresh settings to include new build file',
             r'',
-            r'assemble_settings "${GENERATION_DATA_DIR}" "${COMPOSITE_SETTINGS}"'
+            r'   assemble_settings "${GENERATION_DATA_DIR}" "${COMPOSITE_SETTINGS}"',
+            r'else',
+            r'   info "Skipping image pull as HAMLET_SKIP_IMAGE_PULL is set"',
+            r'fi'
         ]
     ]
 [/#function]


### PR DESCRIPTION

## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds the env var HAMLET_SKIP_IMAGE_PULL which can be used to disable the pull and push of images during deployment generation

## Motivation and Context

This is useful when you are working on changes to a template locally and don't want to keep pulling the same image. Especially useful when dealing with container deployments with large container images

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

