### PR TITLE
feat(ec2): add support for zone based deploy control

### DIFF
--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -12,6 +12,12 @@
     attributes=
         [
             {
+                "Names" : "Zones",
+                "Description" : "A list of zoneIds to create virtual machines in, default is _all which will use all zones or the first for SingleAz",
+                "Types" : ARRAY_OF_STRING_TYPE,
+                "Default" : [ "_all" ]
+            },
+            {
                 "Names" : "FixedIP",
                 "Types" : BOOLEAN_TYPE,
                 "Default" : false


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Allows for defining the the zones that a given component should be deployed to

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for finer grain control over ec2 deployments such as using component instances to control each instance and treating each deployment as an individual service

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

