### PR TITLE
refactor: move domain and certificate to reference data

### DIFF
--- a/engine/configuration/reference.ftl
+++ b/engine/configuration/reference.ftl
@@ -25,15 +25,15 @@
     /]
 
     [#local referenceProperties = combineEntities(
-                                        properties
-                                            ?filter(x -> x.Type != "BlueprintKey" ),
-                                        [
-                                            {
-                                                "Type" : "BlueprintKey",
-                                                "Value" : pluralType
-                                            }
-                                        ]
-                                    )]
+            properties
+                ?filter(x -> x.Type != "BlueprintKey" ),
+            [
+                {
+                    "Type" : "BlueprintKey",
+                    "Value" : pluralType
+                }
+            ]
+        )]
 
     [@addConfigurationSet
         scopeId=REFERENCE_CONFIGURATION_SCOPE

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -282,14 +282,6 @@
     [#assign wafConditions = getReferenceData(WAFCONDITION_REFERENCE_TYPE) ]
     [#assign wafValueSets = getReferenceData(WAFVALUESET_REFERENCE_TYPE) ]
 
-    [#-- Domains --]
-    [#assign domains =
-        addIdNameToObjectAttributes(blueprintObject.Domains!{}) ]
-
-    [#-- Certificates --]
-    [#assign certificates =
-        addIdNameToObjectAttributes(blueprintObject.Certificates!{}) ]
-
     [#-- Tenants --]
     [#if isLayerActive(TENANT_LAYER_TYPE) ]
         [#-- assign tenants = getLayer(TENANT_LAYER_TYPE) --]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -536,35 +536,6 @@
     }
 ]]
 
-[#-- SHOULDN'T have Enabled attribute --]
-[#assign domainChildConfiguration = [
-    {
-        "Names" : "Name",
-        "Description" : "The name of the domain",
-        "Types" : STRING_TYPE
-    },
-    {
-        "Names" : "Stem",
-        "Description" : "The root stem domain name that children will be based on",
-        "Types" : STRING_TYPE
-    },
-    {
-        "Names" : "Zone",
-        "Description" : "The zone the endpoint belongs to",
-        "Types" : STRING_TYPE
-    },
-    {
-        "Names" : "Bare",
-        "Types" : BOOLEAN_TYPE,
-        "Default" : false
-    },
-    {
-        "Names" : "Role",
-        "Types" : STRING_TYPE,
-        "Values" : [DOMAIN_ROLE_PRIMARY, DOMAIN_ROLE_SECONDARY]
-    }
-]]
-
 [#assign domainNameChildConfiguration = [
     {
         "Names" : "Domain",

--- a/providers/shared/references/Certificate/id.ftl
+++ b/providers/shared/references/Certificate/id.ftl
@@ -1,0 +1,73 @@
+[#ftl]
+
+[@addReference
+    type=CERTIFICATE_REFERENCE_TYPE
+    pluralType="Certificates"
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Mapping of a domain to a product certificate entry - the Id of the reference should be a product Id"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "Domain",
+            "Description" : "The Id of a domain reference to map to a product",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]
+
+
+[#function getCertificateObject start ]
+
+    [#local certificateObject =
+        getCompositeObject(
+            certificateChildConfiguration,
+            asFlattenedArray(
+                arrayIfContent((blueprintObject.CertificateBehaviours)!{}, (blueprintObject.CertificateBehaviours)!{}) +
+                arrayIfContent((tenantObject.CertificateBehaviours)!{}, (tenantObject.CertificateBehaviours)!{}) +
+                arrayIfContent((productObject.CertificateBehaviours)!{}, (productObject.CertificateBehaviours)!{}) +
+                ((getObjectLineage(
+                    addIdNameToObjectAttributes(getReferenceData(CERTIFICATE_REFERENCE_TYPE)),
+                    [productId, productName])[0])![]
+                ) +
+                ((getObjectLineage(
+                    addIdNameToObjectAttributes(getReferenceData(CERTIFICATE_REFERENCE_TYPE)),
+                    start)[0])![]
+                )
+            )
+        )
+    ]
+    [#return
+        certificateObject +
+        {
+            "Domains" : getDomainObjects(certificateObject)
+        }
+    ]
+[/#function]
+
+[#function getCertificateDomains certificateObject]
+    [#return certificateObject.Domains![] ]
+[/#function]
+
+[#function getCertificatePrimaryDomain certificateObject]
+    [#list certificateObject.Domains as domain]
+        [#if isPrimaryDomain(domain) ]
+            [#return domain ]
+            [#break]
+        [/#if]
+    [/#list]
+    [#return {} ]
+[/#function]
+
+[#function getCertificateSecondaryDomains certificateObject]
+    [#local result = [] ]
+    [#list certificateObject.Domains as domain]
+        [#if isSecondaryDomain(domain) ]
+            [#local result += [domain] ]
+            [#break]
+        [/#if]
+    [/#list]
+    [#return result ]
+[/#function]

--- a/providers/shared/references/Domain/id.ftl
+++ b/providers/shared/references/Domain/id.ftl
@@ -1,0 +1,155 @@
+[#ftl]
+
+[#-- Domain Roles --]
+[#-- Primary is used on component attributes --]
+[#assign DOMAIN_ROLE_PRIMARY="primary" ]
+[#-- Secondaries allow a smooth transition from one domain to another --]
+[#assign DOMAIN_ROLE_SECONDARY="secondary" ]
+
+[@addReference
+    type=DOMAIN_REFERENCE_TYPE
+    pluralType="Domains"
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Represents a segment of a domain name"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "Name",
+            "Description" : "The name of the domain",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "Stem",
+            "Description" : "The root stem domain name that children will be based on",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "Zone",
+            "Description" : "The zone the endpoint belongs to",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "Bare",
+            "Description" : "Use the name value of the domain as the full domain name value",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : false
+        },
+        {
+            "Names" : "Role",
+            "Types" : STRING_TYPE,
+            "Values" : [
+                DOMAIN_ROLE_PRIMARY,
+                DOMAIN_ROLE_SECONDARY
+            ]
+        },
+        {
+            "Names" : "Parent",
+            "Description" : "The parent of this domain",
+            "Types" : [ STRING_TYPE, ARRAY_OF_STRING_TYPE]
+        }
+    ]
+/]
+
+
+[#function isPrimaryDomain domainObject]
+    [#return domainObject.Role == DOMAIN_ROLE_PRIMARY ]
+[/#function]
+
+[#function isSecondaryDomain domainObject]
+    [#return domainObject.Role == DOMAIN_ROLE_SECONDARY ]
+[/#function]
+
+[#function getDomainObjects certificateObject ]
+    [#local result = [] ]
+    [#local primaryNotSeen = true]
+
+    [#local lines = getObjectLineage(
+        addIdNameToObjectAttributes(
+            getReferenceData(DOMAIN_REFERENCE_TYPE)
+        ),
+        (certificateObject.Domain)!"") ]
+
+    [#list lines as line]
+        [#local name = "" ]
+        [#local role = DOMAIN_ROLE_PRIMARY ]
+        [#list line as domainObject]
+            [#if !(domainObject.Bare) ]
+                [#local name = formatDomainName(
+                                   contentIfContent(
+                                       domainObject.Stem!"",
+                                       contentIfContent(
+                                           domainObject.Name!"",
+                                           ""
+                                       )
+                                   ),
+                                   name
+                               ) ]
+            [/#if]
+            [#if domainObject.Role?? && domainObject.Role?has_content]
+                [#local role = domainObject.Role]
+            [/#if]
+        [/#list]
+
+        [#local result +=
+            [
+                getCompositeObject(
+                    getReferenceConfiguration(DOMAIN_REFERENCE_TYPE).Attributes,
+                    line
+                    + [
+                        {
+                            "Name" : name,
+                            "Role" : valueIfTrue(role, primaryNotSeen, DOMAIN_ROLE_SECONDARY)
+                        }
+                    ])
+            ] ]
+        [#local primaryNotSeen = primaryNotSeen && (role != DOMAIN_ROLE_PRIMARY) ]
+    [/#list]
+
+    [#-- Force first entry to primary if no primary seen --]
+    [#if primaryNotSeen && (result?size > 0) ]
+        [#local forcedResult = [ result[0] + { "Role" : DOMAIN_ROLE_PRIMARY } ] ]
+        [#if (result?size > 1) ]
+            [#local forcedResult += result[1..] ]
+        [/#if]
+        [#local result = forcedResult]
+    [/#if]
+
+    [#-- Add any domain inclusions --]
+    [#local includes = certificateObject.IncludeInDomain!{} ]
+    [#if includes?has_content]
+        [#local hostParts = certificateObject.HostParts ]
+        [#local parts = [] ]
+
+        [#list hostParts as part]
+            [#if includes[part]!false]
+                [#switch part]
+                    [#case "Segment"]
+                        [#local parts += [segmentName!""] ]
+                        [#break]
+                    [#case "Environment"]
+                        [#local parts += [environmentName!""] ]
+                        [#break]
+                    [#case "Product"]
+                        [#local parts += [productName!""] ]
+                        [#break]
+                [/#switch]
+            [/#if]
+        [/#list]
+
+        [#local extendedResult = [] ]
+        [#list result as entry]
+            [#local extendedResult += [
+                    entry +
+                    {
+                        "Name" : formatDomainName(parts, entry.Name)
+                    }
+                ] ]
+        [/#list]
+        [#local result = extendedResult]
+    [/#if]
+
+    [#return result]
+[/#function]

--- a/providers/shared/references/reference.ftl
+++ b/providers/shared/references/reference.ftl
@@ -53,3 +53,7 @@
 
 [#assign TESTCASE_REFERENCE_TYPE = "TestCase" ]
 [#assign TESTPROFILE_REFERENCE_TYPE = "TestProfile" ]
+
+[#-- Domain management --]
+[#assign DOMAIN_REFERENCE_TYPE = "Domain"]
+[#assign CERTIFICATE_REFERENCE_TYPE = "Certificate"]

--- a/providers/shared/views/blueprint/setup.ftl
+++ b/providers/shared/views/blueprint/setup.ftl
@@ -14,7 +14,9 @@
                     "Id" : tenantObject.Id,
                     "Name" : (tenantObject.Name)!tenantObject.Id,
                     "Configuration" : tenantObject,
-                    "Domains" : domains,
+                    "Domains" : addIdNameToObjectAttributes(
+                        getReferenceData(DOMAIN_REFERENCE_TYPE)
+                    ),
                     "Products" : getProductBlueprint()
                 }
             ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Migrates Domain/Certificate handling into Reference data
- Removes the global variable assignment and instead uses getReferenceData calls to get the data when required

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This aligns this configuration with our existing reference configuration usage to make things easier to understand and document

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

