### PR TITLE
feat: LinkRef support for container LB references

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -305,14 +305,16 @@
 
 [#assign lbChildConfiguration = [
         {
+            "Names" : "LinkRef",
+            "Types" : STRING_TYPE
+        },
+        {
             "Names" : "Tier",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
+            "Types" : STRING_TYPE
         },
         {
             "Names" : "Component",
-            "Types" : STRING_TYPE,
-            "Mandatory" : true
+            "Types" : STRING_TYPE
         },
         {
             "Names" : "LinkName",


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add support for the use of LinkRefs to connect containers to the load balancers against which they need to register.


## Motivation and Context
Fixes #1888 

The support for using link lookup to perform this connection was already in place. The changes in this commit simply add LinkRef processing as part of determining the link definition to use in the lookup.


## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

