### PR TITLE
refactor(backup): Configuration options

### DIFF
--- a/providers/shared/components/backupstore/id.ftl
+++ b/providers/shared/components/backupstore/id.ftl
@@ -180,8 +180,8 @@
                 ]
             },
             {
-                "Names" : "Targets",
-                "Description" : "Mechanisms to determine what should be backed up",
+                "Names" : "Conditions",
+                "Description" : "Mechanisms to filter selected targets",
                 "Children" : [
                     {
                         "Names" : "MatchesStore",
@@ -214,10 +214,28 @@
                                 "Default" : true
                             }
                         ]
+                    }
+                ]
+            },
+            {
+                "Names" : "Targets",
+                "Description" : "Mechanisms to determine what should be backed up. Conditions are ORed",
+                "Children" : [
+                    {
+                        "Names" : "All",
+                        "Description" : "Consider all resources. Normally used with the MatchesStore condition",
+                        "Children" : [
+                            {
+                                "Names" : "Enabled",
+                                "Description" : "All resources are targets",
+                                "Types" : BOOLEAN_TYPE,
+                                "Default" : false
+                            }
+                        ]
                     },
                     {
                         "Names" : "Tag",
-                        "Description" : "Target must carry a tag specific to the store. Tag is added by linking from the component to the store",
+                        "Description" : "Include any target carrying a tag specific to the regime. Tag is added by linking from the component to the regime",
                         "Children" : [
                             {
                                 "Names" : "Enabled",


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
- separate out conditions from targets
- add an "All" target option to support the use case where everything in a solution should be considered as a candidate target.

## Motivation and Context
When adding backup to the baseline module for a customer, the need for more flexibility in the configuration options was exposed.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

