### PR TITLE
feat: max-age control on bucket content

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -819,7 +819,7 @@
 
 [/#function]
 
-[#function syncFilesToBucketScript filesArrayName region bucket prefix cleanup=true excludes=[] ]
+[#function syncFilesToBucketScript filesArrayName region bucket prefix cleanup=true excludes=[] maxAge=-1 ]
 
     [#local excludeSwitches = ""]
     [#list asArray(excludes) as exclude]
@@ -843,8 +843,9 @@
                    "\"" + region         + "\"" + " " +
                    "\"" + bucket         + "\"" + " " +
                    "\"" + prefix         + "\"" + " " +
-                   "\"" + filesArrayName + "\"" + " " +
-                   valueIfTrue("--delete", cleanup, "") +
+                   "\"" + filesArrayName + "\"" +
+                   valueIfTrue(" --delete", cleanup, "") +
+                   valueIfTrue(" --cache-control max-age=${maxAge?c}", maxAge >= 0, "") +
                    excludeSwitches +
                    " || return $?",
             "    ;;",


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
When syncing content to an s3 bucket, give the ability to set the max-age cache control on the synced files. 

## Motivation and Context
This is mainly for config files that should have a limited cache lifetime.

## How Has This Been Tested?
Local template generation to confirm additional switches on the `s3 sync` command.

Customer deployment once the change is merged.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

