### PR TITLE
refactor: full names based on district

### DIFF
--- a/engine/inputdata/district.ftl
+++ b/engine/inputdata/district.ftl
@@ -90,14 +90,14 @@
 [#-- validated and normalised district     --]
 [#function getLinkDistrict link logErrors=true]
     [#-- Validate the district configuration --]
-    [#return internalGetLinkDistrict(link, logErrors) ]
+    [#return internalGetLinkDistrict(link, .caller_template_name, logErrors) ]
 [/#function]
 
 [#macro pushDistrict link district={} ]
 
     [#local stackEntry = district ]
     [#if ! district?has_content]
-        [#local stackEntry = internalGetLinkDistrict(link) ]
+        [#local stackEntry = internalGetLinkDistrict(link, .caller_template_name) ]
     [/#if]
 
     [#-- Check if the district has changed --]
@@ -130,7 +130,7 @@
 [#function getDistrictNameParts link short=false]
 
     [#-- First get the district instance --]
-    [#local district = internalGetLinkDistrict(link) ]
+    [#local district = internalGetLinkDistrict(link, .caller_template_name) ]
 
     [#-- Now get the config for the district --]
     [#local config = districtConfiguration[district.District!""]!{} ]
@@ -174,7 +174,7 @@
 --------------------------------------------------------]
 
 [#-- Construct a district stack entry --]
-[#function internalGetLinkDistrict link logErrors=true]
+[#function internalGetLinkDistrict link caller logErrors=true ]
 
     [#-- Handle "self" district --]
     [#if (link.District!"") == SELF_DISTRICT_TYPE]
@@ -205,7 +205,10 @@
                     [#if logErrors]
                         [@fatal
                             message='"${attribute}" attribute is required by a district type of "${link.District}"'
-                            context=link
+                            context={
+                                "Caller" : caller,
+                                "Link": link
+                            }
                         /]
                     [/#if]
                     [#local result = {} ]

--- a/engine/inputdata/district.ftl
+++ b/engine/inputdata/district.ftl
@@ -32,8 +32,8 @@
                             "Mandatory" : true
                         },
                         {
-                            "Names" : "NameOrder",
-                            "Description" : "Layers to be included in the name of an instance of the district. If not provided, the InstanceOrder is assumed.",
+                            "Names" : "NamePartOrder",
+                            "Description" : "Parts to be included in the name of an instance of the district. If not provided, the InstanceOrder is assumed. If not a defined name part, the part is assumed to be a layer.",
                             "Type" : ARRAY_OF_STRING_TYPE
                         },
                         {
@@ -126,6 +126,11 @@
 
 [/#macro]
 
+[#-- Get the ordering of layers for a district --]
+[#function getDistrictLayerOrder district]
+    [#return (districtConfiguration[district.District!""].Layers.InstanceOrder)![] ]
+[/#function]
+
 [#-- Collect the name parts for the district --]
 [#function getDistrictNameParts link short=false]
 
@@ -136,7 +141,7 @@
     [#local config = districtConfiguration[district.District!""]!{} ]
 
     [#-- Determine the order of the name parts --]
-    [#local partsOrder = (config.Layers.NameOrder)!(config.Layers.InstanceOrder)![] ]
+    [#local partsOrder = (config.Layers.NamePartOrder)!(config.Layers.InstanceOrder)![] ]
 
     [#-- Determine the layer data to include in the name --]
     [#local activeLayers = getActiveLayers() ]
@@ -168,6 +173,14 @@
     [#return nameParts ]
 
 [/#function]
+
+[#function getDistrictFullNameParts link ]
+    [#return getDistrictNameParts(link, false)]
+[/#function]
+[#function getDistrictShortNameParts link ]
+    [#return getDistrictNameParts(link, true)]
+[/#function]
+
 
 [#------------------------------------------------------
 -- Internal support functions for district processing --

--- a/engine/inputdata/inputsource.ftl
+++ b/engine/inputdata/inputsource.ftl
@@ -648,6 +648,8 @@ A stack is used to capture the history of input state changes
 [#macro pushInputSource inputSource inputFilter={} ]
 
     [#-- Always include the InputSource in the filter --]
+    [#-- The source needs to be included to ensure    --]
+    [#-- cache checking considers a change in source  --]
     [#local newFilter = inputFilter + {"InputSource" : inputSource} ]
 
     [@debug

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -282,7 +282,7 @@
                     "ShortTypedFullName" : formatSegmentShortName(occurrence.Core.Extensions.Id, type),
                     "ShortTypedRawFullName" : formatSegmentShortName(occurrence.Core.Extensions.RawId, type),
                     "RelativePath" : formatRelativePath(occurrence.Core.Extensions.Name),
-                    "ReltiveRawPath" : formatRelativePath(occurrence.Core.Extensions.RawName),
+                    "RelativeRawPath" : formatRelativePath(occurrence.Core.Extensions.RawName),
                     "FullRelativePath" : formatSegmentRelativePath(occurrence.Core.Extensions.Name),
                     "FullRelativeRawPath" : formatSegmentRelativePath(occurrence.Core.Extensions.RawName),
                     "AbsolutePath" : formatAbsolutePath(occurrence.Core.Extensions.Name),

--- a/engine/provider.ftl
+++ b/engine/provider.ftl
@@ -214,6 +214,22 @@
                 [/#if]
             [/#list]
 
+            [#-- Determine the AttributeSets for the provider --]
+            [#local directories =
+                internalGetPluginFiles(
+                    [providerMarker.Path, "attributesets"],
+                    [
+                        ["[^/]+"]
+                    ]
+                )
+            ]
+            [#list directories as directory]
+                [@internalIncludeTemplatesInDirectory
+                    directory,
+                    ["id", "attributeset"]
+                /]
+            [/#list]
+
             [#-- Determine the layers for the provider --]
             [#local directories =
                 internalGetPluginFiles(
@@ -243,22 +259,6 @@
                 [@internalIncludeTemplatesInDirectory
                     directory,
                     ["id"]
-                /]
-            [/#list]
-
-            [#-- Determine the AttributeSets for the provider --]
-            [#local directories =
-                internalGetPluginFiles(
-                    [providerMarker.Path, "attributesets"],
-                    [
-                        ["[^/]+"]
-                    ]
-                )
-            ]
-            [#list directories as directory]
-                [@internalIncludeTemplatesInDirectory
-                    directory,
-                    ["id", "attributeset"]
                 /]
             [/#list]
 

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -228,8 +228,6 @@
     [@includeReferences blueprintObject /]
 
     [#-- Name prefixes --]
-    [#assign shortNamePrefixes = [] ]
-    [#assign fullNamePrefixes = [] ]
     [#assign cmdbProductLookupPrefixes = [] ]
 
     [#-- Testing --]
@@ -318,8 +316,6 @@
         [#assign productName = (productObject.Name)!"" ]
         [#assign productDomain = productObject.Domain!"" ]
 
-        [#assign shortNamePrefixes += [productId] ]
-        [#assign fullNamePrefixes += [productName] ]
         [#assign cmdbProductLookupPrefixes += ["shared"] ]
     [/#if]
 
@@ -346,8 +342,6 @@
                     "Name" : categoryName
                 } +
                 categories[categoryId]!{} ]
-            [#assign shortNamePrefixes += [environmentId] ]
-            [#assign fullNamePrefixes += [environmentName] ]
 
             [#assign cmdbProductLookupPrefixes +=
                 [
@@ -355,11 +349,6 @@
                     environmentName,
                     [environmentName, segmentName]
                 ] ]
-
-            [#if (segmentName != "default") ]
-                [#assign shortNamePrefixes += [segmentId] ]
-                [#assign fullNamePrefixes += [segmentName] ]
-            [/#if]
         [/#if]
 
         [#assign rotateKeys = segmentObject.RotateKeys ]

--- a/providers/shared/attributesets/attributeset.ftl
+++ b/providers/shared/attributesets/attributeset.ftl
@@ -6,6 +6,7 @@
 [#assign CONTTAINERTASK_ATTRIBUTESET_TYPE = "containertask"]
 [#assign CONTEXTPATH_ATTRIBUTESET_TYPE = "contextpath"]
 [#assign CORE_PROFILE_ATTRIBUTESET_TYPE = "core_profile"]
+[#assign DISTRICT_ATTRIBUTESET_TYPE = "district"]
 [#assign ECS_COMPUTEIMAGE_ATTRIBUTESET_TYPE = "ecs_computeimage"]
 [#assign ENVIRONMENTFORMAT_ATTRIBUTESET_TYPE = "environmentformat"]
 [#assign LBATTACH_ATTRIBUTESET_TYPE = "lbattach"]

--- a/providers/shared/attributesets/district/id.ftl
+++ b/providers/shared/attributesets/district/id.ftl
@@ -1,0 +1,46 @@
+[#ftl]
+
+[@addAttributeSet
+    type=DISTRICT_ATTRIBUTESET_TYPE
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Configuration of a district"
+        }
+    ]
+    attributes=[
+        {
+            "Names" : "InstanceOrder",
+            "Description" : "Layers whose configuration data should be included in the solution for an instance of the district",
+            "Type" : ARRAY_OF_STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "NamePartOrder",
+            "Description" : "Parts to be included in the name of an instance of the district. If not provided, the InstanceOrder is assumed. If not a defined name part, the part is assumed to be a layer.",
+            "Type" : ARRAY_OF_STRING_TYPE
+        },
+        {
+            "Names" : "NameParts",
+            "SubObjects" : true,
+            "Children" : [
+                {
+                    "Names" : "Enabled",
+                    "Description" : "Should this part be ignored/omitted?",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Names" : "Fixed",
+                    "Description" : "Include a fixed string",
+                    "Type" : STRING_TYPE
+                },
+                {
+                    "Names" : "Ignore",
+                    "Description" : "An array of values to not include if encountered",
+                    "Type" : ARRAY_OF_STRING_TYPE
+                }
+            ]
+        }
+    ]
+/]

--- a/providers/shared/components/name.ftl
+++ b/providers/shared/components/name.ftl
@@ -18,17 +18,17 @@
 
 [#-- Format segment short name --]
 [#function formatSegmentShortName extensions...]
-    [#return formatName(shortNamePrefixes, extensions) ]
+    [#return formatName(getDistrictNameParts(getInputFilter(), true), extensions) ]
 [/#function]
 
 [#-- Format segment name --]
 [#function formatSegmentFullName extensions...]
-    [#return formatName(fullNamePrefixes,  extensions) ]
+    [#return formatName(getDistrictNameParts(getInputFilter(), false),  extensions) ]
 [/#function]
 
 [#-- Format environment name --]
 [#function formatEnvironmentFullName extensions...]
-    [#return formatName(fullNamePrefixes[0..1],  extensions) ]
+    [#return formatName(getDistrictNameParts(getInputFilter(), false)[0..1],  extensions) ]
 [/#function]
 
 [#-- Format a component short name - based on ids not names --]
@@ -74,7 +74,7 @@
 
 [#-- Format a segment path --]
 [#function formatSegmentPath absolute extensions...]
-    [#return formatPath(absolute, fullNamePrefixes, extensions)]
+    [#return formatPath(absolute, getDistrictNameParts(getInputFilter(), false), extensions)]
 [/#function]
 
 [#function formatSegmentRelativePath extensions...]

--- a/providers/shared/components/name.ftl
+++ b/providers/shared/components/name.ftl
@@ -18,17 +18,17 @@
 
 [#-- Format segment short name --]
 [#function formatSegmentShortName extensions...]
-    [#return formatName(getDistrictNameParts(getInputFilter(), true), extensions) ]
+    [#return formatName(getDistrictShortNameParts(getInputFilter()), extensions) ]
 [/#function]
 
 [#-- Format segment name --]
 [#function formatSegmentFullName extensions...]
-    [#return formatName(getDistrictNameParts(getInputFilter(), false),  extensions) ]
+    [#return formatName(getDistrictFullNameParts(getInputFilter()),  extensions) ]
 [/#function]
 
 [#-- Format environment name --]
 [#function formatEnvironmentFullName extensions...]
-    [#return formatName(getDistrictNameParts(getInputFilter(), false)[0..1],  extensions) ]
+    [#return formatName(getDistrictFullNameParts(getInputFilter())[0..1],  extensions) ]
 [/#function]
 
 [#-- Format a component short name - based on ids not names --]
@@ -74,7 +74,7 @@
 
 [#-- Format a segment path --]
 [#function formatSegmentPath absolute extensions...]
-    [#return formatPath(absolute, getDistrictNameParts(getInputFilter(), false), extensions)]
+    [#return formatPath(absolute, getDistrictFullNameParts(getInputFilter()), extensions)]
 [/#function]
 
 [#function formatSegmentRelativePath extensions...]

--- a/providers/shared/districts/account/id.ftl
+++ b/providers/shared/districts/account/id.ftl
@@ -8,12 +8,14 @@
             "Value" : "Account level solutions"
         }
     ]
-    layers={
-        "InstanceOrder" : [ TENANT_LAYER_TYPE, ACCOUNT_LAYER_TYPE ],
-        "NamePartOrder" : [ "std" ],
-        "NameParts" : {
-            "std" : {
-                "Fixed" : "account"
+    configuration={
+        "Layers" : {
+            "InstanceOrder" : [ TENANT_LAYER_TYPE, ACCOUNT_LAYER_TYPE ],
+            "NamePartOrder" : [ "std" ],
+            "NameParts" : {
+                "std" : {
+                    "Fixed" : "account"
+                }
             }
         }
     }

--- a/providers/shared/districts/account/id.ftl
+++ b/providers/shared/districts/account/id.ftl
@@ -3,10 +3,18 @@
 [@addDistrict
     type=ACCOUNT_DISTRICT_TYPE
     properties=[
-            {
-                "Type"  : "Description",
-                "Value" : "Account level solutions"
+        {
+            "Type"  : "Description",
+            "Value" : "Account level solutions"
+        }
+    ]
+    layers={
+        "InstanceOrder" : [ TENANT_LAYER_TYPE, ACCOUNT_LAYER_TYPE ],
+        "NameOrder" : [ "std" ],
+        "NameParts" : {
+            "std" : {
+                "Fixed" : "account"
             }
-        ]
-    layers=[TENANT_LAYER_TYPE, ACCOUNT_LAYER_TYPE]
+        }
+    }
 /]

--- a/providers/shared/districts/account/id.ftl
+++ b/providers/shared/districts/account/id.ftl
@@ -10,7 +10,7 @@
     ]
     layers={
         "InstanceOrder" : [ TENANT_LAYER_TYPE, ACCOUNT_LAYER_TYPE ],
-        "NameOrder" : [ "std" ],
+        "NamePartOrder" : [ "std" ],
         "NameParts" : {
             "std" : {
                 "Fixed" : "account"

--- a/providers/shared/districts/district.ftl
+++ b/providers/shared/districts/district.ftl
@@ -2,4 +2,5 @@
 
 [#assign TENANT_DISTRICT_TYPE = "tenant"]
 [#assign ACCOUNT_DISTRICT_TYPE = "account"]
+[#assign ENVIRONMENT_DISTRICT_TYPE = "environment"]
 [#assign SEGMENT_DISTRICT_TYPE = "segment"]

--- a/providers/shared/districts/environment/id.ftl
+++ b/providers/shared/districts/environment/id.ftl
@@ -1,0 +1,15 @@
+[#ftl]
+
+[@addDistrict
+    type=ENVIRONMENT_DISTRICT_TYPE
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Environment level solutions"
+        }
+    ]
+    layers={
+        "InstanceOrder" : [ TENANT_LAYER_TYPE, PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE ],
+        "NameOrder" : [ PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE ]
+    }
+/]

--- a/providers/shared/districts/environment/id.ftl
+++ b/providers/shared/districts/environment/id.ftl
@@ -10,6 +10,6 @@
     ]
     layers={
         "InstanceOrder" : [ TENANT_LAYER_TYPE, PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE ],
-        "NameOrder" : [ PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE ]
+        "NamePartOrder" : [ PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE ]
     }
 /]

--- a/providers/shared/districts/environment/id.ftl
+++ b/providers/shared/districts/environment/id.ftl
@@ -8,8 +8,10 @@
             "Value" : "Environment level solutions"
         }
     ]
-    layers={
-        "InstanceOrder" : [ TENANT_LAYER_TYPE, PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE ],
-        "NamePartOrder" : [ PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE ]
+    configuration={
+        "Layers" : {
+            "InstanceOrder" : [ TENANT_LAYER_TYPE, PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE ],
+            "NamePartOrder" : [ PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE ]
+        }
     }
 /]

--- a/providers/shared/districts/segment/id.ftl
+++ b/providers/shared/districts/segment/id.ftl
@@ -8,12 +8,14 @@
             "Value" : "Segment level solutions"
         }
     ]
-    layers={
-        "InstanceOrder" : [ TENANT_LAYER_TYPE, PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE, SEGMENT_LAYER_TYPE ],
-        "NamePartOrder" : [ PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE, SEGMENT_LAYER_TYPE ],
-        "NameParts" : {
-            SEGMENT_LAYER_TYPE : {
-                "Ignore" : [ "default" ]
+    configuration={
+        "Layers" : {
+            "InstanceOrder" : [ TENANT_LAYER_TYPE, PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE, SEGMENT_LAYER_TYPE ],
+            "NamePartOrder" : [ PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE, SEGMENT_LAYER_TYPE ],
+            "NameParts" : {
+                SEGMENT_LAYER_TYPE : {
+                    "Ignore" : [ "default" ]
+                }
             }
         }
     }

--- a/providers/shared/districts/segment/id.ftl
+++ b/providers/shared/districts/segment/id.ftl
@@ -3,10 +3,18 @@
 [@addDistrict
     type=SEGMENT_DISTRICT_TYPE
     properties=[
-            {
-                "Type"  : "Description",
-                "Value" : "Segment level solutions"
+        {
+            "Type"  : "Description",
+            "Value" : "Segment level solutions"
+        }
+    ]
+    layers={
+        "InstanceOrder" : [ TENANT_LAYER_TYPE, PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE, SEGMENT_LAYER_TYPE ],
+        "NameOrder" : [ PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE, SEGMENT_LAYER_TYPE ],
+        "NameParts" : {
+            SEGMENT_LAYER_TYPE : {
+                "Ignore" : [ "default" ]
             }
-        ]
-    layers=[PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE, SEGMENT_LAYER_TYPE]
+        }
+    }
 /]

--- a/providers/shared/districts/segment/id.ftl
+++ b/providers/shared/districts/segment/id.ftl
@@ -10,7 +10,7 @@
     ]
     layers={
         "InstanceOrder" : [ TENANT_LAYER_TYPE, PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE, SEGMENT_LAYER_TYPE ],
-        "NameOrder" : [ PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE, SEGMENT_LAYER_TYPE ],
+        "NamePartOrder" : [ PRODUCT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE, SEGMENT_LAYER_TYPE ],
         "NameParts" : {
             SEGMENT_LAYER_TYPE : {
                 "Ignore" : [ "default" ]

--- a/providers/shared/districts/tenant/id.ftl
+++ b/providers/shared/districts/tenant/id.ftl
@@ -8,7 +8,9 @@
             "Value" : "Tenant level solutions"
         }
     ]
-    layers={
-         "InstanceOrder" : [ TENANT_LAYER_TYPE ]
+    configuration={
+        "Layers" : {
+            "InstanceOrder" : [ TENANT_LAYER_TYPE ]
+        }
     }
 /]

--- a/providers/shared/districts/tenant/id.ftl
+++ b/providers/shared/districts/tenant/id.ftl
@@ -3,10 +3,12 @@
 [@addDistrict
     type=TENANT_DISTRICT_TYPE
     properties=[
-            {
-                "Type"  : "Description",
-                "Value" : "Tenant level solutions"
-            }
-        ]
-    layers=[TENANT_LAYER_TYPE]
+        {
+            "Type"  : "Description",
+            "Value" : "Tenant level solutions"
+        }
+    ]
+    layers={
+         "InstanceOrder" : [ TENANT_LAYER_TYPE ]
+    }
 /]


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Expand the district configuration to control the format of full names for resources.

Remove the corresponding configuration in setContext.

Add an "environment" district that does not have segment for simpler deployments.

## Motivation and Context
By driving the full names from the district, full names can reflect whatever district layer configuration is selected.

## How Has This Been Tested?
- Local template generation
- Run engine and aws test suites

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

