### PR TITLE
feat: Container build settings

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -1175,6 +1175,7 @@
         environment
         segment
         occurrence
+        containerId
         sourceImage
         imageFormat
         registryHost
@@ -1182,7 +1183,7 @@
         region=""
     ]
 
-    [#local buildUnit = getOccurrenceBuildUnit(occurrence) ]
+    [#local settingNamespace = formatName(occurrence.Core.RawName, containerId)]
 
     [#return
         [
@@ -1193,7 +1194,7 @@
             r'   "' + product + r'" ' +
             r'   "' + environment + r'" ' +
             r'   "' + segment + r'" ' +
-            r'   "' + buildUnit + r'" ' +
+            r'   "' + settingNamespace + r'" ' +
             r'   "' + registryHost + r'" ' +
             r'   "' + registryProvider + r'" ' +
             r'   "' + region + r'" || exit $? ',

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -690,6 +690,16 @@ already prefixed attribute.
     [#return namespaces]
 [/#function]
 
+[#function getAdditionalBuildSettings namespaces ]
+    [#return internalCreateOccurrenceBuildSettings(
+        {
+            "Configuration" : {
+                "SettingNamespaces" : asFlattenedArray(namespaces)
+            }
+        }
+    )]
+[/#function]
+
 [#--------------------------------------------------------
 -- Internal support functions for occurrence processing --
 ----------------------------------------------------------]
@@ -821,11 +831,8 @@ already prefixed attribute.
             alternatives) ]
 [/#function]
 
-[#function internalCreateOccurrenceBuildSettings occurrence namespaces={} ]
-    [#if ! namespaces?has_content ]
-        [#local namespaces = occurrence.Configuration.SettingNamespaces ]
-    [/#if]
-
+[#function internalCreateOccurrenceBuildSettings occurrence ]
+    [#local namespaces = occurrence.Configuration.SettingNamespaces ]
     [#local deploymentUnit = getOccurrenceDeploymentUnit(occurrence) ]
 
     [#local occurrenceBuild =

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -821,8 +821,11 @@ already prefixed attribute.
             alternatives) ]
 [/#function]
 
-[#function internalCreateOccurrenceBuildSettings occurrence]
-    [#local namespaces = occurrence.Configuration.SettingNamespaces ]
+[#function internalCreateOccurrenceBuildSettings occurrence namespaces={} ]
+    [#if ! namespaces?has_content ]
+        [#local namespaces = occurrence.Configuration.SettingNamespaces ]
+    [/#if]
+
     [#local deploymentUnit = getOccurrenceDeploymentUnit(occurrence) ]
 
     [#local occurrenceBuild =

--- a/providers/shared/extensions/dind/extension.ftl
+++ b/providers/shared/extensions/dind/extension.ftl
@@ -35,10 +35,12 @@
     [#local dockerLibSize = defaultEnv["DOCKER_LIB_VOLUME_SIZE"]!"20"         ]
     [#local dindTLSVerify = defaultEnv["DIND_DOCKER_TLS_VERIFY"]!"true"      ]
 
-    [@Attributes
-        image="docker"
-        version="dind"
-    /]
+    [#if ((_context.Container.Image.Source)!"") != "containerregistry" ]
+        [@Attributes
+            image="docker"
+            version="dind"
+        /]
+    [/#if]
 
     [#if dindTLSVerify?boolean ]
         [@Settings
@@ -52,6 +54,8 @@
             containerPath="/docker/certs/client"
         /]
     [/#if]
+
+    [@Settings ["BUILD_REFERENCE"] /]
 
     [@Volume
         name="dockerStage"

--- a/providers/shared/extensions/hamlet/extension.ftl
+++ b/providers/shared/extensions/hamlet/extension.ftl
@@ -33,7 +33,9 @@
 
     [#local dockerStageDir = settings["DOCKER_STAGE_DIR"]!"/tmp/docker-build" ]
 
-    [@Attributes image=jenkinsAgentImage /]
+    [#if ((_context.Container.Image.Source)!"") != "containerregistry" ]
+        [@Attributes image=jenkinsAgentImage /]
+    [/#if]
 
     [@DefaultLinkVariables          enabled=false /]
     [@DefaultCoreVariables          enabled=false /]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds a setting namespace for containers
- Adds a helper function to get build settings for additional setting namespaces
- - in the predefined extensions for containers don't override the container image if the source is the container registry

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The main motivation for this change is to allow for the use of the solution level image configuration when multiple containers are used in tasks/services. This makes it easy to show where the image is coming from and to support scheduled deployments to pull in the latest version of the images. 
Storing the pull details in a settings name space allows for this information to be queried and displayed in container deployments 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

