### PR TITLE
feat(topic): add link support and policy migration

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -649,7 +649,7 @@
     },
     {
         "Names" : "aws:TopicPermissionMigration",
-        "Description" : "Deprecation alert: set to true once policy updated for queue",
+        "Description" : "Deprecation alert: set to true once policy updated for topic",
         "Types" : BOOLEAN_TYPE,
         "Default" : false
     }

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -646,6 +646,12 @@
         "Description" : "Deprecation alert: set to true once policy updated for queue",
         "Types" : BOOLEAN_TYPE,
         "Default" : false
+    },
+    {
+        "Names" : "aws:TopicPermissionMigration",
+        "Description" : "Deprecation alert: set to true once policy updated for queue",
+        "Types" : BOOLEAN_TYPE,
+        "Default" : false
     }
 ]]
 

--- a/providers/shared/components/topic/id.ftl
+++ b/providers/shared/components/topic/id.ftl
@@ -26,6 +26,11 @@
                 "Names" : "Alerts",
                 "SubObjects" : true,
                 "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
+            },
+            {
+                "Names" : "Links",
+                "SubObjects" : true,
+                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
             }
         ]
 /]


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description

- Adds support for links on topics
- Adds migration attribute on topics when working with S3 notifications

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
- Links for topics allows for topic level permissions and actions to be created 
- The migration process creates user action on moving from defining queue policies 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

