### PR TITLE
refactor(efs): rename to fileshare

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -557,8 +557,8 @@
                                 }
                         }]
                     [#break]
-                [#case EFS_COMPONENT_TYPE]
-                [#case EFS_MOUNT_COMPONENT_TYPE]
+                [#case FILESHARE_COMPONENT_TYPE]
+                [#case FILESHARE_MOUNT_COMPONENT_TYPE]
                     [#local _context +=
                         {
                             "DataVolumes" :

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -60,8 +60,14 @@
 [#assign ECS_SERVICE_COMPONENT_TYPE = "service" ]
 [#assign ECS_TASK_COMPONENT_TYPE = "task" ]
 
-[#assign EFS_COMPONENT_TYPE = "efs" ]
-[#assign EFS_MOUNT_COMPONENT_TYPE = "efsmount"]
+[#assign FILESHARE_COMPONENT_TYPE = "fileshare" ]
+[#assign FILESHARE_MOUNT_COMPONENT_TYPE = "filesharemount"]
+
+[#assign FILESHARE_LEGACY_COMPONENT_TYPE = "efs" ]
+[#assign legacyTypeMapping += { FILESHARE_LEGACY_COMPONENT_TYPE : FILESHARE_COMPONENT_TYPE } ]
+
+[#assign FILESHARE_MOUNT_LEGACY_COMPONENT_TYPE = "efsmount" ]
+[#assign legacyTypeMapping += { FILESHARE_MOUNT_LEGACY_COMPONENT_TYPE : FILESHARE_MOUNT_COMPONENT_TYPE } ]
 
 [#assign ES_COMPONENT_TYPE = "es"]
 [#assign ES_LEGACY_COMPONENT_TYPE = "elasticsearch"]

--- a/providers/shared/components/fileshare/id.ftl
+++ b/providers/shared/components/fileshare/id.ftl
@@ -1,7 +1,7 @@
 [#ftl]
 
 [@addComponent
-    type=EFS_COMPONENT_TYPE
+    type=FILESHARE_COMPONENT_TYPE
     properties=
         [
             {
@@ -17,12 +17,29 @@
                 "Default" : true
             },
             {
+                "Names" : "Engine",
+                "Types" : STRING_TYPE,
+                "Description" : "The type of file share that the component will offer",
+                "Values" : [ "NFS", "SMB" ],
+                "Default" : "NFS"
+            },
+            {
+                "Names": "Size",
+                "Description" : "The size in Gb of the file share",
+                "Types": NUMBER_TYPE
+            },
+            {
                 "Names" : "Profiles",
                 "Children" : [
                     {
                         "Names" : "Network",
                         "Types" : STRING_TYPE,
                         "Default" : "default"
+                    },
+                    {
+                        "Names" : "Logging",
+                        "Types" : STRING_TYPE,
+                        "Default": "default"
                     }
                 ]
             },
@@ -35,18 +52,34 @@
                 "Names" : "Links",
                 "SubObjects" : true,
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+            },
+            {
+                "Names" : "MaintenanceWindow",
+                "Description" : "When to apply maintenance on the share",
+                "AttributeSet" : MAINTENANCEWINDOW_ATTRIBUTESET_TYPE
+            },
+            {
+                "Names" : "Backup",
+                "Children" : [
+                    {
+                        "Names" : "RetentionPeriod",
+                        "Description" : "The time in days to keep backups",
+                        "Types" : NUMBER_TYPE,
+                        "Default" : 31
+                    }
+                ]
             }
         ]
 /]
 
 [@addComponentDeployment
-    type=EFS_COMPONENT_TYPE
+    type=FILESHARE_COMPONENT_TYPE
     defaultGroup="solution"
     defaultPriority=50
 /]
 
 [@addChildComponent
-    type=EFS_MOUNT_COMPONENT_TYPE
+    type=FILESHARE_MOUNT_COMPONENT_TYPE
     properties=
         [
             {
@@ -104,7 +137,7 @@
                 ]
             }
         ]
-    parent=EFS_COMPONENT_TYPE
+    parent=FILESHARE_COMPONENT_TYPE
     childAttribute="Mounts"
     linkAttributes="Mount"
 /]


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description

- Renames the efs component to fileshare with backwards compatibility for the current type id of EFS
- Adds extended properties to support broader fileshare components

## Motivation and Context

This makes the naming align to the solution level component rather than a particular provider implementation 

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

