### PR TITLE
fix: module lookup process

### DIFF
--- a/engine/configuration/module.ftl
+++ b/engine/configuration/module.ftl
@@ -27,20 +27,13 @@
     /]
 [/#macro]
 
-[#function getModuleConfiguration name="" ]
-    [#if name?has_content ]
-        [#return getConfigurationSet(MODULE_CONFIGURATION_SCOPE, name)]
-    [#else]
-        [#local result = {}]
-            [#list getConfigurationSets(MODULE_CONFIGURATION_SCOPE) as set]
-                [#local result = mergeObjects(result, { set.Id : { "Attributes" : set.Attributes, "Properties" : set.Properties, "Configuration" : set.Configuration }} )]
-            [/#list]
-        [#return result]
-    [/#if]
+[#function getModuleConfiguration name provider ]
+    [#return (getConfigurationSets(MODULE_CONFIGURATION_SCOPE)?filter(
+            x -> x.Id == name &&  x.Configuration.Provider == provider )[0])!{}]
 [/#function]
 
 [#function getModuleDetails name provider parameters ]
-    [#local moduleConfig = getModuleConfiguration(name) ]
+    [#local moduleConfig = getModuleConfiguration(name, provider) ]
 
     [#if ! moduleConfig?has_content ]
         [#return {}]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Ensures both name and provider are considered when loading modules

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The default behaviour for configuration sets is to generally merge configuration outputs that share the same id across different providers. In the case of modules the provider/plugin represents a different module, so we need to ensure that the provider is considered when searching for configuration

Fixes #1922 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

