### PR TITLE
feat(datafeed): compression control for buckets

### DIFF
--- a/providers/shared/components/datafeed/id.ftl
+++ b/providers/shared/components/datafeed/id.ftl
@@ -53,6 +53,23 @@
                         "Default" : "error/"
                     },
                     {
+                        "Names" : "Compression",
+                        "Description" : "Apply compression to files saved to the bucket",
+                        "Children" : [
+                            {
+                                "Names" : "Enabled",
+                                "Types" : BOOLEAN_TYPE,
+                                "Default" : true
+                            },
+                            {
+                                "Names" : "Format",
+                                "Types" : STRING_TYPE,
+                                "Values" : [ "GZIP", "ZIP"],
+                                "Default" : "GZIP"
+                            }
+                        ]
+                    },
+                    {
                         "Names" : "Include",
                         "Description" : "Deployment specific details to add to prefix",
                         "Children" : [
@@ -148,6 +165,23 @@
                         "Description" : "The backup policy to apply to records",
                         "Values" : [ "AllDocuments", "FailedDocumentsOnly" ],
                         "Default" : "FailedDocumentsOnly"
+                    },
+                    {
+                        "Names" : "Compression",
+                        "Description" : "Apply compression to files saved to the bucket",
+                        "Children" : [
+                            {
+                                "Names" : "Enabled",
+                                "Types" : BOOLEAN_TYPE,
+                                "Default" : true
+                            },
+                            {
+                                "Names" : "Format",
+                                "Types" : STRING_TYPE,
+                                "Values" : [ "GZIP", "ZIP" ],
+                                "Default" : "GZIP"
+                            }
+                        ]
                     }
                 ]
             },


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support to control the compression behaviour for datafeeds sending to buckets

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Initially added to troubleshoot an issue but also useful for controlling how the data is saved

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

