### PR TITLE
chore: add winrm ports to masterdata

### DIFF
--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -906,6 +906,28 @@
         "Timeout": "5"
       }
     },
+    "winrm" : {
+      "Port": 5985,
+      "Protocol": "TCP",
+      "IPProtocol": "tcp",
+      "HealthCheck": {
+        "HealthyThreshold": "3",
+        "UnhealthyThreshold": "5",
+        "Interval": "30",
+        "Timeout": "5"
+      }
+    },
+    "winrm-tls" : {
+      "Port": 5986,
+      "Protocol": "TCP",
+      "IPProtocol": "tcp",
+      "HealthCheck": {
+        "HealthyThreshold": "3",
+        "UnhealthyThreshold": "5",
+        "Interval": "30",
+        "Timeout": "5"
+      }
+    },
     "ws": {
       "Port": 80,
       "Protocol": "TCP",


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)


## Description

- Adds winrm ports to masterdata as a standard port for windows remote management

## Motivation and Context

Allows for the ports to be embedded in component deployments 

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

