### PR TITLE
fix: set maintenance window defaults

### DIFF
--- a/providers/shared/attributesets/maintenancewindow/id.ftl
+++ b/providers/shared/attributesets/maintenancewindow/id.ftl
@@ -20,15 +20,18 @@
                 "Thursday",
                 "Friday",
                 "Saturday"
-            ]
+            ],
+            "Default" : "Sunday"
         },
         {
             "Names" : "TimeOfDay",
-            "Types" : STRING_TYPE
+            "Types" : STRING_TYPE,
+            "Default" : "01:00"
         },
         {
             "Names" : "TimeZone",
-            "Types" : STRING_TYPE
+            "Types" : STRING_TYPE,
+            "Default" : "UTC"
         }
      ]
 /]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Add maintenance defaults to ensure that a standard window is applied

## Motivation and Context

Currently when no option is defined different AWS services set different windows 

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

