### PR TITLE
fix: handle missing deployment unit

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -5,7 +5,7 @@
     [#if obj["deployment:Unit"]?has_content ]
         [#return obj["deployment:Unit"]]
     [#else]
-        [#if ! obj.DeploymentUnits?? || ! obj.DeploymentUnits?has_content ]
+        [#if ! obj.DeploymentUnits?has_content ]
             [#return ""]
         [/#if]
 

--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -5,6 +5,10 @@
     [#if obj["deployment:Unit"]?has_content ]
         [#return obj["deployment:Unit"]]
     [#else]
+        [#if ! obj.DeploymentUnits?? || ! obj.DeploymentUnits?has_content ]
+            [#return ""]
+        [/#if]
+
         [#return (((obj.DeploymentUnits)![])[0])!"" ]
     [/#if]
 [/#function]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Handles scenarios where the deployment unit value is null or empty with the move to only include the attribute when required

## Motivation and Context

Exceptions being thrown when deploymentUnit properties were empty when they were required

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

