### PR TITLE
feat(ecs): add support for secrets in containers

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -580,6 +580,19 @@
 
                     ]
                     [#break]
+                [#case SECRETSTORE_SECRET_COMPONENT_TYPE ]
+                    [#local _context = mergeObjects(
+                        _context,
+                        {
+                            "Secrets" : {
+                                linkId : {
+                                    "Provider" : linkTargetAttributes["ENGINE"],
+                                    "Ref" : linkTargetResources["secret"].Id,
+                                    "EncryptionKeyId" : linkTargetResources["secret"].cmkKeyId
+                                }
+                            }
+                        })]
+                    [#break]
             [/#switch]
         [/#list]
 

--- a/providers/shared/extensions/extension.ftl
+++ b/providers/shared/extensions/extension.ftl
@@ -324,6 +324,47 @@
 
 [/#macro]
 
+
+[#macro SecretEnvironment envName secretLinkId secretJsonKey="" version="" ]
+
+    [#local secretRef = ""]
+
+    [#local secret = (_context.Secrets[secretLinkId])!{}]
+    [#if secret?has_content ]
+
+        [#switch secret.Provider]
+            [#case "aws:secretsmanager"]
+                [#local secretRef = {
+                    "Fn::Join" : [
+                        ":",
+                        [
+                            getArn(secret.Ref),
+                            secretJsonKey,
+                            version,
+                            ""
+                        ]
+                    ]
+                }]
+                [#break]
+        [/#switch]
+
+        [#assign _context = mergeObjects(
+            _context,
+            {
+                "SecretEnv" : {
+                    envName : {
+                        "EnvName" : envName,
+                        "SecretRef" : secretRef
+                    }
+                }
+            }
+        )]
+
+    [/#if]
+[/#macro]
+
+[#-- IAM Specific configuration --]
+
 [#macro Policy statements...]
     [#assign _context +=
         {


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds the SecretEnvironment macro for extensions which allows for defining a secret whose value will be injected into a container at runtime
- Adds link handling to determine the secret and provide environment separation and permissions

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for secrets to be secured and injected into containers as they start. Removing the need for the container to handle decryption of secrets but still keeping things locked down 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

