### PR TITLE
fix: use raw path for settings path prefix

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -85,7 +85,7 @@
 [#-- S3 settings/appdata storage  --]
 
 [#function getSettingsFilePrefix occurrence ]
-    [#return formatRelativePath("settings", occurrence.Core.FullRelativePath) ]
+    [#return formatRelativePath("settings", occurrence.Core.FullRelativeRawPath) ]
 [/#function]
 
 [#function getAppDataFilePrefix occurrence={} ]

--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -36,51 +36,6 @@
     [#return getOccurrenceSettingValue(occurrence, ["Registries", type, "Prefix"], true) ]
 [/#function]
 
-[#function standardPolicies occurrence baselineIds ]
-    [#local permissions = occurrence.Configuration.Solution.Permissions ]
-    [#return
-        valueIfTrue(
-            cmkDecryptPermission(baselineIds["Encryption"]),
-            permissions.Decrypt,
-            []
-        ) +
-        valueIfTrue(
-            s3ReadPermission(baselineIds["OpsData"], getSettingsFilePrefix(occurrence)) +
-            s3ListPermission(baselineIds["OpsData"], getSettingsFilePrefix(occurrence)) +
-            s3EncryptionReadPermission(
-                baselineIds["Encryption"],
-                getExistingReference(baselineIds["OpsData"], NAME_ATTRIBUTE_TYPE),
-                getSettingsFilePrefix(occurrence),
-                getExistingReference(baselineIds["OpsData"], REGION_ATTRIBUTE_TYPE)
-            ),
-            permissions.AsFile,
-            []
-        ) +
-        valueIfTrue(
-            s3AllPermission(baselineIds["AppData"], getAppDataFilePrefix(occurrence)) +
-            s3EncryptionAllPermission(
-                baselineIds["Encryption"],
-                getExistingReference(baselineIds["AppData"], NAME_ATTRIBUTE_TYPE),
-                getAppDataFilePrefix(occurrence),
-                getExistingReference(baselineIds["AppData"], REGION_ATTRIBUTE_TYPE)
-            ),
-            permissions.AppData,
-            []
-        ) +
-        valueIfTrue(
-            s3AllPermission(baselineIds["AppData"], getAppDataPublicFilePrefix(occurrence)) +
-            s3EncryptionAllPermission(
-                baselineIds["Encryption"],
-                getExistingReference(baselineIds["AppData"], NAME_ATTRIBUTE_TYPE),
-                getAppDataPublicFilePrefix(occurrence),
-                getExistingReference(baselineIds["AppData"], REGION_ATTRIBUTE_TYPE)
-            ),
-            permissions.AppPublic && getAppDataPublicFilePrefix(occurrence)?has_content,
-            []
-        )
-    ]
-[/#function]
-
 [#-- Environment Variable Management --]
 [#function addVariableToContext context name value upperCase=true]
     [#return


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- fixes an issue where settings s3 keys were being overridden when syncing as file settings
- moves the standard policies for IAM from the shared provider to the aws provider

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When working with components that have common first sections of their id ( mgmt, mgmt-worker ) the FullRelativePath  value overlaps between the subcomponents. 
When syncing the asFile settings to s3 this can cause the settings to be overriden as the sync command deletes files that don't match the sync. 

Moving to the FullRawRelativePath ensures the paths are unique for each component or subcomponent. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

