### PR TITLE
fix(s3): add enable on notifications

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -630,6 +630,11 @@
 
 [#assign s3NotificationChildConfiguration = [
     {
+        "Names" : "Enabled",
+        "Types" : BOOLEAN_TYPE,
+        "Default" : true
+    },
+    {
         "Names" : "Links",
         "SubObjects": true,
         "AttributeSet" : LINK_ATTRIBUTESET_TYPE


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)


## Description
<!--- Describe your changes in detail -->
- Allows for controlling if notifications are enabled on s3


## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This is required to disable notifications when running initial deployments where the topic is required and the topic needs the bucket for policy setup

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

