### PR TITLE
feat(ecs): add support for default task compute provider

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -764,6 +764,29 @@
         ]
     },
     {
+        "Names" : "Placement",
+        "Children" : [
+            {
+                "Names" : "ComputeProvider",
+                "Description" : "The compute provider placement policy",
+                "Children" : [
+                    {
+                        "Names" : "Default",
+                        "Children" : [
+                            {
+                                "Names" : "Provider",
+                                "Description" : "The default container compute provider - _engine uses the default provider of the engine",
+                                "Types"  : STRING_TYPE,
+                                "Values" : [ "_engine" ],
+                                "Default" : "_engine"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
         "Names" : "TaskLogGroup",
         "Types" : BOOLEAN_TYPE,
         "Default" : true


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for defining a default compute provider on tasks

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for the use of capacity providers in AWS for running tasks on demand.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

