### PR TITLE
feat(ses): add control over IP access policy

### DIFF
--- a/legacy/account/account_ses.ftl
+++ b/legacy/account/account_ses.ftl
@@ -43,16 +43,19 @@
                         id=formatSESReceiptFilterId(replaceAlphaNumericOnly(cidr,"X"))
                         name=formatName("account", replaceAlphaNumericOnly(cidr,"-"))
                         cidr=cidr
+                        allow=( accountObject["aws:SES"].IPAccessPolicy == "allow" )
                     /]
                 [/#list]
 
                 [#-- Add a default block all rule --]
-                [@createSESReceiptIPFilter
+                [#if accountObject["aws:SES"].IPAccessPolicy == "allow" ]
+                    [@createSESReceiptIPFilter
                         id=formatSESReceiptFilterId("0X0X0X0X0")
                         name=formatName("account", "0-0-0-0-0")
                         cidr="0.0.0.0/0"
                         allow=false
                     /]
+                [/#if]
             [/#if]
         [/#if]
     [/#if]

--- a/providers/shared/layers/Account/id.ftl
+++ b/providers/shared/layers/Account/id.ftl
@@ -449,6 +449,13 @@
                     ]
                 },
                 {
+                    "Names" : "IPAccessPolicy",
+                    "Description" : "Controls how IPAddressGroups are handled - deny: deny these groups - allow: only allow these groups",
+                    "Types" : STRING_TYPE,
+                    "Values" : [ "allow", "deny"],
+                    "Default" : "allow"
+                },
+                {
                     "Names" : "IPAddressGroups",
                     "Types" : ARRAY_OF_STRING_TYPE,
                     "Default" : []


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for using IP filtering as an allow list or deny list

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for using the IPAddressGroup filtering to drop specific sources or to only allow specific sources based on the IPAccessPolicy defined on the account. This is mainly to support using the filtering for spam or malicious actor blocking.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

