### PR TITLE
feat(directory): support for log forwarding

### DIFF
--- a/legacy/account/account_directory.ftl
+++ b/legacy/account/account_directory.ftl
@@ -1,0 +1,62 @@
+[#if getCLODeploymentUnit()?contains("directory") || (groupDeploymentUnits!false) ]
+
+    [#if deploymentSubsetRequired("generationcontract", false)]
+        [@addDefaultGenerationContract subsets=[ "template" ] /]
+    [/#if]
+
+    [@includeServicesConfiguration
+        provider=AWS_PROVIDER
+        services=[
+            AWS_CLOUDWATCH_SERVICE
+        ]
+        deploymentFramework=CLOUD_FORMATION_DEPLOYMENT_FRAMEWORK
+    /]
+
+    [#assign directoryLogPolicyId = formatAccountResourceId("logpolicy", "directory")]
+    [#assign directoryLogPolicyName = formatName("account", "directory")]
+
+    [#if deploymentSubsetRequired("lg", true) &&
+            isPartOfCurrentDeploymentUnit(directoryLogPolicyId)]
+
+        [@cfResource
+            id=directoryLogPolicyId
+            type="AWS::Logs::ResourcePolicy"
+            properties=
+                {
+                  "PolicyName" : directoryLogPolicyName,
+                  "PolicyDocument" : {
+                        "Fn::Sub" : [
+                            getJSON(
+                                {
+                                    "Version": "2012-10-17",
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Principal": {
+                                                "Service": "ds.amazonaws.com"
+                                            },
+                                            "Action": [
+                                                "logs:CreateLogStream",
+                                                "logs:PutLogEvents"
+                                            ],
+                                            "Resource": r'arn:aws:logs:${Region}:${AWSAccountId}:log-group:/aws/directoryservice/*'
+                                        }
+                                    ]
+                                }
+                            ),
+                            {
+                                "Region" : {
+                                    "Ref" : "AWS::Region"
+                                },
+                                "AWSAccountId" : {
+                                    "Ref" : "AWS::AccountId"
+                                }
+                            }
+                        ]
+                    }
+                }
+            outputs={}
+        /]
+
+    [/#if]
+[/#if]

--- a/providers/shared/components/directory/id.ftl
+++ b/providers/shared/components/directory/id.ftl
@@ -44,6 +44,17 @@
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
             },
             {
+                "Names" : "Logging",
+                "Description" : "Manage the logging services enabled for the directory",
+                "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : false
+                    }
+                ]
+            },
+            {
                 "Names" : "Profiles",
                 "Children" :
                     [
@@ -54,6 +65,11 @@
                         },
                         {
                             "Names" : "Network",
+                            "Types" : STRING_TYPE,
+                            "Default" : "default"
+                        },
+                        {
+                            "Names" : "Logging",
                             "Types" : STRING_TYPE,
                             "Default" : "default"
                         }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds logging configuration to the directory component
- Adds legacy deployment for setting up a resource policy for directory services to access the cloudwatch logs for AWS accounts

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for configuring logging on components to forward logs generated by the managed service through to standard logging services

The legacy account policy is to support logging for managed directories and is applied at the account level as only 10 log access policies can be assigned to an Account

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->


### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

