### PR TITLE
feat(ecs): add initprocess support for containers

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -533,7 +533,8 @@
                 "Privileged" : container.Privileged,
                 "LogMetrics" : container.LogMetrics,
                 "Alerts" : container.Alerts,
-                "Container" : container
+                "Container" : container,
+                "InitProcess" : container.InitProcess
             } +
             attributeIfContent("LogGroup", containerLogGroup) +
             attributeIfContent("ImageVersion", container.Version) +

--- a/providers/shared/attributesets/containertask/id.ftl
+++ b/providers/shared/attributesets/containertask/id.ftl
@@ -183,6 +183,12 @@
                     "Default" : 1024
                 }
             ]
+        },
+        {
+            "Names" : "InitProcess",
+            "Description" : "Enable a docker based init process to manage processes",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : false
         }
     ]
 /]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Enables InitProcess handling as part of task definitions

This aligns with the --init flag in docker which adds a simple init process to manage zombie processes

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This is a recommended feature when working with AWS ECS Exec to ensure that processes created as part of the exec session are cleared up 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

