### PR TITLE
feat: bastion ssh runbook

### DIFF
--- a/providers/shared/components/baseline/id.ftl
+++ b/providers/shared/components/baseline/id.ftl
@@ -275,6 +275,17 @@
                 "Description" : "Extensions to invoke as part of component processing",
                 "Types" : ARRAY_OF_STRING_TYPE,
                 "Default" : []
+            },
+            {
+                "Names" : "engine:ssh",
+                "Children" : [
+                    {
+                        "Names" : "EncryptionScheme",
+                        "Description" : "When providing the key as a string the scheme to include",
+                        "Types" : STRING_TYPE,
+                        "Default" : ""
+                    }
+                ]
             }
         ]
     parent=BASELINE_COMPONENT_TYPE

--- a/providers/shared/extensions/runbook_get_provider_id/extension.ftl
+++ b/providers/shared/extensions/runbook_get_provider_id/extension.ftl
@@ -1,0 +1,27 @@
+[#ftl]
+
+[@addExtension
+    id="runbook_get_provider_id"
+    aliases=[
+        "_runbook_get_provider_id"
+    ]
+    description=[
+        "Sets the runbook task paramter ProviderId to the current Accounts providerId"
+    ]
+    supportedTypes=[
+        RUNBOOK_STEP_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_runbook_get_provider_id_runbook_setup occurrence ]
+    [#assign _context = mergeObjects(
+        _context,
+        {
+            "TaskParameters" : {
+                "AccountId" : accountObject.Id,
+                "ProviderId" : accountObject.ProviderId,
+                "Provider" : accountObject.Provider
+            }
+        }
+    )]
+[/#macro]

--- a/providers/shared/extensions/runbook_get_region/extension.ftl
+++ b/providers/shared/extensions/runbook_get_region/extension.ftl
@@ -1,0 +1,25 @@
+[#ftl]
+
+[@addExtension
+    id="runbook_get_region"
+    aliases=[
+        "_runbook_get_region"
+    ]
+    description=[
+        "Get the current provider region"
+    ]
+    supportedTypes=[
+        RUNBOOK_STEP_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_runbook_get_region_runbook_setup occurrence ]
+    [#assign _context = mergeObjects(
+        _context,
+        {
+            "TaskParameters" : {
+                "Region" : getRegion()
+            }
+        }
+    )]
+[/#macro]

--- a/providers/shared/tasks/set_provider_credentials/id.ftl
+++ b/providers/shared/tasks/set_provider_credentials/id.ftl
@@ -1,0 +1,31 @@
+[#ftl]
+
+[@addTask
+    type=SET_PROVIDER_CREDENTIALS_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Use the hamlet context to define the credentials for cloud providers"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "AccountId",
+            "Description" : "The hamlet Account Id for the provider login",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Provider",
+            "Description" : "The name of the provider the account is defined for",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "ProviderId",
+            "Description" : "The Id that represents the account with the provider",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        }
+    ]
+/]

--- a/providers/shared/tasks/start_ssh_shell/id.ftl
+++ b/providers/shared/tasks/start_ssh_shell/id.ftl
@@ -1,0 +1,47 @@
+[#ftl]
+
+[@addTask
+    type=START_SSH_SHELL_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Start an ssh shell on a remote host"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "Host",
+            "Description" : "The IP or Hostname of the remote host",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Port",
+            "Description" : "The port number the host is listening on for ssh connections",
+            "Types" : NUMBER_TYPE,
+            "Default" : 22
+        },
+        {
+            "Names" : "Username",
+            "Description" : "The username on the remote host",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Password",
+            "Description" : "The password for the username on the remote host",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "SSHKey",
+            "Description" : "The path or content of an ssh private key to use for authentication",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "Shell",
+            "Description" : "The command to execute to start the shell",
+            "Types" : STRING_TYPE,
+            "Default" : "/bin/bash"
+        }
+    ]
+/]

--- a/providers/shared/tasks/task.ftl
+++ b/providers/shared/tasks/task.ftl
@@ -8,3 +8,5 @@
 [#assign RENAME_FILE_TASK_TYPE              = "rename_file" ]
 [#assign RUN_BASH_SCRIPT_TASK_TYPE          = "run_bash_script" ]
 [#assign CONDITIONAL_STAGE_SKIP_TASK_TYPE   = "conditional_stage_skip" ]
+[#assign START_SSH_SHELL_TASK_TYPE          = "start_ssh_shell" ]
+[#assign SET_PROVIDER_CREDENTIALS_TASK_TYPE = "set_provider_credentials" ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds the required shared tasks for a runbook that will establish an ssh session with a bastion component
- Adds support for including the baseline ssh key as an attribute along with a file
- Adds a standard extension for getting the region as a runbook parameter

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
These changes are part of an initial implementation in the AWS provider of runbooks which allow for an ssh session to be established through a runbook

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

