### PR TITLE
fix(apigateway): handling of null values in definitions

### DIFF
--- a/providers/shared/inputseeders/shared/id.ftl
+++ b/providers/shared/inputseeders/shared/id.ftl
@@ -376,8 +376,15 @@
         ]
     [/#if]
 
+    [#if definitions?contains("null")]
+        [@warn
+            message="null JSON values not supportd in hamlet"
+            detail="A possible null value was detected in a definition file - remove the null value if it is not required"
+        /]
+    [/#if]
+
     [#local compositeDefinitions =
-        ((definitions!"")?has_content && (!definitions?contains("null")))?then(
+        ((definitions!"")?has_content)?then(
             definitions?eval_json,
             {}
         )

--- a/providers/shared/inputseeders/shared/id.ftl
+++ b/providers/shared/inputseeders/shared/id.ftl
@@ -376,7 +376,7 @@
         ]
     [/#if]
 
-    [#if definitions?contains("null")]
+    [#if (definitions!"")?contains("null")]
         [@warn
             message="null JSON values not supportd in hamlet"
             detail="A possible null value was detected in a definition file - remove the null value if it is not required"


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Add a warning but continue to process null values found in definition files

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
In OpenAPI there is a property called nullable within the specification, this is being caught by the current processing and the API definitions are not loaded even though it is valid. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

