### PR TITLE
feat: add image details entrance for image reference info

### DIFF
--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -852,12 +852,12 @@ already prefixed attribute.
             cmdbProductLookupPrefixes,
             namespaces
         ) ]
-
     [#-- a local unit build commit/tag takes preference over a shared one --]
     [#local occurrenceBuildCommit = occurrenceBuild.COMMIT!{} ]
     [#local occurrenceBuildTag = occurrenceBuild.TAG!{} ]
     [#local occurrenceBuildFormats = occurrenceBuild.FORMATS!{} ]
     [#local occurrenceBuildScope = occurrenceBuild.SCOPE!{} ]
+    [#local occurrenceBuildSource = occurrenceBuild.SOURCE!{}]
 
     [#-- Reference could be to a deployment unit (legacy) or a component --]
     [#local matchedReference = "" ]
@@ -928,6 +928,10 @@ already prefixed attribute.
                     deploymentUnit
                 )
             )
+        ) +
+        attributeIfContent(
+            "BUILD_SOURCE",
+            contentIfContent(occurrenceBuildSource, occurrenceBuild.SOURCE!{})
         )
     ]
 [/#function]

--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -608,6 +608,7 @@
         [#case "schemaset"]
         [#case "unitlist"]
         [#case "validate"]
+        [#case "imagedetails"]
             [#local filename_parts =
                         mergeObjects(
                             filename_parts,

--- a/providers/shared/components/shared/setup.ftl
+++ b/providers/shared/components/shared/setup.ftl
@@ -305,3 +305,36 @@
         [/#if]
     [/#list]
 [/#macro]
+
+[#-- Build unit details --]
+[#macro shared_imagedetails_generationcontract occurrence ]
+    [@addDefaultGenerationContract subsets=["config"] /]
+[/#macro]
+
+[#macro shared_imagedetails_config occurrence ]
+    [#local allOccurrences = asFlattenedArray( [ occurrence, occurrence.Occurrences![] ], true )]
+    [#list allOccurrences as occurrence ]
+
+        [#if (occurrence.Configuration.Settings.Build)?has_content &&
+                ((occurrence.Configuration.Settings.Build.BUILD_REFERENCE.Value)!"")?has_content]
+            [@addToDefaultJsonOutput
+                content={
+                    "Images" : combineEntities(
+                        (getOutputContent(JSON_DEFAULT_OUTPUT_TYPE)["Images"])![],
+                        [
+                            {
+                                "Occurrence" : occurrence.Core.TypedRawName,
+                                "BUILD_UNIT": (occurrence.Configuration.Settings.Build.BUILD_UNIT.Value)!"",
+                                "BUILD_REFERENCE": (occurrence.Configuration.Settings.Build.BUILD_REFERENCE.Value)!"",
+                                "BUILD_FORMATS": (occurrence.Configuration.Settings.Build.BUILD_FORMATS.Value[0])!"",
+                                "APP_REFERENCE": (occurrence.Configuration.Settings.Build.APP_REFERENCE.Value)!"",
+                                "BUILD_SOURCE": (occurrence.Configuration.Settings.Build.BUILD_SOURCE.Value)!""
+                            }
+                        ],
+                        APPEND_COMBINE_BEHAVIOUR
+                    )
+                }
+            /]
+        [/#if]
+    [/#list]
+[/#macro]

--- a/providers/shared/entrances/entrance.ftl
+++ b/providers/shared/entrances/entrance.ftl
@@ -3,6 +3,7 @@
 [#-- Shared Entrances --]
 [#assign BLUEPRINT_ENTRANCE_TYPE         = "blueprint" ]
 [#assign BUILDBLUEPRINT_ENTRANCE_TYPE    = "buildblueprint" ]
+[#assign IMAGEDETAILS_ENTRANCE_TYPE      = "imagedetails" ]
 [#assign CONFIGURATION_ENTRANCE_TYPE     = "configuration" ]
 [#assign DEPLOYMENT_ENTRANCE_TYPE        = "deployment" ]
 [#assign DEPLOYMENTTEST_ENTRANCE_TYPE    = "deploymenttest" ]

--- a/providers/shared/entrances/imagedetails/entrance.ftl
+++ b/providers/shared/entrances/imagedetails/entrance.ftl
@@ -1,0 +1,18 @@
+[#ftl]
+
+[#-- Entrance logic --]
+[#macro shared_entrance_imagedetails ]
+
+  [#assign allDeploymentUnits = true]
+
+  [#if getCLODeploymentUnitSubset() == "generationcontract" ]
+    [#assign allDeploymentUnits = false]
+  [/#if]
+
+  [@generateOutput
+      deploymentFramework=getCLODeploymentFramework()
+      type=getCLODeploymentOutputType()
+      format=getCLODeploymentOutputFormat()
+  /]
+
+[/#macro]

--- a/providers/shared/entrances/imagedetails/id.ftl
+++ b/providers/shared/entrances/imagedetails/id.ftl
@@ -1,0 +1,18 @@
+[#ftl]
+
+[@addEntrance
+    type=IMAGEDETAILS_ENTRANCE_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "Provide details of the images used by occurrences"
+            }
+        ]
+    commandlineoptions=[
+        {
+            "Names" : "*",
+            "Types" : ANY_TYPE
+        }
+    ]
+/]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds am imagedetails entrance which lists the build information for occurrences that have the information available
- Adds the source option to build information to show where the image came from

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Used to provide a query command to show what has been deployed to your environments

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

