### PR TITLE
feat: operational runbooks

### DIFF
--- a/engine/configuration/component.ftl
+++ b/engine/configuration/component.ftl
@@ -195,6 +195,18 @@
             "Default" : true
         },
         {
+            "Names" : "Description",
+            "Types" : STRING_TYPE,
+            "Description" : "A description of the component",
+            "Default" : ""
+        },
+        {
+            "Names" : "Title",
+            "Types" : STRING_TYPE,
+            "Description" : "A longer form tilte of the component",
+            "Default" : ""
+        },
+        {
             "Names" : "Export",
             "Types" : BOOLEAN_TYPE,
             "Default" : false

--- a/engine/configuration/component.ftl
+++ b/engine/configuration/component.ftl
@@ -203,7 +203,7 @@
         {
             "Names" : "Title",
             "Types" : STRING_TYPE,
-            "Description" : "A longer form tilte of the component",
+            "Description" : "A longer form title of the component",
             "Default" : ""
         },
         {

--- a/engine/configuration/task.ftl
+++ b/engine/configuration/task.ftl
@@ -20,23 +20,29 @@
     /]
 [/#macro]
 
-[#function getTask type parameters ]
+[#function getTaskConfig type ]
     [#local taskConfig = getConfigurationSet(TASK_CONFIGURATION_SCOPE, type)]
 
-    [#if taskConfig?has_content ]
-        [#return
-            {
-                "Type" : type,
-                "Parameters" : getCompositeObject(
-                                    taskConfig.Attributes,
-                                    parameters
-                                )
-            }
-        ]
-    [#else]
+    [#if ! taskConfig?has_content ]
         [@fatal
-            message="Attempt to add data for unknown task type"
+            message="Task could not be found"
             detail=type
         /]
     [/#if]
+
+    [#return taskConfig]
+[/#function]
+
+[#function getTask type parameters ]
+    [#local taskConfig = getTaskConfig(type)]
+
+    [#return
+        {
+            "Type" : type,
+            "Parameters" : getCompositeObject(
+                                (taskConfig.Attributes)![],
+                                parameters
+                            )
+        }
+    ]
 [/#function]

--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -689,6 +689,8 @@
             [#break]
 
         [#case "schema" ]
+        [#case "runbook"]
+        [#case "runbookinfo"]
             [#local filename_parts =
                 mergeObjects(
                     filename_parts,

--- a/providers/shared/attributesets/attributeset.ftl
+++ b/providers/shared/attributesets/attributeset.ftl
@@ -18,6 +18,8 @@
 
 [#assign OSPATCHING_ATTRIBUTESET_TYPE = "ospatching"]
 
+[#assign RUNBOOK_VALUE_ATTRIBUTESET_TYPE = "runbook_value"]
+
 [#assign SECRETSTRING_ATTRIBUTESET_TYPE = "secretstring" ]
 
 [#assign PLUGIN_ATTRIBUTESET_TYPE = "plugin"]

--- a/providers/shared/attributesets/runbook_value/id.ftl
+++ b/providers/shared/attributesets/runbook_value/id.ftl
@@ -1,0 +1,78 @@
+[#ftl]
+
+[@addAttributeSet
+    type=RUNBOOK_VALUE_ATTRIBUTESET_TYPE
+    properties=[
+        {
+                "Type"  : "Description",
+                "Value" : "The source of a value to use as part of runbooks"
+        }]
+    attributes=[
+        {
+            "Names" : "Source",
+            "Description" : "Where to get the value from",
+            "Values" : [ "Setting", "Attribute", "Input", "Output", "Fixed" ],
+            "Mandatory" : true
+        },
+        {
+            "Names" : "source:Setting",
+            "Children" : [
+                {
+                    "Names" : "Name",
+                    "Description" : "The name of the step setting",
+                    "Types" : STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : "source:Attribute",
+            "Children" : [
+                {
+                    "Names" : "LinkId",
+                    "Description" : "The id of a link in Links that the attribute will come from",
+                    "Types" : STRING_TYPE
+                },
+                {
+                    "Names" : "Name",
+                    "Description" : "The name of the attribute from the links attributes",
+                    "Types" : STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : "source:Input",
+            "Children" : [
+                {
+                    "Names" : "Id",
+                    "Description" : "The Id of an input provided to the parent runbook",
+                    "Types" : STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : "source:Output",
+            "Children" : [
+                {
+                    "Names" : "StepId",
+                    "Description" : "The Id of the step to use for the output",
+                    "Types" : STRING_TYPE
+                },
+                {
+                    "Names" : "Name",
+                    "Description" : "The name of an output provided by the step",
+                    "Types" : STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : "source:Fixed",
+            "Children" : [
+                {
+                    "Names" : "Value",
+                    "Description" : "A fixed value to use",
+                    "Types" : [ STRING_TYPE, NUMBER_TYPE, BOOLEAN_TYPE, ARRAY_OF_STRING_TYPE, ARRAY_OF_NUMBER_TYPE]
+                }
+            ]
+        }
+    ]
+/]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -129,6 +129,9 @@
 
 [#assign QUEUEHOST_COMPONENT_TYPE = "queuehost" ]
 
+[#assign RUNBOOK_COMPONENT_TYPE = "runbook" ]
+[#assign RUNBOOK_STEP_COMPONENT_TYPE = "runbookstep"]
+
 [#assign S3_COMPONENT_TYPE = "s3" ]
 
 [#assign SECRETSTORE_COMPONENT_TYPE = "secretstore" ]

--- a/providers/shared/components/runbook/id.ftl
+++ b/providers/shared/components/runbook/id.ftl
@@ -1,0 +1,139 @@
+[#ftl]
+
+[@addComponent
+    type=RUNBOOK_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A series of tasks to perform using other deployed components"
+            },
+            {
+                "Type" : "Note",
+                "Value" : "Runbooks do not have deployments and are instead generated through the runbook entrance"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "Engine",
+                "Description" : "The implemntation that will run the runbook",
+                "Values" : [ "hamlet" ],
+                "Default" : "hamlet"
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : [
+                    {
+                        "Names" : "Placement",
+                        "Default" : "shared"
+                    }
+                ]
+            },
+            {
+                "Names" : "Inputs",
+                "Description" : "Inputs can be provided by users to start the runbook with different options",
+                "SubObjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Default",
+                        "Description" : "The default value of the input",
+                        "Types" : ANY_TYPE
+                    },
+                    {
+                        "Names" : "Mandatory",
+                        "Description"  : "If the input must be provided",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "Types",
+                        "Description" : "The supported types of the input",
+                        "Values" : [
+                            ARRAY_TYPE,
+                            OBJECT_TYPE,
+                            STRING_TYPE,
+                            BOOLEAN_TYPE
+                        ],
+                        "Types" : ARRAY_OF_STRING_TYPE
+                    }
+                ]
+            }
+        ]
+/]
+
+[@addChildComponent
+    type=RUNBOOK_STEP_COMPONENT_TYPE
+    parent=RUNBOOK_COMPONENT_TYPE
+    childAttribute="Steps"
+    linkAttributes="RunBookStep"
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "A step to perform as part of a runbook"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "Priority",
+            "Description" : "The priority order for the step to run (lowest first)",
+            "Types" : NUMBER_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Conditions",
+            "Description" : "All conditions for a step must pass to run the step",
+            "SubObjects" : true,
+            "Children" : [
+                {
+                    "Names" : "Value",
+                    "AttributeSet" : RUNBOOK_VALUE_ATTRIBUTESET_TYPE
+                },
+                {
+                    "Names" : "Match",
+                    "Description" : "How to match the value of the setting",
+                    "Types" : STRING_TYPE,
+                    "Values" : [ "Contains", "Equals", "StartsWith", "EndsWith"],
+                    "Default" : "Equals"
+                },
+                {
+                    "Names" : "Test",
+                    "Description" : "The test to match the value against",
+                    "Mandatory" : true,
+                    "Types" : [
+                        STRING_TYPE,
+                        BOOLEAN_TYPE
+                    ]
+                }
+            ]
+        },
+        {
+            "Names" : "Extensions",
+            "Description" : "Extensions to invoke to provide task Parameters",
+            "Types" : ARRAY_OF_STRING_TYPE,
+            "Default" : []
+        },
+        {
+            "Names" : "Task",
+            "Children" : [
+                {
+                    "Names" : "Type",
+                    "Description" : "The type of the task to run in the step",
+                    "Types" : STRING_TYPE,
+                    "Mandatory" : true
+                },
+                {
+                    "Names" : "Parameters",
+                    "Description" : "The parameters required to run the task type",
+                    "SubObjects" : true,
+                    "AttributeSet" : RUNBOOK_VALUE_ATTRIBUTESET_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : "Links",
+            "SubObjects" : true,
+            "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+        }
+    ]
+/]

--- a/providers/shared/components/runbook/id.ftl
+++ b/providers/shared/components/runbook/id.ftl
@@ -22,15 +22,6 @@
                 "Default" : "hamlet"
             },
             {
-                "Names" : "Profiles",
-                "Children" : [
-                    {
-                        "Names" : "Placement",
-                        "Default" : "shared"
-                    }
-                ]
-            },
-            {
                 "Names" : "Inputs",
                 "Description" : "Inputs can be provided by users to start the runbook with different options",
                 "SubObjects" : true,

--- a/providers/shared/components/runbook/setup.ftl
+++ b/providers/shared/components/runbook/setup.ftl
@@ -1,0 +1,245 @@
+[#ftl]
+[#macro shared_runbook_default_runbook_generationcontract occurrence ]
+    [@addDefaultGenerationContract
+        subsets=[ "contract" ]
+    /]
+[/#macro]
+
+[#macro shared_runbook_default_runbook occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
+
+    [#local core = occurrence.Core ]
+    [#local solution = occurrence.Configuration.Solution ]
+
+    [#if getCommandLineOptions()["RunBook"] != core.TypedRawName ]
+        [#return]
+    [/#if]
+
+    [#local runBookInputAttributes = []]
+    [#list solution.Inputs as name, input ]
+        [#local runBookInputAttributes = combineEntities(
+            runBookInputAttributes,
+            normaliseCompositeConfiguration(
+                [ mergeObjects({ "Names" : name }, input) ]
+            ),
+            APPEND_COMBINE_BEHAVIOUR
+        )]
+    [/#list]
+
+    [#local runBookInputs = getCompositeObject(runBookInputAttributes, getCommandLineOptions()["RunBookInputs"] )]
+
+    [@contractProperties
+        properties=runBookInputs
+    /]
+
+    [#list (occurrence.Occurrences)![] as subOccurrence ]
+
+        [#local core = subOccurrence.Core ]
+        [#local solution = subOccurrence.Configuration.Solution ]
+
+        [#local stageId = core.SubComponent.RawName]
+
+        [#local contextLinks = getLinkTargets(subOccurrence) ]
+        [#local _context =
+            {
+                "DefaultEnvironment" : defaultEnvironment(subOccurrence, contextLinks),
+                "Environment" : {},
+                "Links" : contextLinks,
+                "TaskParameters" : {}
+            }
+        ]
+        [#local _context = invokeExtensions(subOccurrence, _context, {}, [], false, "runbook")]
+
+        [@contractStage
+            id=stageId
+            executionMode=CONTRACT_EXECUTION_MODE_SERIAL
+            priority=solution.Priority
+            mandatory=true
+        /]
+
+        [#list solution.Conditions as id, condition]
+            [@contractStep
+                id=formatName("condition", core.SubComponent.RawId)
+                stageId=stageId
+                taskType=CONDITIONAL_STAGE_SKIP_TASK_TYPE
+                parameters={
+                    "Test" : condition.Test,
+                    "Condition" : condition.Match,
+                    "Value" : getRunBookValue(condition.Value, runBookInputs, subOccurrence, occurrence)
+                }
+                priority=10
+                mandatory=true
+                status="skip_stage_if_failure"
+            /]
+        [/#list]
+
+        [#-- Add Task run Step --]
+        [#local taskParameters = {}]
+        [#list solution.Task.Parameters as id, parameter ]
+            [#local taskParameters = mergeObjects(
+                taskParameters,
+                { id : getRunBookValue(parameter, runBookInputs, subOccurrence, occurrence)}
+            )]
+        [/#list]
+
+        [#local taskParameters = mergeObjects(taskParameters, _context.TaskParameters )]
+
+        [@contractStep
+            id=core.SubComponent.RawId
+            stageId=stageId
+            taskType=solution.Task.Type
+            parameters=taskParameters
+            priority=100
+            mandatory=true
+            status="available"
+        /]
+    [/#list]
+[/#macro]
+
+[#-- Resolves the different inputs to contract values that engines can process --]
+[#function getRunBookValue value inputs occurrence parentOccurrence ]
+    [#local result = ""]
+    [#switch value.Source ]
+        [#case "Setting" ]
+            [#local settingName = (value["source:Setting"].Name)!"" ]
+            [#local collectedSettings = {}]
+
+            [#list (occurrence.Configuration.Settings)?values?filter(x -> x?has_content) as settingGroup ]
+                [#list settingGroup as key, value]
+                    [#local collectedSettings = mergeObjects(collectedSettings, { key : value } )]
+                [/#list]
+            [/#list]
+            [#local result = (collectedSettings[settingName].Value)!"" ]
+            [#break]
+
+
+        [#case "Attribute"]
+            [#local linkId = (value["source:Attribute"].LinkId)!"" ]
+            [#local attributeName = (value["source:Attribute"].Name)!"" ]
+
+            [#local link = (occurrence.Configuration.Solution.Links[linkId])!{}]
+            [#local linkTarget = getLinkTarget(occurrence, link)]
+
+            [#if ! linkTarget?has_content ]
+                [@fatal
+                    message="Link could not be found for attribute"
+                    context={
+                        "Step"  : occurrence.Core.Component.RawId,
+                        "LinkId" : linkId,
+                        "Links" : occurrence.Configuration.Solution.Links
+                    }
+                /]
+            [/#if]
+
+            [#local result = (linkTarget.State.Attributes[attributeName?upper_case])!"" ]
+            [#break]
+
+        [#case "Input"]
+            [#local inputId = (value["source:Input"].Id)!"" ]
+
+            [#if ! inputs?keys?seq_contains(inputId)?has_content ]
+                [@fatal
+                    message="Input Id could not be found"
+                    context={
+                        "Step" : occurrence.Core.Component.RawId,
+                        "Input" : inputId
+                    }
+                /]
+            [/#if]
+            [#local result = ":property:${inputId}" ]
+            [#break]
+
+        [#case "Output"]
+            [#local stepId = (value["source:Output"].StepId)!""]
+            [#local outputName = (value["source:Output"].Name)!"" ]
+
+            [#if ! ((parentOccurrence.Occurrences)![])?map( x -> x.Core.SubComponent.RawId)?seq_contains(stepId) ]
+                [@fatal
+                    message="Step could not be found for output condition"
+                    context={
+                        "Step" : occurrence.Core.Component.RawId,
+                        "Output" :{
+                            "StepId" : stepId,
+                            "Output" : outputName
+                        }
+                    }
+                /]
+            [/#if]
+
+            [#local result = ":output:${stepId}:${outputName}" ]
+            [#break]
+
+        [#case "Fixed"]
+            [#local result = (value["source:Fixed"].Value)!"" ]
+            [#break]
+    [/#switch]
+    [#return result]
+[/#function]
+
+[#-- Provides information on the format of the runbook and what it does --]
+[#macro shared_runbook_default_runbookinfo_generationcontract occurrence ]
+    [@addDefaultGenerationContract
+        subsets=[ "config" ]
+    /]
+[/#macro]
+
+
+[#macro shared_runbook_default_runbookinfo occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
+
+    [#local core = occurrence.Core ]
+    [#local solution = occurrence.Configuration.Solution ]
+
+    [#local runbookDetails = {
+        "Name" : core.TypedRawName,
+        "Description" : solution.Description,
+        "Engine" : solution.Engine,
+        "Inputs" : solution.Inputs
+    }]
+
+    [#local runBookSteps = []]
+
+    [#list (occurrence.Occurrences)![] as subOccurrence ]
+
+        [#if subOccurrence.Core.Type != RUNBOOK_STEP_COMPONENT_TYPE ]
+            [#continue]
+        [/#if]
+
+        [#local core = subOccurrence.Core ]
+        [#local solution = subOccurrence.Configuration.Solution ]
+
+        [#local taskConfig = getTaskConfig(solution.Task.Type)]
+
+        [#local runBookSteps = combineEntities(
+            runBookSteps,
+            [
+                {
+                    "Name" : core.SubComponent.RawName,
+                    "Priority" : solution.Priority,
+                    "Conditions" : solution.Conditions,
+                    "Parameters" : solution.Task.Parameters,
+                    "Links" : solution.Links,
+                    "Task" : {
+                        "Type" : solution.Task.Type,
+                        "Details" : taskConfig.Properties,
+                        "Attributes" : taskConfig.Attributes
+                    }
+                }
+            ],
+            APPEND_COMBINE_BEHAVIOUR
+        )]
+    [/#list]
+
+    [#local runbookDetails = mergeObjects(runbookDetails, { "Steps" : runBookSteps?sort_by("Priority")})]
+
+    [@addToDefaultJsonOutput
+        content={
+            "RunBooks" :
+                combineEntities(
+                    (getOutputContent(JSON_DEFAULT_OUTPUT_TYPE)["RunBooks"])![]
+                    runbookDetails,
+                    APPEND_COMBINE_BEHAVIOUR
+                )
+        }
+    /]
+[/#macro]

--- a/providers/shared/components/runbook/state.ftl
+++ b/providers/shared/components/runbook/state.ftl
@@ -1,0 +1,33 @@
+[#ftl]
+
+[#macro shared_runbook_default_state occurrence parent={} ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#assign componentState =
+        {
+            "Resources" : {},
+            "Attributes" : {},
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#macro]
+
+[#macro shared_runbookstep_default_state occurrence parent={} ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#assign componentState =
+        {
+            "Resources" : {},
+            "Attributes" : {},
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#macro]

--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -414,7 +414,7 @@
 
 [#function formatContractStep id taskType parameters priority=100 mandatory=true status="available" ]
 
-    [#local supportedStatuses = [ "available", "completed", "failed" ]]
+    [#local supportedStatuses = [ "available", "completed", "failed", "skip_stage_if_failure" ]]
     [#if ! (supportedStatuses?seq_contains(status)) ]
         [@fatal
             message="Invalid contract step status"

--- a/providers/shared/deploymentframeworks/default/output.ftl
+++ b/providers/shared/deploymentframeworks/default/output.ftl
@@ -669,6 +669,14 @@
 [#-- Add Output Step mappings for each output --]
 [@addGenerationContractStepOutputMapping
     provider=SHARED_PROVIDER
+    subset="contract"
+    outputType=CONTRACT_DEFAULT_OUTPUT_TYPE
+    outputFormat=""
+    outputSuffix="contract.json"
+/]
+
+[@addGenerationContractStepOutputMapping
+    provider=SHARED_PROVIDER
     subset="generationcontract"
     outputType=JSON_DEFAULT_OUTPUT_TYPE
     outputFormat=""

--- a/providers/shared/entrances/entrance.ftl
+++ b/providers/shared/entrances/entrance.ftl
@@ -8,6 +8,8 @@
 [#assign DEPLOYMENTTEST_ENTRANCE_TYPE    = "deploymenttest" ]
 [#assign INFO_ENTRANCE_TYPE              = "info" ]
 [#assign LOADER_ENTRANCE_TYPE            = "loader" ]
+[#assign RUNBOOK_ENTRANCE_TYPE           = "runbook" ]
+[#assign RUNBOOKINFO_ENTRANCE_TYPE       = "runbookinfo" ]
 [#assign SCHEMA_ENTRANCE_TYPE            = "schema" ]
 [#assign SCHEMALIST_ENTRANCE_TYPE        = "schemalist" ]
 [#assign OCCURRENCES_ENTRANCE_TYPE       = "occurrences" ]

--- a/providers/shared/entrances/runbook/entrance.ftl
+++ b/providers/shared/entrances/runbook/entrance.ftl
@@ -1,0 +1,46 @@
+[#ftl]
+
+[#-- Entrance logic --]
+[#macro shared_entrance_runbook ]
+    [@generateOutput
+        deploymentFramework=getCLODeploymentFramework()
+        type=getCLODeploymentOutputType()
+        format=getCLODeploymentOutputFormat()
+    /]
+[/#macro]
+
+[#-- Add seeder for command line options --]
+[#macro shared_entrance_runbook_inputsteps ]
+
+    [@registerInputSeeder
+        id=RUNBOOK_ENTRANCE_TYPE
+        description="Entrance"
+    /]
+
+    [@addSeederToConfigPipeline
+        stage=COMMANDLINEOPTIONS_SHARED_INPUT_STAGE
+        seeder=RUNBOOK_ENTRANCE_TYPE
+    /]
+
+[/#macro]
+
+[#-- Set the required flow/view --]
+[#function runbook_configseeder_commandlineoptions filter state]
+
+    [#return
+        addToConfigPipelineClass(
+            state,
+            COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS,
+            {
+                "Deployment" : {
+                    "Framework" : {
+                        "Name" : DEFAULT_DEPLOYMENT_FRAMEWORK
+                    }
+                },
+                "RunBook" : RunBook!"",
+                "RunBookInputs" : ((RunBookInputs)!"{}")?eval_json
+            }
+        )
+    ]
+
+[/#function]

--- a/providers/shared/entrances/runbook/id.ftl
+++ b/providers/shared/entrances/runbook/id.ftl
@@ -1,0 +1,29 @@
+[#ftl]
+
+[@addEntrance
+    type=RUNBOOK_ENTRANCE_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "Creates a runbook contract to perform tasks using components"
+            }
+        ]
+    commandlineoptions=[
+        {
+            "Names" : "RunBook",
+            "Description" : "The TypedRawName of the run book to create a contract from",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "RunBookInputs",
+            "Description" : "A JSON escaped string that will be exanded to the inputs of the runbook",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "*",
+            "Types" : ANY_TYPE
+        }
+    ]
+/]

--- a/providers/shared/entrances/runbookinfo/entrance.ftl
+++ b/providers/shared/entrances/runbookinfo/entrance.ftl
@@ -1,0 +1,44 @@
+[#ftl]
+
+[#-- Entrance logic --]
+[#macro shared_entrance_runbookinfo ]
+    [@generateOutput
+        deploymentFramework=getCLODeploymentFramework()
+        type=getCLODeploymentOutputType()
+        format=getCLODeploymentOutputFormat()
+    /]
+[/#macro]
+
+[#-- Add seeder for command line options --]
+[#macro shared_entrance_runbookinfo_inputsteps ]
+
+    [@registerInputSeeder
+        id=RUNBOOKINFO_ENTRANCE_TYPE
+        description="Entrance"
+    /]
+
+    [@addSeederToConfigPipeline
+        stage=COMMANDLINEOPTIONS_SHARED_INPUT_STAGE
+        seeder=RUNBOOKINFO_ENTRANCE_TYPE
+    /]
+
+[/#macro]
+
+[#-- Set the required flow/view --]
+[#function runbookinfo_configseeder_commandlineoptions filter state]
+
+    [#return
+        addToConfigPipelineClass(
+            state,
+            COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS,
+            {
+                "Deployment" : {
+                    "Framework" : {
+                        "Name" : DEFAULT_DEPLOYMENT_FRAMEWORK
+                    }
+                }
+            }
+        )
+    ]
+
+[/#function]

--- a/providers/shared/entrances/runbookinfo/id.ftl
+++ b/providers/shared/entrances/runbookinfo/id.ftl
@@ -1,0 +1,18 @@
+[#ftl]
+
+[@addEntrance
+    type=RUNBOOKINFO_ENTRANCE_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "Provides a list of the available runbooks"
+            }
+        ]
+    commandlineoptions=[
+        {
+            "Names" : "*",
+            "Types" : ANY_TYPE
+        }
+    ]
+/]

--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -1946,6 +1946,13 @@
         "Region": "external",
         "DeploymentFramework": "default"
       }
+    },
+    "shared" : {
+      "default" : {
+        "Provider" : "shared",
+        "Region" : "shared",
+        "DeploymentFramework" : "default"
+      }
     }
   },
   "DeploymentGroups": {

--- a/providers/shared/references/TestCase/id.ftl
+++ b/providers/shared/references/TestCase/id.ftl
@@ -14,6 +14,7 @@
             "Names" : "OutputSuffix",
             "Types" : STRING_TYPE,
             "Values" : [
+                "contract.json",
                 "template.json",
                 "config.json",
                 "cli.json",

--- a/providers/shared/tasks/conditional_stage_skip/id.ftl
+++ b/providers/shared/tasks/conditional_stage_skip/id.ftl
@@ -1,0 +1,32 @@
+[#ftl]
+
+[@addTask
+    type=CONDITIONAL_STAGE_SKIP_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "If a condition doesn't match skip the rest of the steps in the stage"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "Test",
+            "Description" : "The value compared to",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Condition",
+            "Description" : "How to test the value",
+            "Types" : STRING_TYPE,
+            "Values" : [ "Equals", "StartsWith", "EndsWith", "Contains" ],
+            "Mandatory" : true
+        }
+        {
+            "Names" : "Value",
+            "Description" : "The value to test the match on",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        }
+    ]
+/]

--- a/providers/shared/tasks/task.ftl
+++ b/providers/shared/tasks/task.ftl
@@ -7,3 +7,4 @@
 [#assign INSTALL_PLUGIN_TASK_TYPE           = "install_plugin" ]
 [#assign RENAME_FILE_TASK_TYPE              = "rename_file" ]
 [#assign RUN_BASH_SCRIPT_TASK_TYPE          = "run_bash_script" ]
+[#assign CONDITIONAL_STAGE_SKIP_TASK_TYPE   = "conditional_stage_skip" ]

--- a/providers/sharedtest/components/internaltest/state.ftl
+++ b/providers/sharedtest/components/internaltest/state.ftl
@@ -4,7 +4,6 @@
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
-    [#local attributes = {}]
     [#local contextLinks = getLinkTargets(occurrence) ]
     [#local _context =
         {
@@ -15,33 +14,35 @@
             "DefaultCoreVariables" : false,
             "DefaultEnvironmentVariables" : true,
             "DefaultBaselineVariables" : false,
-            "DefaultLinkVariables" : false
-        }
-    ]
-
-    [#-- Add in extension specifics including override of defaults --]
-    [#local _context = invokeExtensions( occurrence, _context, {}, solution.Extensions, true )]
-
-    [#local environment = getFinalEnvironment(occurrence, _context ).Environment ]
-
-    [#list environment as name,value]
-        [#local attributes += { name : value } ]
-    [/#list]
-
-    [#assign componentState =
-        {
+            "DefaultLinkVariables" : false,
+            "Attributes" : {},
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            },
             "Resources" : {
                 "external" : {
                     "Id" : formatResourceId("internaltest", core.Id),
                     "Type" : "internaltest",
                     "Deployed" : true
                 }
-            },
-            "Attributes" : attributes,
-            "Roles" : {
-                "Inbound" : {},
-                "Outbound" : {}
             }
+        }
+    ]
+
+    [#-- Add in extension specifics including override of defaults --]
+    [#local _context = invokeExtensions( occurrence, _context, {}, solution.Extensions, true )]
+    [#local environment = getFinalEnvironment(occurrence, _context ).Environment ]
+
+    [#list environment as name,value]
+        [#local _context = mergeObjects(_context, { "Attributes" : { name : value }} ) ]
+    [/#list]
+
+    [#assign componentState =
+        {
+            "Resources" : _context.Resources,
+            "Attributes" : _context.Attributes,
+            "Roles" : _context.Roles
         }
     ]
 [/#macro]

--- a/providers/sharedtest/inputseeders/sharedtest/id.ftl
+++ b/providers/sharedtest/inputseeders/sharedtest/id.ftl
@@ -50,6 +50,10 @@
                         "internaltest" : {
                             "Provider" : "sharedtest",
                             "Name" : "internaltest"
+                        },
+                        "runbook" : {
+                            "Provider" : "sharedtest",
+                            "Name" : "runbook"
                         }
                     }
                 },

--- a/providers/sharedtest/modules/runbook/module.ftl
+++ b/providers/sharedtest/modules/runbook/module.ftl
@@ -29,9 +29,6 @@
                             "Steps" : {
                                 "step1" : {
                                     "Priority" : 10,
-                                    "Host" : {
-                                        "Engine" : "Local"
-                                    },
                                     "Conditions" : {
                                         "linkTest" : {
                                             "Test" : "linkAttr1",
@@ -46,8 +43,8 @@
                                         }
                                     },
                                     "Task" : {
-                                        "Name" : "rename_file",
-                                        "Properties" : {
+                                        "Type" : "rename_file",
+                                        "Parameters" : {
                                             "currentFileName" : {
                                                 "Source" : "Input",
                                                 "source:Input" : {
@@ -72,8 +69,8 @@
                                 "step2" : {
                                     "Priority" : 20,
                                     "Task" : {
-                                        "Name" : "run_ssh_shell_command",
-                                        "Properties" : {
+                                        "Type" : "run_ssh_shell_command",
+                                        "Parameters" : {
                                             "Username" : {
                                                 "Source" : "Fixed",
                                                 "source:Fixed" : {
@@ -106,7 +103,7 @@
                                 }
                             },
                             "Profiles" : {
-                                "Placement" : "external"
+                                "Placement" : "shared"
                             }
                         }
                     }

--- a/providers/sharedtest/modules/runbook/module.ftl
+++ b/providers/sharedtest/modules/runbook/module.ftl
@@ -1,0 +1,117 @@
+[#ftl]
+
+[@addModule
+    name="runbook"
+    description="Hamlet engine runbook testing"
+    provider=SHAREDTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro sharedtest_module_runbook ]
+
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "app" : {
+                    "Components" : {
+                        "runbookbase" : {
+                            "Type" : "runbook",
+                            "Engine" : "hamlet",
+                            "Inputs" : {
+                                "input1" : {
+                                    "Types" : [ "string" ],
+                                    "Default" : "value1"
+                                }
+                            },
+                            "Profiles" : {
+                                "Placement" : "shared"
+                            },
+                            "Steps" : {
+                                "step1" : {
+                                    "Priority" : 10,
+                                    "Host" : {
+                                        "Engine" : "Local"
+                                    },
+                                    "Conditions" : {
+                                        "linkTest" : {
+                                            "Test" : "linkAttr1",
+                                            "Match" : "Equals",
+                                            "Value" : {
+                                                "Source" : "Attribute",
+                                                "source:Attribute" : {
+                                                    "LinkId" : "linktest",
+                                                    "Name" : "attr1"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "Task" : {
+                                        "Name" : "rename_file",
+                                        "Properties" : {
+                                            "currentFileName" : {
+                                                "Source" : "Input",
+                                                "source:Input" : {
+                                                    "Id" : "input1"
+                                                }
+                                            },
+                                            "newFileName" : {
+                                                "Source" : "Setting",
+                                                "source:Setting" : {
+                                                    "Name" : "ENVIRONMENT"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "linktest" : {
+                                            "Tier" : "app",
+                                            "Component" : "runbookbase_linktest"
+                                        }
+                                    }
+                                },
+                                "step2" : {
+                                    "Priority" : 20,
+                                    "Task" : {
+                                        "Name" : "run_ssh_shell_command",
+                                        "Properties" : {
+                                            "Username" : {
+                                                "Source" : "Fixed",
+                                                "source:Fixed" : {
+                                                    "Value" : "admin"
+                                                }
+                                            },
+                                            "Host" : {
+                                                "Source" : "Fixed",
+                                                "source:Fixed" : {
+                                                    "Value" : "host.local"
+                                                }
+                                            },
+                                            "Command" : {
+                                                "Source" : "Fixed",
+                                                "source:Fixed" : {
+                                                    "Value" : "/bin/bash"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "runbookbase_linktest" : {
+                            "Type" : "externalservice",
+                            "Properties" : {
+                                "attr1" : {
+                                    "Key" : "attr1",
+                                    "Value" : "linkAttr1"
+                                }
+                            },
+                            "Profiles" : {
+                                "Placement" : "external"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for the runbook component
- Adds entrances to support the generation of a runbook contract for the hamlet engine to execute 
- Adds a conditional task which can be used in runbooks to skip a runbook step if the conditions fail 

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The runbook component generates a contract with a collection of tasks to complete. Since the runbook is generated inside hamlet it has access to the full state and details available within the CMDB. This includes settings, link attributes and anything available through the extensions methods 

Using this it is possible to make runbooks which perform operational activities on your hamlet deployments

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and with test module

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

