### PR TITLE
fix: ensure orphaned deployments are always first

### DIFF
--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -1974,7 +1974,7 @@
   "DeploymentModes": {
     "_orphan" : {
       "Operations": [ "delete" ],
-      "Membership": "priority",
+      "Membership": "orphaned",
       "Priority": {
         "GroupFilter": ".*",
         "Order": "HighestFirst"

--- a/providers/shared/provider.ftl
+++ b/providers/shared/provider.ftl
@@ -60,6 +60,8 @@
                 [#case "orphaned"]
                     [#if deploymentGroupDetails.Name?matches( deploymentModeDetails.Priority.GroupFilter ) ]
                         [#local stageEnabled = true]
+                        [#-- Make the priority as low as possible while still maintaining the group order --]
+                        [#-- This ensures that orphaned components are cleaned up in order to reduce dependencies --]
                         [#local stagePriority = deploymentGroupDetails.Priority * 0.1 ]
                     [/#if]
                     [#break]

--- a/providers/shared/provider.ftl
+++ b/providers/shared/provider.ftl
@@ -32,7 +32,7 @@
 
         [#if deploymentGroupDetails?has_content ]
 
-            [#local stageId = deploymentGroupDetails.Id ]
+            [#local stageId = "${deploymentGroupDetails.Id}_${deploymentModeDetails.Id}" ]
             [#local stagePriority = 0 ]
             [#local stageEnabled = false ]
 
@@ -54,6 +54,13 @@
                                                     (deploymentModeDetails.Priority.Order == "LowestFirst"),
                                                     1000 - deploymentGroupDetails.Priority
                                                 )]
+                    [/#if]
+                    [#break]
+
+                [#case "orphaned"]
+                    [#if deploymentGroupDetails.Name?matches( deploymentModeDetails.Priority.GroupFilter ) ]
+                        [#local stageEnabled = true]
+                        [#local stagePriority = deploymentGroupDetails.Priority * 0.1 ]
                     [/#if]
                     [#break]
 

--- a/providers/shared/references/DeploymentMode/id.ftl
+++ b/providers/shared/references/DeploymentMode/id.ftl
@@ -33,7 +33,7 @@
             "Names" : "Membership",
             "Description" : "How deployment groups are included in the mode and their ordering",
             "Types" : STRING_TYPE,
-            "Values" : [ "explicit", "priority" ],
+            "Values" : [ "explicit", "priority", "orphaned" ],
             "Mandatory" : true
         },
         {

--- a/providers/shared/views/unitlist/setup.ftl
+++ b/providers/shared/views/unitlist/setup.ftl
@@ -39,7 +39,7 @@
                         deploymentGroup=deploymentGroup
                         deploymentUnit=deploymentUnit
                         currentState="orphaned"
-                        priority=999
+                        priority=0
                         deploymentMode="_orphan"
                     /]
 
@@ -62,7 +62,7 @@
                 [#if ! deployState?has_content ]
                     [@createManagementContractStage
                         deploymentUnit=deploymentUnit
-                        deploymentPriority=999
+                        deploymentPriority=0
                         deploymentGroup=deploymentGroup
                         deploymentProvider=(getLoaderProviders()[0])!SHARED_PROVIDER
                         currentState="orphaned"


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Updates the deployment mode ordering when dealing with orphan deployments to always run these deployments first

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This ensures that the resources aren't available for other components to process them if they are not supposed to be there. Currently orphaned deployments were reordering all units when they were found causing issues in deployments

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

