### PR TITLE
refactor: mta rules for send process

### DIFF
--- a/providers/shared/components/mta/id.ftl
+++ b/providers/shared/components/mta/id.ftl
@@ -75,7 +75,7 @@
                     },
                     {
                         "Names" : "Senders",
-                        "Description" : "The sneders of the email to match on",
+                        "Description" : "The senders of the email to match on",
                         "Types" : ARRAY_OF_STRING_TYPE,
                         "Default" : []
                     }

--- a/providers/shared/components/mta/id.ftl
+++ b/providers/shared/components/mta/id.ftl
@@ -19,7 +19,7 @@
                 "Mandatory" : true
             },
             {
-                "Names" : [ "Certificate", "Hostname" ],
+                "Names" : [ "Hostname", "Certificate" ],
                 "Description" : "Configure the domain(s) associated with this MTA",
                 "Children" : certificateChildConfiguration
             },
@@ -27,7 +27,7 @@
                 "Names" : "IPAddressGroups",
                 "Description" : "Allowed IP addresses. If any group is provided, all unmatching traffic will be blocked",
                 "Types" : ARRAY_OF_STRING_TYPE,
-                "Default" : []
+                "Default" : [ "_global" ]
             }
         ]
 /]
@@ -69,33 +69,43 @@
                 "Children" : [
                     {
                         "Names" : "Recipients",
-                        "Description" : "Expected To addresses",
+                        "Description" : "The recipient of the email to match on",
                         "Types" : ARRAY_OF_STRING_TYPE,
                         "Default" : []
                     },
                     {
-                        "Names" : "EventTypes",
-                        "Description" : "Expected events to action (send only)",
+                        "Names" : "Senders",
+                        "Description" : "The sneders of the email to match on",
                         "Types" : ARRAY_OF_STRING_TYPE,
-                        "Default" : [],
-                        "Values" : [ 
-                            "click", 
-                            "bounce", 
-                            "send", 
-                            "open", 
-                            "complaint", 
-                            "delivery", 
-                            "renderingFailure", 
-                            "reject" 
-                        ]
+                        "Default" : []
                     }
                 ]
             },
             {
                 "Names" : "Action",
                 "Types" : STRING_TYPE,
-                "Values" : ["forward", "drop"],
+                "Values" : ["forward", "drop", "log"],
                 "Mandatory" : true
+            },
+            {
+                "Names" : "EventTypes",
+                "Description" : "Expected events to log  (send only)",
+                "Types" : ARRAY_OF_STRING_TYPE,
+                "Default" : [
+                    "reject",
+                    "bounce",
+                    "complaint"
+                ],
+                "Values" : [
+                    "click",
+                    "bounce",
+                    "send",
+                    "open",
+                    "complaint",
+                    "delivery",
+                    "renderingFailure",
+                    "reject"
+                ]
             },
             {
                 "Names" : "Links",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->

- Adds a new action for logging email events
- Adds a Senders condition to align with recipients
- Moves the EventTypes out of conditions to show they are log events to watch for
- Makes the hostname the default property to highlight what the configuration is for

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Highlights the differences between send and receive along with how the actions behave

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

