### PR TITLE
fix(schema): attributes which are not hashes

### DIFF
--- a/providers/shared/views/schema/setup.ftl
+++ b/providers/shared/views/schema/setup.ftl
@@ -106,6 +106,10 @@
 
     [#list asFlattenedArray(attributes) as attribute]
 
+        [#if ! attribute?is_hash ]
+            [#continue]
+        [/#if]
+
         [#local properties = {}]
 
         [#-- Required Properties --]


### PR DESCRIPTION

## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Skips processing of any attributes which are not hashes

This is based on the expectation that the attributes are normalised before being processed for their schema

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Schema generation failing when inhibitEnabled was found

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

