### PR TITLE
fix: encryption of logs for sms account

### DIFF
--- a/legacy/account/account_sms.ftl
+++ b/legacy/account/account_sms.ftl
@@ -19,7 +19,10 @@
 
     [@includeServicesConfiguration
         provider=AWS_PROVIDER
-        services=[AWS_IDENTITY_SERVICE ]
+        services=[
+            AWS_IDENTITY_SERVICE,
+            AWS_KEY_MANAGEMENT_SERVICE
+        ]
         deploymentFramework=getCLODeploymentFramework()
     /]
 
@@ -43,6 +46,7 @@
 
     [#assign lgId = formatMobileNotifierLogGroupId(MOBILENOTIFIER_SMS_ENGINE, "", false) ]
     [#assign lgFailureId = formatMobileNotifierLogGroupId(MOBILENOTIFIER_SMS_ENGINE, "", true) ]
+    [#assign accountCMKId = formatAccountCMKTemplateId()]
 
     [#assign accountCMKArn = getExistingReference(accountCMKId, ARN_ATTRIBUTE_TYPE, getCLOSegmentRegion())]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds the KMS service to the account template loading
- Adds a lookup for the KMS account key id that was missing

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Template generation was failing for the account sms unit

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

