### PR TITLE
feat: add support for using local docker volumes for builds

### DIFF
--- a/providers/shared/extensions/hamlet/extension.ftl
+++ b/providers/shared/extensions/hamlet/extension.ftl
@@ -41,6 +41,7 @@
     [@DefaultCoreVariables          enabled=false /]
     [@DefaultEnvironmentVariables   enabled=false /]
     [@DefaultBaselineVariables      enabled=false /]
+    [@DefaultComponentVariables     enabled=false /]
 
     [@Settings {
         "AWS_AUTOMATION_USER"   : awsAutomationUser,
@@ -208,15 +209,6 @@
         [@Volume
             name="dockerStage"
             containerPath=dockerStageDir
-            volumeEngine="ebs"
-            scope=dockerStagePersist?then(
-                        "shared",
-                        "task"
-            )
-            driverOpts={
-                "volumetype": "gp2",
-                "size": dockerStageSize
-            }
         /]
 
     [/#if]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds the option to use local docker volumes instead of rexray
- Updates image support to allow for containerregistry settings

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
With the new storage setup for awslinux2 its easier to extend the disks where docker volumes are stored on hosts. As a result of this its safer to use local docker volumes when handling multiple builds jobs

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

