### PR TITLE
refactor: remove implicit Enabled attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To run the test suite locally install the hamlet cli and use the provider testin
 pip install hamlet
 
 # run the tests
-hamlet -i mock -p shared -p sharedtest -f default deploy run-deployments -o /tmp/results_dir
+hamlet -i mock -p shared -p sharedtest -f default deploy test-deployments -o /tmp/results_dir
 ```
 
 This will run all of the tests and provide you the results. We also run this on all Pull requests made to the repository

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To run the test suite locally install the hamlet cli and use the provider testin
 pip install hamlet
 
 # run the tests
-hamlet -p shared -p sharedtest -f default deploy run-deployments
+hamlet -i mock -p shared -p sharedtest -f default deploy run-deployments -o /tmp/results_dir
 ```
 
 This will run all of the tests and provide you the results. We also run this on all Pull requests made to the repository

--- a/engine/configuration/component.ftl
+++ b/engine/configuration/component.ftl
@@ -190,6 +190,11 @@
 
     [#local attributes = [
         {
+            "Names" : "Enabled",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : true
+        },
+        {
             "Names" : "Export",
             "Types" : BOOLEAN_TYPE,
             "Default" : false

--- a/engine/configuration/layer.ftl
+++ b/engine/configuration/layer.ftl
@@ -13,11 +13,6 @@
 [#-- contains common or reference attribute values for the layer --]
 [#macro addLayer type referenceLookupType properties attributes inputFilterAttributes=[] ]
 
-    [#local attributes = attributes?seq_contains("InhibitEnabled")?then(
-            attributes,
-            combineEntities(asArray(attributes), [ "InhibitEnabled"], APPEND_COMBINE_BEHAVIOUR)
-        )]
-
     [#local configuration =
         {
             "Type" : type,

--- a/engine/configuration/module.ftl
+++ b/engine/configuration/module.ftl
@@ -23,10 +23,7 @@
         configuration={
             "Provider" : provider
         }
-        attributes=properties?seq_contains("InhibitEnabled")?then(
-            properties,
-            combineEntities(asArray(properties), [ "InhibitEnabled"], APPEND_COMBINE_BEHAVIOUR)
-        )
+        attributes=properties
     /]
 [/#macro]
 

--- a/engine/configuration/task.ftl
+++ b/engine/configuration/task.ftl
@@ -16,10 +16,7 @@
         scopeId=TASK_CONFIGURATION_SCOPE
         id=type
         properties=properties
-        attributes=attributes?seq_contains("InhibitEnabled")?then(
-            attributes,
-            combineEntities(asArray(attributes), [ "InhibitEnabled"], APPEND_COMBINE_BEHAVIOUR)
-        )
+        attributes=attributes
     /]
 [/#macro]
 

--- a/engine/extension.ftl
+++ b/engine/extension.ftl
@@ -67,7 +67,6 @@
 [#macro addExtension id description supportedTypes aliases=[] entrances=["deployment"] scopes=[ SETUP_EXTENSION_SCOPE ] provider=SHARED_PROVIDER ]
 
     [#local extensionConfiguration = [
-        "InhibitEnabled",
         {
             "Names" : "Id",
             "Type" : STRING_TYPE

--- a/engine/inputdata/layer.ftl
+++ b/engine/inputdata/layer.ftl
@@ -83,7 +83,6 @@
                         filter,
                         blueprint,
                         [
-                            "InhibitEnabled",
                             {
                                 "Names" : "Id",
                                 "Types" : STRING_TYPE

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -765,7 +765,7 @@ already prefixed attribute.
         [/#if]
     [/#list]
 
-    [#return asFlattenedSettings(getCompositeObject(["InhibitEnabled", { "Names" : "*" }], contexts)) ]
+    [#return asFlattenedSettings(getCompositeObject([{ "Names" : "*" }], contexts)) ]
 [/#function]
 
 [#function internalGetOccurrenceSetting occurrence names emptyIfNotProvided=false]

--- a/providers/shared/attributesets/containertask/id.ftl
+++ b/providers/shared/attributesets/containertask/id.ftl
@@ -82,7 +82,10 @@
             "Names" : "Ports",
             "SubObjects" : true,
             "Children" : [
-                "Container",
+                {
+                    "Names": "Container",
+                    "Types": STRING_TYPE
+                },
                 {
                     "Names" : "DynamicHostPort",
                     "Types" : BOOLEAN_TYPE,

--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -111,6 +111,11 @@ object.
                 "Names" : "CloudFront",
                 "Children" : [
                     {
+                        "Names" : "Enabled",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
                         "Names" : "AssumeSNI",
                         "Types" : BOOLEAN_TYPE,
                         "Default" : true
@@ -203,6 +208,11 @@ object.
                 "Description" : "Deprecated - Please switch to the publishers configuration",
                 "Children" : [
                     {
+                        "Names" : "Enabled",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
                         "Names" : "DnsNamePrefix",
                         "Types" : STRING_TYPE,
                         "Default" : "docs"
@@ -243,6 +253,11 @@ object.
             {
                 "Names" : "Mapping",
                 "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
                     {
                         "Names" : "IncludeStage",
                         "Types" : BOOLEAN_TYPE,

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -223,6 +223,11 @@
             "Names" : "Stepped",
             "Children" : [
                 {
+                    "Names" : "Enabled",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
                     "Names" : "MetricAggregation",
                     "Description" : "The method used to agregate the cloudwatch metric",
                     "Types" : STRING_TYPE,
@@ -271,6 +276,11 @@
             "Names" : "Tracked",
             "Children" : [
                 {
+                    "Names" : "Enabled",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
                     "Names" : "TargetValue",
                     "Types" : NUMBER_TYPE
                 },
@@ -289,6 +299,11 @@
         {
             "Names" : "Scheduled",
             "Children" : [
+                {
+                    "Names" : "Enabled",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
                 {
                     "Names" : "ProcessorProfile",
                     "Types" : STRING_TYPE,
@@ -369,6 +384,11 @@
 ]
 
 [#assign wafChildConfiguration = [
+        {
+            "Names" : "Enabled",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : true
+        },
         {
             "Names" : "Version",
             "Description" : "Version of WAF to use",
@@ -513,6 +533,7 @@
     }
 ]]
 
+[#-- SHOULDN'T have Enabled attribute --]
 [#assign domainChildConfiguration = [
     {
         "Names" : "Name",
@@ -538,8 +559,7 @@
         "Names" : "Role",
         "Types" : STRING_TYPE,
         "Values" : [DOMAIN_ROLE_PRIMARY, DOMAIN_ROLE_SECONDARY]
-    },
-    "InhibitEnabled"
+    }
 ]]
 
 [#assign domainNameChildConfiguration = [
@@ -616,6 +636,13 @@
 ]]
 
 [#assign certificateChildConfiguration =
+    [
+        {
+            "Names" : "Enabled",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : true
+        }
+    ] +
     domainNameChildConfiguration +
     hostNameChildConfiguration +
     [
@@ -1337,6 +1364,11 @@
         "SubObjects" : true,
         "Children" : [
             {
+                "Names" : "Enabled",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
                 "Names" : "Expression",
                 "Types" : STRING_TYPE,
                 "Default" : "rate(1 hours)"
@@ -1416,6 +1448,11 @@
 
 [#assign tracingChildConfiguration =
     [
+        {
+            "Names" : "Enabled",
+            "Type" : BOOLEAN_TYPE,
+            "Default" : true
+        },
         {
             "Names" : "Mode",
             "Types" : STRING_TYPE,

--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -105,6 +105,11 @@
                 "SubObjects" : true,
                 "Children" : [
                     {
+                        "Names" : "Enabled",
+                        "Type" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
                         "Names" : "Expression",
                         "Types" : STRING_TYPE,
                         "Default" : "rate(6 minutes)"
@@ -173,6 +178,11 @@
             {
                 "Names" : "FixedCodeVersion",
                 "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
                     {
                         "Names" : "NewVersionOnDeploy",
                         "Types" : BOOLEAN_TYPE,

--- a/providers/shared/components/lb/id.ftl
+++ b/providers/shared/components/lb/id.ftl
@@ -241,6 +241,11 @@
                 "Description" : "When the rule matches send a redirect response to the client",
                 "Children" : [
                     {
+                        "Names" : "Enabled",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
                         "Names" : "Protocol",
                         "Types" : STRING_TYPE,
                         "Values" : ["HTTPS", "#\{protocol}" ],
@@ -277,6 +282,11 @@
                 "Names" : "Fixed",
                 "Description" : "When the rule is matched send a fixed http response to the client",
                 "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
                     {
                         "Names" : "Message",
                         "Types" : STRING_TYPE,

--- a/providers/shared/components/s3/id.ftl
+++ b/providers/shared/components/s3/id.ftl
@@ -25,6 +25,11 @@
                 "Names" : "Lifecycle",
                 "Children" : [
                     {
+                        "Names" : "Enabled",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
                         "Names" : "Expiration",
                         "Types" : [STRING_TYPE, NUMBER_TYPE],
                         "Description" : "Provide either a date or a number of days"
@@ -51,6 +56,11 @@
             {
                 "Names" : "Website",
                 "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
                     {
                         "Names": "Index",
                         "Types" : STRING_TYPE,

--- a/providers/shared/components/sqs/id.ftl
+++ b/providers/shared/components/sqs/id.ftl
@@ -36,6 +36,11 @@
                 "Description" : "Enables a dead letter queue for messages which reach a specified retry count",
                 "Children" : [
                     {
+                        "Names" : "Enabled",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
                         "Names" : "MaxReceives",
                         "Description" : "The maximum number of times a single message can be put back on the queue",
                         "Types" : NUMBER_TYPE,

--- a/providers/shared/layers/Segment/id.ftl
+++ b/providers/shared/layers/Segment/id.ftl
@@ -155,6 +155,11 @@
                     "Names" : "CIDR",
                     "Children" : [
                         {
+                            "Names" : "Enabled",
+                            "Types" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
                             "Names" : "Address",
                             "Types" : STRING_TYPE,
                             "Default" : ""

--- a/providers/shared/references/Port/id.ftl
+++ b/providers/shared/references/Port/id.ftl
@@ -85,6 +85,11 @@
             "Names" : "PortRange",
             "Children" : [
                 {
+                    "Names" : "Enabled",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
                     "Names" : "From",
                     "Types" : NUMBER_TYPE
                 },

--- a/providers/shared/references/TestCase/id.ftl
+++ b/providers/shared/references/TestCase/id.ftl
@@ -110,6 +110,11 @@
                     "Description" : "Run cfn-lint on the file - https://github.com/aws-cloudformation/cfn-lint",
                     "Children" : [
                         {
+                            "Names": "Enabled",
+                            "Type": BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
                             "Names" : "IgnoreChecks",
                             "Description" : "A list of checks to ignore in cfn-lint",
                             "Type" : ARRAY_OF_STRING_TYPE,
@@ -121,6 +126,11 @@
                     "Names" : "checkov",
                     "Description" : "Run checkov on the file - https://github.com/bridgecrewio/checkov",
                     "Children" : [
+                        {
+                            "Names": "Enabled",
+                            "Type": BOOLEAN_TYPE,
+                            "Default" : true
+                        },
                         {
                             "Names" : "Framework",
                             "Description" : "The framework of the file to run testing against",


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
- remove the behaviour where an `Enabled` attribute was added by default to composite objects
- remove use of the `InihibitEnabled` attribute to suppress the default behaviour
- add explicit `Enabled` attributes where they are currently expected by code
- extend the `isPresent` macro to throw an error if it doesn't find an `Enabled` attribute
- restrict the specification of attributes for composite object to use the full object based notation, removing the support for string based attributes.

## Motivation and Context
Part of #1894

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
- https://github.com/hamlet-io/engine-plugin-aws/pull/491

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

