### PR TITLE
fix: prefix handling for shared provider

### DIFF
--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -1753,6 +1753,10 @@ are added.
 
     [#local prefix = prefix?ensure_ends_with(":")]
 
+    [#if prefix == disablePrefix ]
+        [#local prefix = ""]
+    [/#if]
+
     [#if depth gte maxDepth ]
         [#local prefixNames = false ]
         [#local prefixValues = false ]
@@ -1779,12 +1783,12 @@ are added.
         [#if ((attribute.Values)![])?has_content ]
             [#local prefixedValues = asArray(attribute.Values)?map(
                                         x -> x?is_string?then(
-                                                            x?starts_with(disablePrefix)?then(
-                                                                x?remove_beginning(disablePrefix),
-                                                                prefixValues?then( x?ensure_starts_with(prefix), x)
-                                                            ),
-                                                            x
-                                                        )
+                                            x?starts_with(disablePrefix)?then(
+                                                x?remove_beginning(disablePrefix),
+                                                prefixValues?then( x?ensure_starts_with(prefix), x)
+                                            ),
+                                            x
+                                        )
                                         )]
         [/#if]
 

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -474,13 +474,21 @@ already prefixed attribute.
                         [#-- If extension value starts with the disable prefix, --]
                         [#-- value is shared so strip prefix, otherwise         --]
                         [#-- force extension value to be prefixed               --]
-                        [#local extendedValues +=
-                            [
-                                extensionValue?starts_with(disablePrefix)?then(
-                                    extensionValue?remove_beginning(disablePrefix),
-                                    extensionValue?ensure_starts_with(prefix)
-                                )
-                            ]]
+                        [#if prefix != disablePrefix ]
+                            [#local extendedValues +=
+                                [
+                                    extensionValue?starts_with(disablePrefix)?then(
+                                        extensionValue?remove_beginning(disablePrefix),
+                                        extensionValue?ensure_starts_with(prefix)
+                                    )
+                                ]]
+                        [#else]
+                            [#local extendedValues +=
+                                [
+                                    extensionValue?remove_beginning(disablePrefix)
+                                ]
+                            ]
+                        [/#if]
                     [#else ]
                         [#local extendedValues += extensionValue ]
                     [/#if]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Handles cases where the disablePrefix and prefix are the same when extending attributes

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Attribute prefixes were being added back onto attributes when they should have been ignored 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

