### PR TITLE
feat(lambda): add layers and jar image support

### DIFF
--- a/providers/shared/extensions/extension.ftl
+++ b/providers/shared/extensions/extension.ftl
@@ -126,7 +126,8 @@
         zipFile=""
         codeHash=""
         versionDependencies=[]
-        createVersionInExtension=false ]
+        createVersionInExtension=false
+        layers=[] ]
 
     [#assign _context += {
         "CreateVersionInExtension" : createVersionInExtension
@@ -156,6 +157,12 @@
     [#if zipFile?has_content ]
         [#assign _context += {
             "ZipFile" : combineEntities((_context.ZipFile)![], asArray(zipFile), APPEND_COMBINE_BEHAVIOUR)
+        }]
+    [/#if]
+
+    [#if layers?has_content ]
+        [#assign _context += {
+            "Layers" : combineEntities((_context.Layers)![], asArray(layers), APPEND_COMBINE_BEHAVIOUR)
         }]
     [/#if]
 [/#macro]

--- a/providers/shared/layers/Account/id.ftl
+++ b/providers/shared/layers/Account/id.ftl
@@ -291,6 +291,22 @@
                             ]
                         },
                         {
+                            "Names" : "lambda_jar",
+                            "Children" : [
+                                {
+                                    "Names" : "Enabled",
+                                    "Type" : BOOLEAN_TYPE,
+                                    "Default" : true
+                                },
+                                {
+                                    "Names" : "Storage",
+                                    "Description" : "How the images are stored",
+                                    "Values" : [ "objectstore" ],
+                                    "Default" : "objectstore"
+                                }
+                            ]
+                        },
+                        {
                             "Names" : "pipeline",
                             "Children" : [
                                 {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for providing jar files instead of zip files for java based functions
- Adds support for including layers as part of lambda functions using an extension macro

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The jar file support aligns with the one of the supported models for lambda based functions to avoid having to zip an already compressed ( jar ) package 
Layers allows for the inclusion of OS level installations for lambda runtimes to use 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and on active deployment

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

