### PR TITLE
refactor: backup encryption key

### DIFF
--- a/providers/shared/components/backupstore/id.ftl
+++ b/providers/shared/components/backupstore/id.ftl
@@ -19,12 +19,6 @@
                         "Names" : "Enabled",
                         "Types" : BOOLEAN_TYPE,
                         "Default" : false
-                    },
-                    {
-                        "Names" : "Key",
-                        "Description" : "Baseline key to use for snapshot encryption",
-                        "Types" : STRING_TYPE,
-                        "Default" : "Encryption"
                     }
                 ]
             },


### PR DESCRIPTION

## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Rely on the encryption key configured in the baseline profile.

## Motivation and Context
Implementation now reflects the intent of the baseline profile.

A different profile can be configured specifically on the backupstore if a different baseline key should be used for encryption.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

