### PR TITLE
 fix: s3 versioning without lifecycle management

### DIFF
--- a/providers/shared/components/s3/id.ftl
+++ b/providers/shared/components/s3/id.ftl
@@ -37,9 +37,16 @@
                     {
                         "Names" : "Versioning",
                         "Types" : BOOLEAN_TYPE,
+                        "Description" : "Enable versioning - this setting is deprecated - use the same named top level attribute",
                         "Default" : false
                     }
                 ]
+            },
+            [#-- TODO(mfl): default of false should be added when lifecycle Versioning attribute is removed --]
+            {
+                "Names" : "Versioning",
+                "Types" : BOOLEAN_TYPE,
+                "Description" : "Enable versioning"
             },
             {
                 "Names" : "Website",


### PR DESCRIPTION

## Intent of Change
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Because of the location of the configuration controlling versioning of the s3 bucket, if versioning is turned on, the bucket will automatically be lifecycled.

## Motivation and Context
To permit versioning without lifecycle management, support a separate versioning attribute.

The Versioning attribute on Lifecycle will be deprecated to avoid lifecycle management as an unwanted side effect of enabling versioning.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
- https://github.com/hamlet-io/engine-plugin-aws/pull/486

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

