### PR TITLE
feat: component type info

### DIFF
--- a/engine/component.ftl
+++ b/engine/component.ftl
@@ -366,6 +366,10 @@
     /]
 [/#macro]
 
+[#function getAllComponentConfiguration ]
+    [#return componentConfiguration ]
+[/#function]
+
 [#function getComponentDependencies type]
     [#return (componentConfiguration[type].Dependencies)![] ]
 [/#function]
@@ -420,6 +424,25 @@
     [#return result]
 [/#function]
 
+[#function getComponentResourceGroupAttributes componentResourceGroup provider]
+    [#if (componentResourceGroup.Extensions![])?has_content]
+
+        [#local extendedSharedAttributes =
+            extendAttributes(
+                (componentResourceGroup.Attributes[SHARED_ATTRIBUTES])![],
+                (componentResourceGroup.Extensions[provider])![],
+                provider)]
+    [#else]
+        [#local extendedSharedAttributes = (componentResourceGroup.Attributes[SHARED_ATTRIBUTES])![] ]
+    [/#if]
+
+    [#return
+        extendedSharedAttributes +
+        ((componentResourceGroup.Attributes[BASE_ATTRIBUTES])![]) +
+        ((componentResourceGroup.Attributes[DEPLOYMENT_ATTRIBUTES])![]) +
+        ((componentResourceGroup.Attributes[provider])![])
+    ]
+[/#function]
 
 [#function getResourceGroupPlacement key profile]
     [#return profile[key]!{} ]

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -553,22 +553,7 @@ already prefixed attribute.
         [#local placement = (occurrence.State.ResourceGroups[key].Placement)!{}]
         [#local provider = placement.Provider!"" ]
 
-        [#if (value.Extensions![])?has_content]
-            [#local extendedSharedAttributes =
-                extendAttributes(
-                    (value.Attributes[SHARED_ATTRIBUTES])![],
-                    (value.Extensions[provider])![],
-                    provider)]
-        [#else]
-            [#local extendedSharedAttributes = (value.Attributes[SHARED_ATTRIBUTES])![] ]
-        [/#if]
-
-        [#local attributes +=
-            extendedSharedAttributes +
-            ((value.Attributes[BASE_ATTRIBUTES])![]) +
-            ((value.Attributes[DEPLOYMENT_ATTRIBUTES])![]) +
-            ((value.Attributes[provider])![])
-        ]
+        [#local attributes += getComponentResourceGroupAttributes(value, provider)]
 
     [/#list]
     [#return attributes]

--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -200,7 +200,8 @@
             "ReferenceTypes" : getOutputContent("referencetypes")?values,
             "ReferenceData" : asFlattenedArray(getOutputContent("referencedata")?values),
             "LayerTypes" : getOutputContent("layertypes")?values,
-            "LayerData" : getOutputContent("layerdata")?values
+            "LayerData" : getOutputContent("layerdata")?values,
+            "ComponentTypes" : getOutputContent("componenttypes")?values
         }
     ]
 [/#function]

--- a/providers/shared/views/info/setup.ftl
+++ b/providers/shared/views/info/setup.ftl
@@ -130,4 +130,36 @@
         [/#list]
     [/#list]
 
+    [#-- Components --]
+    [#list getAllComponentConfiguration() as type,componentConfig ]
+
+        [#local componentConfigDescription = asFlattenedArray(
+                componentConfig.Properties?filter( prop -> prop.Type == "Description")?map( prop -> prop.Value )
+            )?join(' ') ]
+
+        [#local componentAttributes = []]
+
+        [#list getComponentResourceGroups(type) as id, resourceGroup ]
+
+            [#list combineEntities([ SHARED_PROVIDER ], getLoaderProviders(), UNIQUE_COMBINE_BEHAVIOUR) as provider ]
+
+                [#local componentAttributes = combineEntities(
+                        componentAttributes,
+                        getComponentResourceGroupAttributes(resourceGroup, provider),
+                        MERGE_COMBINE_BEHAVIOUR)]
+            [/#list]
+        [/#list]
+
+        [#local componentTypeDetails = {
+            "Type" : type,
+            "Description" : componentConfigDescription,
+            "Attributes" : componentAttributes
+        }]
+
+        [@infoContent
+            type="componenttypes"
+            id=type
+            details=componentTypeDetails
+        /]
+    [/#list]
 [/#macro]


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds a standard component function for assembling the attributes of a component
- Adds a base get function for all component configuration
- Use the standard attribute configuration for schema generation
- Adds support for including component type configuration as part of the info view

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Ensures that a standard representation of the components attributes can be generated when required

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and with https://github.com/hamlet-io/executor-python/pull/260

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

