### PR TITLE
feat: db secret store support

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -593,6 +593,23 @@
                             }
                         })]
                     [#break]
+
+                [#case DB_COMPONENT_TYPE]
+                    [#if ((linkTargetAttributes["SECRET_ARN"])!"")?has_content ]
+                        [#local _context = mergeObjects(
+                            _context,
+                            {
+                                "Secrets" : {
+                                    linkId : {
+                                        "Provider" : linkTargetResources["rootCredentials"]["secret"].Provider,
+                                        "Ref" : linkTargetResources["rootCredentials"]["secret"].Id,
+                                        "EncryptionKeyId" : linkTargetResources["rootCredentials"]["secret"].cmkKeyId
+                                    }
+                                }
+                            }
+                        )]
+                    [/#if]
+                    [#break]
             [/#switch]
         [/#list]
 

--- a/providers/shared/attributesets/attributeset.ftl
+++ b/providers/shared/attributesets/attributeset.ftl
@@ -18,6 +18,8 @@
 
 [#assign OSPATCHING_ATTRIBUTESET_TYPE = "ospatching"]
 
+[#assign SECRETSTRING_ATTRIBUTESET_TYPE = "secretstring" ]
+
 [#assign PLUGIN_ATTRIBUTESET_TYPE = "plugin"]
 
 [#assign VOLUME_ATTRIBUTESET_TYPE = "volume"]

--- a/providers/shared/attributesets/secretstring/id.ftl
+++ b/providers/shared/attributesets/secretstring/id.ftl
@@ -1,0 +1,62 @@
+[#ftl]
+
+[@addAttributeSet
+    type=SECRETSTRING_ATTRIBUTESET_TYPE
+    pluralType="SecretStrings"
+    properties=[
+        {
+                "Type"  : "Description",
+                "Value" : "Defines the policy for generating secret strings"
+        }
+    ]
+    attributes=[
+        {
+            "Names" : "MinLength",
+            "Description" : "The minimum character length",
+            "Types" : NUMBER_TYPE,
+            "Default" : 20
+        },
+        {
+            "Names" : "MaxLength",
+            "Description" : "The maximum character length",
+            "Types" : NUMBER_TYPE,
+            "Default" : 30
+        },
+        {
+            "Names" : "IncludeUpper",
+            "Description" : "Include upper-case characters",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : true
+        },
+        {
+            "Names" : "IncludeLower",
+            "Description" : "Include lower-case characters",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : true
+        },
+        {
+            "Names" : "IncludeSpecial",
+            "Description" : "Include special characters",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : false
+        },
+        {
+            "Names" : "IncludeNumber",
+            "Description" : "Include numbers characters",
+            "Types" : BOOLEAN_TYPE,
+            "Default": true
+        },
+        {
+            "Names" : "ExcludedCharacters",
+            "Description" : "Characters that must be excluded",
+            "Types" : ARRAY_OF_STRING_TYPE,
+            "Default" : [ r'"', r"'", r'$', r'@', r'/', r'\' ]
+        },
+        {
+            "Names" : "RequireAllIncludedTypes",
+            "Description" : "Require at least one of each included type",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : true
+        }
+    ]
+/]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -786,59 +786,9 @@
     {
         "Names" : "Requirements",
         "Description" : "Format requirements for the Secret",
-        "Children" : [
-            {
-                "Names" : "MinLength",
-                "Description" : "The minimum character length",
-                "Types" : NUMBER_TYPE,
-                "Default" : 20
-            },
-            {
-                "Names" : "MaxLength",
-                "Description" : "The maximum character length",
-                "Types" : NUMBER_TYPE,
-                "Default" : 30
-            },
-            {
-                "Names" : "IncludeUpper",
-                "Description" : "Include upper-case characters",
-                "Types" : BOOLEAN_TYPE,
-                "Default" : true
-            },
-            {
-                "Names" : "IncludeLower",
-                "Description" : "Include lower-case characters",
-                "Types" : BOOLEAN_TYPE,
-                "Default" : true
-            },
-            {
-                "Names" : "IncludeSpecial",
-                "Description" : "Include special characters",
-                "Types" : BOOLEAN_TYPE,
-                "Default" : false
-            },
-            {
-                "Names" : "IncludeNumber",
-                "Description" : "Include numbers characters",
-                "Types" : BOOLEAN_TYPE,
-                "Default": true
-            },
-            {
-                "Names" : "ExcludedCharacters",
-                "Description" : "Characters that must be excluded",
-                "Types" : ARRAY_OF_STRING_TYPE,
-                "Default" : [ r'"', r"'", r'$', r'@', r'/', r'\' ]
-            },
-            {
-                "Names" : "RequireAllIncludedTypes",
-                "Description" : "Require at least one of each included type",
-                "Types" : BOOLEAN_TYPE,
-                "Default" : true
-            }
-        ]
+        "AttributeSet" : SECRETSTRING_ATTRIBUTESET_TYPE
     }
-    ]
-]
+]]
 
 [#assign networkRuleChildConfiguration = [
     {

--- a/providers/shared/components/db/id.ftl
+++ b/providers/shared/components/db/id.ftl
@@ -50,7 +50,15 @@
                 "Default" : false
             },
             {
-                "Names" : "GenerateCredentials",
+                "Names" : "rootCredential:Source",
+                "Description" : "The source of the root credentials used in the database",
+                "Types" : STRING_TYPE,
+                "Values" : [ "Generated", "SecretStore", "Settings" ],
+                "Default" : "Settings"
+            },
+            {
+                "Names" : [ "rootCredential:Generated", "GenerateCredentials" ],
+                "Description" : "Generate credentials and store them as an encrypted string",
                 "Children" : [
                     {
                         "Names" : "Enabled",
@@ -58,7 +66,7 @@
                         "Default" : false
                     },
                     {
-                        "Names" : "MasterUserName",
+                        "Names" : [ "Username", "MasterUserName" ],
                         "Types" : STRING_TYPE,
                         "Default" : "root"
                     },
@@ -72,6 +80,57 @@
                         "Types" : STRING_TYPE,
                         "Description" : "A prefix appended to link attributes to show encryption status",
                         "Default" : ""
+                    }
+                ]
+            },
+            {
+                "Names" : "rootCredential:SecretStore",
+                "Description" : "Use a secret store to manage the root credentials",
+                "Children" : [
+                    {
+                        "Names" : "Username",
+                        "Types" : STRING_TYPE,
+                        "Default" : "root"
+                    },
+                    {
+                        "Names" : "UsernameAttribute",
+                        "Description" : "The attribute of the username to store in the secret",
+                        "Types" : STRING_TYPE,
+                        "Default" : "username"
+                    },
+                    {
+                        "Names" : "PasswordAttribute",
+                        "Description" : "The attribute of the password to store in the secret",
+                        "Types" : STRING_TYPE,
+                        "Default" : "password"
+                    },
+                    {
+                        "Names" : "GenerationRequirements",
+                        "Description" : "When creating the secret using secretstore the policy for generating the secret",
+                        "AttributeSet" : SECRETSTRING_ATTRIBUTESET_TYPE
+                    }
+                    {
+                        "Names" : "Link",
+                        "Description" : "A link to a secret or store that will keep the secret",
+                        "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+                    }
+                ]
+            },
+            {
+                "Names" : "rootCredential:Settings",
+                "Description" : "Store the credentials as settings of the database occurrence",
+                "Children" : [
+                    {
+                        "Names" : "UsernameAttribute",
+                        "Description" : "The setting attribute that contains the username",
+                        "Types" : STRING_TYPE,
+                        "Default" : "MASTER_USERNAME"
+                    },
+                    {
+                        "Names" : "PasswordAttribute",
+                        "Description" : "The setting attribute that contains the password",
+                        "Types" : STRING_TYPE,
+                        "Default" : "MASTER_PASSWORD"
                     }
                 ]
             },


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description

- Adds definitions for database root credentials and includes a new source of secret store
- Creates an attributeset used to define generation rules for secret strings 
- Adds support for looking up Db secrets when using SecretEnvironment macros

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for using secret stores when configuring databases as an alternative to using encrypted strings or settings

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

