### PR TITLE
feat: add support for HealthCheck Protocol

### DIFF
--- a/providers/shared/references/Port/id.ftl
+++ b/providers/shared/references/Port/id.ftl
@@ -27,6 +27,13 @@
     [#return ""]
 [/#function]
 
+[#function getHealthCheckProtocol port]
+    [#return (port.HealthCheck.Protocol == "_protocol")?then(
+        (port.Protocol)!port.IPProtocol,
+        port.HealthCheck.Protocol
+    )]
+[/#function]
+
 [@addReference
     type=PORT_REFERENCE_TYPE
     pluralType="Ports"
@@ -55,6 +62,13 @@
         {
             "Names" : "HealthCheck",
             "Children" : [
+                {
+                    "Names" : "Protocol",
+                    "Description": "The protocol used for healthchecks. _protocol uses the ports protocol",
+                    "Types" : STRING_TYPE,
+                    "Values" : [ "_protocol", "TCP", "UDP", "HTTP", "HTTPS"],
+                    "Default" : "_protocol"
+                },
                 {
                     "Names" : "Path",
                     "Types" : STRING_TYPE


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for defining the HealthCheck Protocol separate from the ports protocol itself

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for using more complex load balancing processes where the protocol used for the load balancer is different to the one used for HealthChecks
This was supported but missed in the reference definition and has been updated to handle fallbacks for protocol lookup 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

