### PR TITLE
feat(cdn): add origin connection timeout support

### DIFF
--- a/providers/shared/components/cdn/id.ftl
+++ b/providers/shared/components/cdn/id.ftl
@@ -136,6 +136,19 @@
             "Names" : "Origin",
             "Children" : [
                 {
+                    "Names" : "ConnectionTimeout",
+                    "Description" : "How long to wait until a response is received from the origin",
+                    "Types" : NUMBER_TYPE,
+                    "Default" : 30
+                },
+                {
+                    "Names" : "TLSProtocols",
+                    "Description" : "When using a TLS backend the protocols the CDN will use as a client",
+                    "Types" : ARRAY_OF_STRING_TYPE,
+                    "Values" : [ "TLSv1.2", "TLSv1.1", "TLSv1", "SSLv3" ],
+                    "Default" : [ "TLSv1.2" ]
+                },
+                {
                     "Names" : "BasePath",
                     "Description" : "The base path at the origin destination",
                     "Types" : STRING_TYPE,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for controlling the timeout for origin connections
- Exposes the TLS protocol used for connections to TLS based Origins

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Provides greater control over CDN origins and their behaviour

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

