### PR TITLE
feat: add filter policies to topic subscriptions

### DIFF
--- a/providers/shared/components/topic/id.ftl
+++ b/providers/shared/components/topic/id.ftl
@@ -107,12 +107,12 @@
                 "SubObjects" : true,
                 "Children" : [
                     {
-                        "Names" : "MsgKey",
+                        "Names" : "Attribute",
                         "Description" : "Name of the filter",
                         "Types" : STRING_TYPE
                     },
                     {
-                        "Names" : "MsgValues",
+                        "Names" : "Values",
                         "Description" : "Valid values for the filter",
                         "Types" : ARRAY_OF_STRING_TYPE
                     },

--- a/providers/shared/components/topic/id.ftl
+++ b/providers/shared/components/topic/id.ftl
@@ -103,6 +103,27 @@
                 ]
             },
             {
+                "Names" : "Filters",
+                "SubObjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "MsgKey",
+                        "Description" : "Name of the filter",
+                        "Types" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "MsgValues",
+                        "Description" : "Valid values for the filter",
+                        "Types" : ARRAY_OF_STRING_TYPE
+                    },
+                    {
+                        "Names" : "Links",
+                        "SubObjects" : true,
+                        "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+                    }
+                ]
+            },
+            {
                 "Names" : "RawMessageDelivery",
                 "Description" : "Deliver message as received not with JSON payload strucutre",
                 "Types" : BOOLEAN_TYPE,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Add filter policy to topic subscriptions
New child attribute of Filters for Subscriptions

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Required for https://github.com/gs-dawr/exdoc-mail-aws/issues/49

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Local generation, not deployed to AWS

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

