### PR TITLE
feat(kinesis): Prefix time path control

### DIFF
--- a/providers/shared/components/datafeed/id.ftl
+++ b/providers/shared/components/datafeed/id.ftl
@@ -60,7 +60,7 @@
                                 "Names" : "Order",
                                 "Description" : "The order of the included prefixes",
                                 "Types" : ARRAY_OF_STRING_TYPE,
-                                "Default" : [ "AccountId", "ComponentPath" ]
+                                "Default" : [ "AccountId", "ComponentPath", "TimePath" ]
                             }
                             {
                                 "Names" : "AccountId",
@@ -71,6 +71,12 @@
                             {
                                 "Names" : "ComponentPath",
                                 "Description" : "The full component path defaults",
+                                "Types": BOOLEAN_TYPE,
+                                "Default" : false
+                            },
+                            {
+                                "Names" : "TimePath",
+                                "Description" : "The time path defaults",
                                 "Types": BOOLEAN_TYPE,
                                 "Default" : false
                             }


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add the ability to include the year, month, day and hour in the prefix.

## Motivation and Context
While the time path is added automatically when not using partitioning, it must be explicitly added when partitioning is used.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

