### PR TITLE
refactor: hamlet and dind docker extensions

### DIFF
--- a/providers/shared/extensions/dind/extension.ftl
+++ b/providers/shared/extensions/dind/extension.ftl
@@ -29,74 +29,25 @@
     [@Hostname hostname=(_context.Name)?replace("_", "") /]
 
     [#local dockerStageDir = _context.DefaultEnvironment["DOCKER_STAGE_DIR"]!"/home/jenkins"  ]
-    [#local dockerStageSize = _context.DefaultEnvironment["DOCKER_STAGE_SIZE_GB"]!"20"        ]
-    [#local dockerStagePersist = (_context.DefaultEnvironment["DOCKER_STAGE_PERSIST"]?boolean)!false ]
-    [#local dockerLibSize = _context.DefaultEnvironment["DOCKER_LIB_VOLUME_SIZE"]!"20"         ]
-    [#local dindTLSVerify = _context.DefaultEnvironment["DIND_DOCKER_TLS_VERIFY"]!"true"      ]
 
-    [#if ((_context.Container.Image.Source)!"") != "containerregistry" ]
-        [@Attributes
-            image="docker"
-            version="dind"
-        /]
-    [/#if]
+    [@Settings
+        {
+            "DOCKER_TLS_CERTDIR" : "/docker/certs"
+        }
+    /]
 
-    [#if dindTLSVerify?boolean ]
-        [@Settings
-            {
-                "DOCKER_TLS_CERTDIR" : "/docker/certs"
-            }
-        /]
+    [@Volume
+        name="dind_certs_client"
+        containerPath="/docker/certs/client"
+    /]
 
-        [@Volume
-            name="dind_certs_client"
-            containerPath="/docker/certs/client"
-        /]
-    [/#if]
+    [@Volume
+        name="dockerStage"
+        containerPath=dockerStageDir
+    /]
 
-    [#switch (_context.DefaultEnvironment["DOCKER_VOLUME_HOST"])!"ebs" ]
-        [#case "ebs"]
-            [@Volume
-                name="dockerStage"
-                containerPath=dockerStageDir
-                volumeEngine="ebs"
-                scope=dockerStagePersist?then(
-                            "shared",
-                            "task"
-                )
-                driverOpts={
-                    "volumetype": "gp2",
-                    "size": dockerStageSize
-                }
-            /]
-
-            [@Volume
-                name="dind_lib"
-                containerPath="/var/lib/docker"
-                volumeEngine="ebs"
-                scope="task"
-                scope=dockerStagePersist?then(
-                    "shared",
-                    "task"
-                )
-                driverOpts={
-                    "volumetype": "gp2",
-                    "size": dockerLibSize
-                }
-            /]
-            [#break]
-
-        [#case "local"]
-
-            [@Volume
-                name="dockerStage"
-                containerPath=dockerStageDir
-            /]
-
-            [@Volume
-                name="dind_lib"
-                containerPath="/var/lib/docker"
-            /]
-            [#break]
-    [/#switch]
+    [@Volume
+        name="dind_lib"
+        containerPath="/var/lib/docker"
+    /]
 [/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Updates the hamlet and dind ecs extensions to align with the latest supported approaches in hamlet
- Remove the use of the docker-ebs volume extensions as it is no longer supported
- Always use TLS verification for dind to hamlet agent communication


## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Makes it easier to follow the configuration required for running hamlet CI/CD agent with DIND on ecs and removes deprecated approaches for hamlet and docker hosting

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- ! This will require updates to existing hamlet agents running in jenkins
- Update AWS_AUTOMATION_USER to HAMLET_AWS_AUTH_SOURCE/HAMLET_AWS_AUTH_USER as per https://docs.hamlet.io/how-to/configure/provider-authentication

