### PR TITLE
feat(kinesis): ErrorType in prefix

### DIFF
--- a/providers/shared/components/datafeed/id.ftl
+++ b/providers/shared/components/datafeed/id.ftl
@@ -60,7 +60,7 @@
                                 "Names" : "Order",
                                 "Description" : "The order of the included prefixes",
                                 "Types" : ARRAY_OF_STRING_TYPE,
-                                "Default" : [ "AccountId", "ComponentPath", "TimePath" ]
+                                "Default" : [ "AccountId", "ComponentPath", "TimePath", "ErrorType" ]
                             }
                             {
                                 "Names" : "AccountId",
@@ -77,6 +77,12 @@
                             {
                                 "Names" : "TimePath",
                                 "Description" : "The time path defaults",
+                                "Types": BOOLEAN_TYPE,
+                                "Default" : false
+                            },
+                            {
+                                "Names" : "ErrorType",
+                                "Description" : "The type of error",
                                 "Types": BOOLEAN_TYPE,
                                 "Default" : false
                             }


### PR DESCRIPTION


## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add ability to explicitly include error type in prefix.

## Motivation and Context
This only applies to the error prefix. For partitioning the error type must be present in the error prefix.

The error type has been put after the time path to maintain consistency with the good data path. Investigations also tend to focus on what happened at a particular time so having the error types after the time path collects all error types under a single point.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

