### PR TITLE
feat(tasks): extend ssh tasks and add bash command

### DIFF
--- a/providers/shared/tasks/bash_run_command/id.ftl
+++ b/providers/shared/tasks/bash_run_command/id.ftl
@@ -1,0 +1,19 @@
+[#ftl]
+
+[@addTask
+    type=BASH_RUN_COMMAND_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Run a bash command locally and use the stdout as the returned result"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "Command",
+            "Description" : "The command to run",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        }
+    ]
+/]

--- a/providers/shared/tasks/ssh_copy_file/id.ftl
+++ b/providers/shared/tasks/ssh_copy_file/id.ftl
@@ -54,6 +54,32 @@
             "Description" : "The path to the remote file",
             "Types" : STRING_TYPE,
             "Mandatory" : true
+        },
+        {
+            "Names" : "BastionHost",
+            "Description" : "The IP or Hostname of the bastion host",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "BastionPort",
+            "Description" : "The port number the bastion host is listening on for ssh connections",
+            "Types" : NUMBER_TYPE,
+            "Default" : 22
+        },
+        {
+            "Names" : "BastionUsername",
+            "Description" : "The username on the bastion host",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "BastionPassword",
+            "Description" : "The password for the username on the bastion host",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "BastionSSHKey",
+            "Description" : "The path or content of an ssh private key to use for authentication",
+            "Types" : STRING_TYPE
         }
     ]
 /]

--- a/providers/shared/tasks/ssh_run_command/id.ftl
+++ b/providers/shared/tasks/ssh_run_command/id.ftl
@@ -42,6 +42,32 @@
             "Description" : "The command to execute",
             "Types" : STRING_TYPE,
             "Mandatory" : true
+        },
+        {
+            "Names" : "BastionHost",
+            "Description" : "The IP or Hostname of the bastion host",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "BastionPort",
+            "Description" : "The port number the bastion host is listening on for ssh connections",
+            "Types" : NUMBER_TYPE,
+            "Default" : 22
+        },
+        {
+            "Names" : "BastionUsername",
+            "Description" : "The username on the bastion host",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "BastionPassword",
+            "Description" : "The password for the username on the bastion host",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "BastionSSHKey",
+            "Description" : "The path or content of an ssh private key to use for authentication",
+            "Types" : STRING_TYPE
         }
     ]
 /]

--- a/providers/shared/tasks/task.ftl
+++ b/providers/shared/tasks/task.ftl
@@ -7,6 +7,7 @@
 [#assign INSTALL_PLUGIN_TASK_TYPE           = "install_plugin" ]
 [#assign RENAME_FILE_TASK_TYPE              = "rename_file" ]
 [#assign RUN_BASH_SCRIPT_TASK_TYPE          = "run_bash_script" ]
+[#assign BASH_RUN_COMMAND_TASK_TYPE         = "bash_run_command" ]
 [#assign CONDITIONAL_STAGE_SKIP_TASK_TYPE   = "conditional_stage_skip" ]
 [#assign SSH_RUN_COMMAND_TASK_TYPE          = "ssh_run_command" ]
 [#assign SSH_COPY_FILE_TASK_TYPE            = "ssh_copy_file" ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for providing a bastion host for ssh tasks which will be used as an ssh gateway to the host
- Adds a bash command which will execute a bash command and return the results as an output

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The ssh support allows for accessing instances within a deployment without manual steps
The local bash command is a general purpose commands to get extra info when required

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

