### PR TITLE
feat: district based solutions

### DIFF
--- a/engine/bootstrap.ftl
+++ b/engine/bootstrap.ftl
@@ -33,6 +33,7 @@
 [#include "inputdata/reference.ftl" ]
 [#include "inputdata/setting.ftl" ]
 [#include "inputdata/seed.ftl" ]
+[#include "inputdata/solution.ftl" ]
 
 [#-- Plugin data loading --]
 [#include "extension.ftl" ]

--- a/engine/bootstrap.ftl
+++ b/engine/bootstrap.ftl
@@ -12,6 +12,7 @@
 [#include "flow.ftl" ]
 
 [#-- Dynamic Configuration entry points --]
+[#include "configuration/configuration.ftl"]
 [#include "configuration/attributeset.ftl"]
 [#include "configuration/blueprint.ftl"]
 [#include "configuration/component.ftl" ]
@@ -20,6 +21,7 @@
 [#include "configuration/layer.ftl"]
 [#include "configuration/module.ftl" ]
 [#include "configuration/reference.ftl" ]
+[#include "configuration/solution.ftl" ]
 [#include "configuration/task.ftl" ]
 [#include "configuration/dynamicvalues.ftl" ]
 

--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -111,34 +111,6 @@
     [/#if]
 [/#function]
 
-[#function getAppDataPublicFilePrefix occurrence={} ]
-    [#if segmentObject.Data.Public.Enabled ]
-        [#if occurrence?has_content]
-            [#local override =
-                getOccurrenceSettingValue(
-                    occurrence,
-                    [
-                        ["FilePrefixes", "AppPublic"],
-                        ["FilePrefixes", "AppData"],
-                        ["DefaultFilePrefix"]
-                    ], true) ]
-            [#return
-                formatRelativePath(
-                    "apppublic",
-                    valueIfContent(
-                        formatSegmentRelativePath(override),
-                        override,
-                        occurrence.Core.FullRelativePath
-                    )
-                ) ]
-        [#else]
-            [#return _context.Environment["APPDATA_PUBLIC_PREFIX"] ]
-        [/#if]
-    [#else]
-        [#return ""]
-    [/#if]
-[/#function]
-
 [#function getBackupsFilePrefix occurrence={} ]
     [#if occurrence?has_content ]
         [#return formatRelativePath("backups", occurrence.Core.FullRelativePath) ]

--- a/engine/configuration/configuration.ftl
+++ b/engine/configuration/configuration.ftl
@@ -1,0 +1,200 @@
+[#ftl]
+
+[#--
+Attribute extension
+
+Attribute extension is designed to permit providers to supplement any attributes
+defined in the shared provider. It is done in a way that permits multiple
+providers to extend the attributes simultaneously, but with extensions specific
+to the provider easily identified.
+
+A provider has two options - enrich an existing attribute or add namespaced attributes.
+
+** Attribute enrichment **
+
+If the name of the extension matches one of the names of the existing attributes,
+the attribute maintains its existing name, and the extension configuration is
+merged with the existing attribute configuration.
+
+Where the existing attribute has children, the extension is also expected to have
+children and attribute extension is recursively applied to each child.
+
+Where the extension provides possible values, any unique values are added to
+the existing attribute values. By default these values are prefixed based on the
+provided prefix attribute (a colon is used as a separator). However if the
+extension value starts with the provided disablePrefix, the disablePrefix is stripped.
+This allows a provider to contribute sharable as well as provider specific values.
+
+If the extension provides a default value, it will be merged with any existing
+value.
+
+If the extension provides an attribute set, this overrides any children definition
+currently on the existing attribute.
+
+** Namespaced attribute addition **
+
+If the extension names do not overlap those of the existing attributes, the extension
+is added to the list of attributes. All the extension names has the provided prefix
+added. Any Values or Default value are NOT prefixed, as they are defined within an
+already prefixed attribute.
+
+--]
+[#function extendAttributes attributes=[] extensions=[] prefix="" disablePrefix="shared:" ]
+
+    [#if ! extensions?has_content]
+        [#-- Nothing to do --]
+        [#return attributes]
+    [/#if]
+
+    [#local result = [] ]
+    [#local prefix = prefix?ensure_ends_with(":") ]
+
+    [#local attributes = expandCompositeConfiguration(attributes, true, false)]
+    [#local extensions = expandCompositeConfiguration(extensions, true, false)]
+
+    [#-- First extend existing attributes --]
+    [#list asArray(attributes) as attribute]
+
+        [#-- Check if any of the extensions have a name matching one of the existing attribute names --]
+        [#local attributeExtensions =
+            asArray(extensions)?filter(
+                e ->
+                    getArrayIntersection(
+                        asArray(attribute.Names),
+                        asArray(e.Names)
+                    )?has_content
+            )
+        ]
+
+        [#-- At most one extension should match the existing attribute --]
+        [#if attributeExtensions?size > 1]
+            [@warning
+                message="Multiple attribute extensions match attribute"
+                context={
+                    "Attribute" : attribute,
+                    "MatchingExtensions" : attributeExtensions
+                }
+            /]
+        [/#if]
+
+        [#if attributeExtensions?has_content]
+            [#local attributeExtension = attributeExtensions?first]
+            [#if (attribute.Children![])?has_content]
+                [#-- Recursively extend child definitions --]
+                [#if (attributeExtension.Children![])?has_content]
+                    [#local result += [
+                        mergeObjects(
+                            attribute,
+                            {
+                                "Children" : extendAttributes(
+                                                attribute.Children,
+                                                attributeExtension.Children,
+                                                prefix)
+                            }
+                        )
+                    ]]
+                [#else]
+                    [@fatal
+                        message="Attribute Extension missing children."
+                        context={
+                            "Attribute" : attribute,
+                            "Extension" : attributeExtension
+                        }
+                    /]
+                [/#if]
+            [#else]
+
+                [#local extendedAttributes = {}]
+                [#local extendedValues = (attribute.Values)![]]
+
+                [#-- Check for extra values --]
+                [#list (attributeExtension.Values)![] as extensionValue]
+
+                    [#if extensionValue?is_string ]
+                        [#-- If extension value starts with the disable prefix, --]
+                        [#-- value is shared so strip prefix, otherwise         --]
+                        [#-- force extension value to be prefixed               --]
+                        [#if prefix != disablePrefix ]
+                            [#local extendedValues +=
+                                [
+                                    extensionValue?starts_with(disablePrefix)?then(
+                                        extensionValue?remove_beginning(disablePrefix),
+                                        extensionValue?ensure_starts_with(prefix)
+                                    )
+                                ]]
+                        [#else]
+                            [#local extendedValues +=
+                                [
+                                    extensionValue?remove_beginning(disablePrefix)
+                                ]
+                            ]
+                        [/#if]
+                    [#else ]
+                        [#local extendedValues += extensionValue ]
+                    [/#if]
+
+                    [#-- At least one extended value so update the values list --]
+                    [#local extendedAttributes += {
+                        "Values" : getUniqueArrayElements(extendedValues)
+                    }]
+
+                [/#list]
+
+                [#-- Check for different default --]
+                [#if ((attributeExtension.Default)!"")?has_content ]
+                    [#local extendedAttributes += {
+                        "Default" : attributeExtension.Default
+                    } ]
+                [/#if]
+
+                [#-- Extension has extra attributes defined via an attribute set --]
+                [#if ((attributeExtension.AttributeSet)![])?has_content ]
+                    [#local extendedAttributes += {
+                        "AttributeSet" : attributeExtension.AttributeSet,
+                        "Children" : []
+                    }]
+                [/#if]
+
+                [#local result += [
+                    mergeObjects(
+                        attribute,
+                        extendedAttributes
+                    )]]
+            [/#if]
+        [#else]
+            [#local result += [attribute]]
+        [/#if]
+    [/#list]
+
+    [#-- Deal with any new attributes contributed by the extensions --]
+    [#local additionalAttributes = [] ]
+    [#list extensions as extension ]
+
+        [#-- Check if the extension has a name matching one of the existing attribute names --]
+        [#-- If it does, it will already have been processed                                --]
+        [#if !
+            asArray(attributes)?filter(
+                a ->
+                    getArrayIntersection(
+                        asArray(extension.Names),
+                        asArray(a.Names)
+                    )?has_content
+            )?has_content
+        ]
+            [#-- The provided extension names will be prefixed. Any values or default are --]
+            [#-- NOT prefixed given that the extension names are prefixed.                --]
+            [#local additionalAttributes +=
+                addPrefixToAttributes(
+                    [ extension ],
+                    prefix,
+                    true,
+                    false,
+                    false
+                )
+            ]
+        [/#if]
+    [/#list]
+    [#local result += additionalAttributes ]
+
+    [#return result]
+[/#function]

--- a/engine/configuration/solution.ftl
+++ b/engine/configuration/solution.ftl
@@ -86,15 +86,12 @@
                 "Description": "Defines the components that belong to a district",
                 "SubObjects" : true,
                 "Children" : combineEntities(
-                    (getConfigurationSet(SOLUTION_CONFIGURATION_SCOPE, DISTRICT_SOLUTION_CONFIGURATION_SET)["Attributes"])![]
+                    (getConfigurationSet(SOLUTION_CONFIGURATION_SCOPE, DISTRICT_SOLUTION_CONFIGURATION_SET)["Attributes"])![],
                     (getConfigurationSet(SOLUTION_CONFIGURATION_SCOPE, SOLUTION_CONFIGURATION_SET)["Attributes"])![],
                     APPEND_COMBINE_BEHAVIOUR
                 )
             }
-        ] +
-
-        [#-- Supports the existing solution layout which uses the root --]
-        (getConfigurationSet(SOLUTION_CONFIGURATION_SCOPE, SOLUTION_CONFIGURATION_SET)["Attributes"])![]
+        ]
     /]
 
 [/#macro]

--- a/engine/configuration/solution.ftl
+++ b/engine/configuration/solution.ftl
@@ -1,0 +1,100 @@
+[#ftl]
+
+[#-- Solutions define the components that will be deployed into districts --]
+[#assign SOLUTION_CONFIGURATION_SCOPE = "Solution"]
+[#assign SOLUTION_EXTENSIONS_CONFIGURATION_SCOPE = "SolutionExtensions" ]
+
+[#assign SOLUTION_CONFIGURATION_SET = "_default"]
+[#assign DISTRICT_SOLUTION_CONFIGURATION_SET = "_district"]
+
+[@addConfigurationScope
+    id=SOLUTION_CONFIGURATION_SCOPE
+    description="Solutions define the components in a district"
+/]
+
+[@addConfigurationScope
+    id=SOLUTION_EXTENSIONS_CONFIGURATION_SCOPE
+    description="A collection of the solution extensions that contribute to the overall solution"
+/]
+
+[#-- Add a specific district based configuration set district based solutions --]
+[@addConfigurationSet
+    scopeId=SOLUTION_CONFIGURATION_SCOPE
+    id=DISTRICT_SOLUTION_CONFIGURATION_SET
+    attributes=[
+        {
+            "Names" : "District",
+            "Descriptions" : "Defines the layers that the solution applies to",
+            "Children" : [
+                {
+                    "Names" : "Type",
+                    "Description" : "The type of district the solution applies to",
+                    "Default" : "segment"
+                },
+                {
+                    "Names" : "Layers",
+                    "Description": "The layers to match in a given district",
+                    "SubObjects" : true,
+                    "Children" : [
+                        {
+                            "Names" : "Type",
+                            "Description" : "The type of layer the solution applies to",
+                            "Types": STRING_TYPE,
+                            "Mandatory": true
+                        },
+                        {
+                            "Names": "Id",
+                            "Description" : "The Id of a layer the solution applies to - * applies to all layers that match the type",
+                            "Types" : STRING_TYPE,
+                            "Default" : "*"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+/]
+
+
+[#macro extendSolutionConfiguration id attributes provider]
+
+    [@addConfigurationSet
+        scopeId=SOLUTION_EXTENSIONS_CONFIGURATION_SCOPE
+        id=id
+        attributes=attribues
+    /]
+
+    [#local extendedAttributes = extendAttributes(
+        (getConfigurationSet(SOLUTION_CONFIGURATION_SCOPE, SOLUTION_CONFIGURATION_SET)["Attributes"])![],
+        attributes,
+        provider
+    )]
+
+    [@addConfigurationSet
+        scopeId=SOLUTION_CONFIGURATION_SCOPE
+        id=SOLUTION_CONFIGURATION_SET
+        attributes=extendedAttributes
+    /]
+
+    [@addConfigurationSet
+        scopeId=BLUEPRINT_CONFIGURATION_SCOPE
+        id="Solution"
+        properties=properties
+        attributes=[
+            {
+                "Names" : "Solutions",
+                "Description": "Defines the components that belong to a district",
+                "SubObjects" : true,
+                "Children" : combineEntities(
+                    (getConfigurationSet(SOLUTION_CONFIGURATION_SCOPE, DISTRICT_SOLUTION_CONFIGURATION_SET)["Attributes"])![]
+                    (getConfigurationSet(SOLUTION_CONFIGURATION_SCOPE, SOLUTION_CONFIGURATION_SET)["Attributes"])![],
+                    APPEND_COMBINE_BEHAVIOUR
+                )
+            }
+        ] +
+
+        [#-- Supports the existing solution layout which uses the root --]
+        (getConfigurationSet(SOLUTION_CONFIGURATION_SCOPE, SOLUTION_CONFIGURATION_SET)["Attributes"])![]
+    /]
+
+[/#macro]

--- a/engine/configuration/solution.ftl
+++ b/engine/configuration/solution.ftl
@@ -23,6 +23,12 @@
     id=DISTRICT_SOLUTION_CONFIGURATION_SET
     attributes=[
         {
+            "Names": "Priority",
+            "Description" : "The priority order for the inclusion of this solution - Lowest = last loaded",
+            "Types" : NUMBER_TYPE,
+            "Default" : 100
+        },
+        {
             "Names" : "District",
             "Descriptions" : "Defines the layers that the solution applies to",
             "Children" : [
@@ -95,3 +101,12 @@
     /]
 
 [/#macro]
+
+
+[#function getSolutionConfiguration ]
+    [#local result = []]
+    [#list getConfigurationSets(SOLUTION_CONFIGURATION_SCOPE) as set]
+        [#local result = combineEntities(result, set.Attributes, APPEND_COMBINE_BEHAVIOUR)]
+    [/#list]
+    [#return result]
+[/#function]

--- a/engine/inputdata/solution.ftl
+++ b/engine/inputdata/solution.ftl
@@ -1,0 +1,54 @@
+[#ftl]
+
+[#function getSolution ]
+    [#local result = {}]
+
+
+
+    [#return {}]
+[/#function]
+
+
+[#-- Active tiers --]
+[#function getTiers]
+    [#local result = [] ]
+
+    [#if isLayerActive(SEGMENT_LAYER_TYPE) ]
+        [#local blueprintTiers = getBlueprint().Tiers!{} ]
+        [#local segmentObject = getActiveLayer(SEGMENT_LAYER_TYPE) ]
+
+        [#list segmentObject.Tiers.Order as tierId]
+            [#local blueprintTier = (blueprintTiers[tierId])!{} ]
+            [#if ! (blueprintTier?has_content) ]
+                [#continue]
+            [/#if]
+            [#local tierNetwork =
+                {
+                    "Enabled" : false
+                } ]
+
+            [#if blueprintTier.Components?has_content || ((blueprintTier.Required)!false)]
+                [#if (blueprintTier.Network.Enabled)!false ]
+                    [#list segmentObject.Network.Tiers.Order![] as networkTier]
+                        [#if networkTier == tierId]
+                            [#local tierNetwork =
+                                blueprintTier.Network +
+                                {
+                                    "Index" : networkTier?index,
+                                    "Link" : addIdNameToObject(blueprintTier.Network.Link, "network")
+                                } ]
+                            [#break]
+                        [/#if]
+                    [/#list]
+                [/#if]
+                [#local result +=
+                    [
+                        addIdNameToObject(blueprintTier, tierId) +
+                        { "Network" : tierNetwork }
+                    ] ]
+            [/#if]
+        [/#list]
+    [/#if]
+
+    [#return result]
+[/#function]

--- a/engine/inputdata/solution.ftl
+++ b/engine/inputdata/solution.ftl
@@ -82,13 +82,14 @@
         [/#if]
     [/#list]
 
-    [#list solutionTiers?sort_by("Index") as tier ]
+    [#list (getActiveSolution().Tiers)!{} as id, tier ]
         [#if tier.Components?has_content]
             [#local result = combineEntities(
                 result,
                 [
                     mergeObjects(
                         tier,
+                        addIdNameToObject(tier, id)
                         {
                             "Active" : true
                         }

--- a/engine/inputdata/solution.ftl
+++ b/engine/inputdata/solution.ftl
@@ -1,54 +1,102 @@
 [#ftl]
 
-[#function getSolution ]
-    [#local result = {}]
+[#---------------------------------------------
+-- Public functions for Solution processing --
+-----------------------------------------------]
+[#assign solutionData = {}]
 
+[#macro includeSolutionData blueprint ]
+    [#local configuration = getSolutionConfiguration()]
 
+    [#-- Get the blueprint base Tiers object to include as a Segment solution --]
+    [#if isLayerActive(SEGMENT_LAYER_TYPE)]
 
-    [#return {}]
+        [#local segmentObject = getActiveLayer(SEGMENT_LAYER_TYPE) ]
+
+        [#local tiers = {}]
+        [#list (blueprint.Tiers)!{} as id, tier ]
+            [#local indexedTier = mergeObjects(tier, { "Index": (segmentObject.Network.Tiers.Order![])?seq_index_of(id) })]
+            [#local tiers = mergeObjects( tiers, { id : indexedTier })]
+        [/#list]
+
+        [#local baseSegmentSolutionData = {
+            "Priority" : 900,
+            "District" : {
+                "Type" : "segment",
+                "Layers" : {
+                    "all_segments" : {
+                        "Type" : SEGMENT_LAYER_TYPE,
+                        "Id" : "*"
+                    }
+                }
+            },
+            "Tiers" : tiers
+        }]
+        [#assign solutionData = mergeObjects(solutionData, { "_baseSegmentTiers" : getCompositeObject(configuration, baseSegmentSolutionData)})]
+    [/#if]
+
+    [#list (blueprint.Solutions)!{} as id, solution]
+        [#assign solutionData = mergeObjects(solutionData, { id: getCompositeObject(configuration, solution)})]
+    [/#list]
+[/#macro]
+
+[#function getSolutions ]
+    [#return solutionData]
 [/#function]
 
+[#function getActiveSolution ]
+    [#local result = {}]
+
+    [#local activeLayers = getActiveLayers()]
+
+    [#list getSolutions()?values?filter(
+            x-> x.District.Type == getCommandLineOptions()["Input"]["Filter"]["DistrictType"]
+        )?sort_by("Priority")?reverse as solution ]
+
+        [#list (solution.District.Layers)?values as layerFilter ]
+            [#if activeLayers[layerFilter.Type]?? && ( layerFilter.Id == "*" || layerFilter.Id == activeLayers[layerFilter.Type].Id ) ]
+                [#local result = mergeObjects(result, solution)]
+            [/#if]
+        [/#list]
+    [/#list]
+
+    [#return result]
+[/#function]
 
 [#-- Active tiers --]
 [#function getTiers]
     [#local result = [] ]
 
-    [#if isLayerActive(SEGMENT_LAYER_TYPE) ]
-        [#local blueprintTiers = getBlueprint().Tiers!{} ]
-        [#local segmentObject = getActiveLayer(SEGMENT_LAYER_TYPE) ]
+    [#local solutionTiers = ((getActiveSolution().Tiers)!{})?values?filter(x -> (x.Index)?is_number && x.Index > 0) ]
+    [#local tierIndexes = solutionTiers?map(x -> x.Index) ]
+    [#list tierIndexes as i ]
+        [#if tierIndexes?seq_index_of(i) != tierIndexes?seq_last_index_of(i) ]
+            [@fatal
+                message="Duplicate tier index found"
+                detail="All tiers must have a unique index to ensure network placement"
+                context={
+                    "Tiers" : solutionTiers?values,
+                    "TierIndexes" : tierIndexes
+                }
+            /]
+        [/#if]
+    [/#list]
 
-        [#list segmentObject.Tiers.Order as tierId]
-            [#local blueprintTier = (blueprintTiers[tierId])!{} ]
-            [#if ! (blueprintTier?has_content) ]
-                [#continue]
-            [/#if]
-            [#local tierNetwork =
-                {
-                    "Enabled" : false
-                } ]
-
-            [#if blueprintTier.Components?has_content || ((blueprintTier.Required)!false)]
-                [#if (blueprintTier.Network.Enabled)!false ]
-                    [#list segmentObject.Network.Tiers.Order![] as networkTier]
-                        [#if networkTier == tierId]
-                            [#local tierNetwork =
-                                blueprintTier.Network +
-                                {
-                                    "Index" : networkTier?index,
-                                    "Link" : addIdNameToObject(blueprintTier.Network.Link, "network")
-                                } ]
-                            [#break]
-                        [/#if]
-                    [/#list]
-                [/#if]
-                [#local result +=
-                    [
-                        addIdNameToObject(blueprintTier, tierId) +
-                        { "Network" : tierNetwork }
-                    ] ]
-            [/#if]
-        [/#list]
-    [/#if]
+    [#list solutionTiers?sort_by("Index") as tier ]
+        [#if tier.Components?has_content]
+            [#local result = combineEntities(
+                result,
+                [
+                    mergeObjects(
+                        tier,
+                        {
+                            "Active" : true
+                        }
+                    )
+                ]
+            )]
+        [/#if]
+    [/#list]
 
     [#return result]
 [/#function]

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -635,26 +635,35 @@
 
 [#function internalCreateOccurrenceCoreSettings occurrence]
     [#local core = occurrence.Core ]
+    [#local layerSettings = {}]
+    [#list getActiveLayers() as type, layer ]
+        [#local layerSettings = mergeObjects(
+            layerSettings,
+            {
+                type?upper_case : layer.Name
+            }
+        )]
+    [/#list]
+
     [#return
         asFlattenedSettings(
-            {
-                "TEMPLATE_TIMESTAMP" : .now?iso_utc,
-                "PRODUCT" : productName,                [#-- Have a layer setup --]
-                "ENVIRONMENT" : environmentName,
-                "SEGMENT" : segmentName,
-                "TIER" : core.Tier.Name,
-                "COMPONENT" : core.Component.Name,
-                "COMPONENT_INSTANCE" : core.Instance.Name,
-                "COMPONENT_VERSION" : core.Version.Name,
-                "REQUEST_REFERENCE" : getCLORequestReference(),
-                "CONFIGURATION_REFERENCE" : getCLOConfigurationReference(),
-                "APPDATA_PREFIX" : getAppDataFilePrefix(occurrence),
-                "APPSETTINGS_PREFIX" : getSettingsFilePrefix(occurrence),
-                "CREDENTIALS_PREFIX" : getSettingsFilePrefix(occurrence),
-                "SETTINGS_PREFIX" : getSettingsFilePrefix(occurrence)
-            } +
+            mergeObjects(
+                layerSettings,
+                {
+                    "TEMPLATE_TIMESTAMP" : .now?iso_utc,
+                    "TIER" : core.Tier.Name,
+                    "COMPONENT" : core.Component.Name,
+                    "COMPONENT_INSTANCE" : core.Instance.Name,
+                    "COMPONENT_VERSION" : core.Version.Name,
+                    "REQUEST_REFERENCE" : getCLORequestReference(),
+                    "CONFIGURATION_REFERENCE" : getCLOConfigurationReference(),
+                    "APPDATA_PREFIX" : getAppDataFilePrefix(occurrence),
+                    "APPSETTINGS_PREFIX" : getSettingsFilePrefix(occurrence),
+                    "CREDENTIALS_PREFIX" : getSettingsFilePrefix(occurrence),
+                    "SETTINGS_PREFIX" : getSettingsFilePrefix(occurrence)
+                }
+            ) +
             attributeIfContent("SUBCOMPONENT", (core.SubComponent.Name)!"") +
-            attributeIfContent("APPDATA_PUBLIC_PREFIX", getAppDataPublicFilePrefix(occurrence)) +
             attributeIfContent("SES_REGION", (productObject.SES.Region)!"")         [#-- Should be removed and made into something else - standard extension --]
         )
     ]
@@ -679,7 +688,7 @@
     [#local occurrenceBuild =
         internalCreateOccurrenceSettings(
             (getSettings().Builds.Products)!{},
-            productName,
+            getDistrictFullNameParts(getInputFilter())[0],
             cmdbProductLookupPrefixes,
             namespaces
         ) ]
@@ -714,7 +723,7 @@
             [#local nextReference =
                 internalCreateOccurrenceSettings(
                     (getSettings().Builds.Products)!{},
-                    productName,
+                    getDistrictFullNameParts(getInputFilter())[0],
                     buildLookupPrefixes,
                     [
                         {"Key" : formattedReference, "Match" : "exact"}
@@ -791,7 +800,7 @@
     [#return
         internalCreateOccurrenceSettings(
             (getSettings().Settings.Products)!{},
-            productName,
+            getDistrictFullNameParts(getInputFilter())[0],
             cmdbProductLookupPrefixes,
             namespaces) ]
 [/#function]
@@ -803,7 +812,7 @@
         markAsSensitiveSettings(
             internalCreateOccurrenceSettings(
                 (getSettings().Sensitive.Products)!{},
-                productName,
+                getDistrictFullNameParts(getInputFilter())[0],
                 cmdbProductLookupPrefixes,
                 namespaces) ) ]
 [/#function]

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -390,205 +390,6 @@
     [#return occurrence]
 [/#function]
 
-[#--
-Attribute extension
-
-Attribute extension is designed to permit providers to supplement any attributes
-defined in the shared provider. It is done in a way that permits multiple
-providers to extend the attributes simultaneously, but with extensions specific
-to the provider easily identified.
-
-A provider has two options - enrich an existing attribute or add namespaced attributes.
-
-** Attribute enrichment **
-
-If the name of the extension matches one of the names of the existing attributes,
-the attribute maintains its existing name, and the extension configuration is
-merged with the existing attribute configuration.
-
-Where the existing attribute has children, the extension is also expected to have
-children and attribute extension is recursively applied to each child.
-
-Where the extension provides possible values, any unique values are added to
-the existing attribute values. By default these values are prefixed based on the
-provided prefix attribute (a colon is used as a separator). However if the
-extension value starts with the provided disablePrefix, the disablePrefix is stripped.
-This allows a provider to contribute sharable as well as provider specific values.
-
-If the extension provides a default value, it will be merged with any existing
-value.
-
-If the extension provides an attribute set, this overrides any children definition
-currently on the existing attribute.
-
-** Namespaced attribute addition **
-
-If the extension names do not overlap those of the existing attributes, the extension
-is added to the list of attributes. All the extension names has the provided prefix
-added. Any Values or Default value are NOT prefixed, as they are defined within an
-already prefixed attribute.
-
---]
-[#function extendAttributes attributes=[] extensions=[] prefix="" disablePrefix="shared:" ]
-
-    [#if ! extensions?has_content]
-        [#-- Nothing to do --]
-        [#return attributes]
-    [/#if]
-
-    [#local result = [] ]
-    [#local prefix = prefix?ensure_ends_with(":") ]
-
-    [#local attributes = expandCompositeConfiguration(attributes, true, false)]
-    [#local extensions = expandCompositeConfiguration(extensions, true, false)]
-
-    [#-- First extend existing attributes --]
-    [#list asArray(attributes) as attribute]
-
-        [#-- Check if any of the extensions have a name matching one of the existing attribute names --]
-        [#local attributeExtensions =
-            asArray(extensions)?filter(
-                e ->
-                    getArrayIntersection(
-                        asArray(attribute.Names),
-                        asArray(e.Names)
-                    )?has_content
-            )
-        ]
-
-        [#-- At most one extension should match the existing attribute --]
-        [#if attributeExtensions?size > 1]
-            [@warning
-                message="Multiple attribute extensions match attribute"
-                context={
-                    "Attribute" : attribute,
-                    "MatchingExtensions" : attributeExtensions
-                }
-            /]
-        [/#if]
-
-        [#if attributeExtensions?has_content]
-            [#local attributeExtension = attributeExtensions?first]
-            [#if (attribute.Children![])?has_content]
-                [#-- Recursively extend child definitions --]
-                [#if (attributeExtension.Children![])?has_content]
-                    [#local result += [
-                        mergeObjects(
-                            attribute,
-                            {
-                                "Children" : extendAttributes(
-                                                attribute.Children,
-                                                attributeExtension.Children,
-                                                prefix)
-                            }
-                        )
-                    ]]
-                [#else]
-                    [@fatal
-                        message="Attribute Extension missing children."
-                        context={
-                            "Attribute" : attribute,
-                            "Extension" : attributeExtension
-                        }
-                    /]
-                [/#if]
-            [#else]
-
-                [#local extendedAttributes = {}]
-                [#local extendedValues = (attribute.Values)![]]
-
-                [#-- Check for extra values --]
-                [#list (attributeExtension.Values)![] as extensionValue]
-
-                    [#if extensionValue?is_string ]
-                        [#-- If extension value starts with the disable prefix, --]
-                        [#-- value is shared so strip prefix, otherwise         --]
-                        [#-- force extension value to be prefixed               --]
-                        [#if prefix != disablePrefix ]
-                            [#local extendedValues +=
-                                [
-                                    extensionValue?starts_with(disablePrefix)?then(
-                                        extensionValue?remove_beginning(disablePrefix),
-                                        extensionValue?ensure_starts_with(prefix)
-                                    )
-                                ]]
-                        [#else]
-                            [#local extendedValues +=
-                                [
-                                    extensionValue?remove_beginning(disablePrefix)
-                                ]
-                            ]
-                        [/#if]
-                    [#else ]
-                        [#local extendedValues += extensionValue ]
-                    [/#if]
-
-                    [#-- At least one extended value so update the values list --]
-                    [#local extendedAttributes += {
-                        "Values" : getUniqueArrayElements(extendedValues)
-                    }]
-
-                [/#list]
-
-                [#-- Check for different default --]
-                [#if ((attributeExtension.Default)!"")?has_content ]
-                    [#local extendedAttributes += {
-                        "Default" : attributeExtension.Default
-                    } ]
-                [/#if]
-
-                [#-- Extension has extra attributes defined via an attribute set --]
-                [#if ((attributeExtension.AttributeSet)![])?has_content ]
-                    [#local extendedAttributes += {
-                        "AttributeSet" : attributeExtension.AttributeSet,
-                        "Children" : []
-                    }]
-                [/#if]
-
-                [#local result += [
-                    mergeObjects(
-                        attribute,
-                        extendedAttributes
-                    )]]
-            [/#if]
-        [#else]
-            [#local result += [attribute]]
-        [/#if]
-    [/#list]
-
-    [#-- Deal with any new attributes contributed by the extensions --]
-    [#local additionalAttributes = [] ]
-    [#list extensions as extension ]
-
-        [#-- Check if the extension has a name matching one of the existing attribute names --]
-        [#-- If it does, it will already have been processed                                --]
-        [#if !
-            asArray(attributes)?filter(
-                a ->
-                    getArrayIntersection(
-                        asArray(extension.Names),
-                        asArray(a.Names)
-                    )?has_content
-            )?has_content
-        ]
-            [#-- The provided extension names will be prefixed. Any values or default are --]
-            [#-- NOT prefixed given that the extension names are prefixed.                --]
-            [#local additionalAttributes +=
-                addPrefixToAttributes(
-                    [ extension ],
-                    prefix,
-                    true,
-                    false,
-                    false
-                )
-            ]
-        [/#if]
-    [/#list]
-    [#local result += additionalAttributes ]
-
-    [#return result]
-[/#function]
-
 [#function constructOccurrenceAttributes occurrence]
     [#local attributes = [] ]
 
@@ -838,7 +639,7 @@ already prefixed attribute.
         asFlattenedSettings(
             {
                 "TEMPLATE_TIMESTAMP" : .now?iso_utc,
-                "PRODUCT" : productName,
+                "PRODUCT" : productName,                [#-- Have a layer setup --]
                 "ENVIRONMENT" : environmentName,
                 "SEGMENT" : segmentName,
                 "TIER" : core.Tier.Name,
@@ -854,7 +655,7 @@ already prefixed attribute.
             } +
             attributeIfContent("SUBCOMPONENT", (core.SubComponent.Name)!"") +
             attributeIfContent("APPDATA_PUBLIC_PREFIX", getAppDataPublicFilePrefix(occurrence)) +
-            attributeIfContent("SES_REGION", (productObject.SES.Region)!"")
+            attributeIfContent("SES_REGION", (productObject.SES.Region)!"")         [#-- Should be removed and made into something else - standard extension --]
         )
     ]
 [/#function]

--- a/engine/provider.ftl
+++ b/engine/provider.ftl
@@ -294,6 +294,22 @@
                 /]
             [/#list]
 
+            [#-- Determine the solution extensions for the provider --]
+            [#local directories =
+                internalGetPluginFiles(
+                    [providerMarker.Path, "solution"],
+                    [
+                        ["[^/]+"]
+                    ]
+                )
+            ]
+            [#list directories as directory]
+                [@internalIncludeTemplatesInDirectory
+                    directory,
+                    [ "id", "solution" ]
+                /]
+            [/#list]
+
             [#-- Determine the modules for the provider --]
             [#local directories =
                 internalGetPluginFiles(

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -146,7 +146,6 @@
     [#return (getRegions()[contentIfContent( region, getAccountRegion() ) ])!{} ]
 [/#function]
 
-
 [#-- Active zones --]
 [#function getZones]
     [#local result = [] ]
@@ -180,6 +179,9 @@
 [#macro setContext]
 
     [#assign blueprintObject = getBlueprint() ]
+
+    [#-- Load the solution data that will be used for occurrences --]
+    [@includeSolutionData blueprintObject /]
 
     [#-- Load reference data for any references defined by providers --]
     [@includeReferences blueprintObject /]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -146,49 +146,6 @@
     [#return (getRegions()[contentIfContent( region, getAccountRegion() ) ])!{} ]
 [/#function]
 
-[#-- Active tiers --]
-[#function getTiers]
-    [#local result = [] ]
-
-    [#if isLayerActive(SEGMENT_LAYER_TYPE) ]
-        [#local blueprintTiers = getBlueprint().Tiers!{} ]
-        [#local segmentObject = getActiveLayer(SEGMENT_LAYER_TYPE) ]
-
-        [#list segmentObject.Tiers.Order as tierId]
-            [#local blueprintTier = (blueprintTiers[tierId])!{} ]
-            [#if ! (blueprintTier?has_content) ]
-                [#continue]
-            [/#if]
-            [#local tierNetwork =
-                {
-                    "Enabled" : false
-                } ]
-
-            [#if blueprintTier.Components?has_content || ((blueprintTier.Required)!false)]
-                [#if (blueprintTier.Network.Enabled)!false ]
-                    [#list segmentObject.Network.Tiers.Order![] as networkTier]
-                        [#if networkTier == tierId]
-                            [#local tierNetwork =
-                                blueprintTier.Network +
-                                {
-                                    "Index" : networkTier?index,
-                                    "Link" : addIdNameToObject(blueprintTier.Network.Link, "network")
-                                } ]
-                            [#break]
-                        [/#if]
-                    [/#list]
-                [/#if]
-                [#local result +=
-                    [
-                        addIdNameToObject(blueprintTier, tierId) +
-                        { "Network" : tierNetwork }
-                    ] ]
-            [/#if]
-        [/#list]
-    [/#if]
-
-    [#return result]
-[/#function]
 
 [#-- Active zones --]
 [#function getZones]

--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -1976,21 +1976,21 @@
     "segment": {
       "Priority": 100,
       "Level": "segment",
-      "DistrictType": "segment",
+      "DistrictType": "*",
       "OutputPrefix": "seg",
       "ResourceSets": {}
     },
     "solution": {
       "Priority": 200,
       "Level": "solution",
-      "DistrictType": "segment",
+      "DistrictType": "*",
       "OutputPrefix": "soln",
       "ResourceSets": {}
     },
     "application": {
       "Priority": 300,
       "Level": "application",
-      "DistrictType": "segment",
+      "DistrictType": "*",
       "OutputPrefix": "app",
       "ResourceSets": {}
     }

--- a/providers/shared/layers/Segment/id.ftl
+++ b/providers/shared/layers/Segment/id.ftl
@@ -201,21 +201,6 @@
             "Names" : "Data",
             "Children" : [
                 {
-                    "Names" : "Public",
-                    "Children" : [
-                        {
-                            "Names" : "Enabled",
-                            "Types" : BOOLEAN_TYPE,
-                            "Default" : false
-                        },
-                        {
-                            "Names" : [ "IPAddressGroups", "IPWhitelist" ],
-                            "Types" : ARRAY_OF_STRING_TYPE,
-                            "Default" : []
-                        }
-                    ]
-                },
-                {
                     "Names" : "Expiration",
                     "Types" : [ NUMBER_TYPE, STRING_TYPE ]
                 },

--- a/providers/shared/provider.ftl
+++ b/providers/shared/provider.ftl
@@ -19,7 +19,8 @@
     [#if deploymentModeDetails?has_content ]
         [#local executionPolicy = deploymentModeDetails.ExecutionPolicy ]
 
-        [#if deploymentGroupDetails.DistrictType == getCommandLineOptions()["Input"]["Filter"]["DistrictType"] ]
+        [#if deploymentGroupDetails.DistrictType == "*" ||
+                deploymentGroupDetails.DistrictType == getCommandLineOptions()["Input"]["Filter"]["DistrictType"] ]
 
             [#local mandatoryContract = false]
             [#switch executionPolicy ]

--- a/providers/shared/references/DeploymentGroup/id.ftl
+++ b/providers/shared/references/DeploymentGroup/id.ftl
@@ -32,7 +32,7 @@
             "Names" : "DistrictType",
             "Description" : "The DistrictType to include as part of the Deployment Group",
             "Types" : STRING_TYPE,
-            "Mandatory" : true
+            "Default" : "*"
         },
         {
             "Names" : "OutputPrefix",

--- a/providers/shared/solution/tiers/solution.ftl
+++ b/providers/shared/solution/tiers/solution.ftl
@@ -1,0 +1,41 @@
+[#ftl]
+
+[@extendSolutionConfiguration
+    id="Tiers"
+    provider=SHARED_PROVIDER
+    attributes=[
+        {
+            "Names" : "Tiers",
+            "SubObjects" : true,
+            "Children" : [
+                {
+                    "Names" : "Network",
+                    "Children" : [
+                        {
+                            "Names" : "Link",
+                            "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+                        },
+                        {
+                            "Names" : "RouteTable",
+                            "Types" : STRING_TYPE
+                        },
+                        {
+                            "Names" : "NetworkACL",
+                            "Types" : STRING_TYPE
+                        }
+                    ]
+                },
+                {
+                    "Names" : "Components",
+                    "SubObjects" : true,
+                    "Children" : [
+                        {
+                            "Names" : "*",
+                            "Types" : OBJECT_TYPE
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+/]

--- a/providers/shared/solution/tiers/solution.ftl
+++ b/providers/shared/solution/tiers/solution.ftl
@@ -9,8 +9,25 @@
             "SubObjects" : true,
             "Children" : [
                 {
+                    "Names" : "Index",
+                    "Description" : "A unique index number used when ordering tiers",
+                    "Types" : NUMBER_TYPE,
+                    "Mandatory" : true
+                },
+                {
+                    "Names" : "Active",
+                    "Description" : "Defines if the layer should be used. Automatically true if components are defined",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
                     "Names" : "Network",
                     "Children" : [
+                        {
+                            "Names" : "Enabled",
+                            "Types" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
                         {
                             "Names" : "Link",
                             "AttributeSet" : LINK_ATTRIBUTESET_TYPE
@@ -27,13 +44,7 @@
                 },
                 {
                     "Names" : "Components",
-                    "SubObjects" : true,
-                    "Children" : [
-                        {
-                            "Names" : "*",
-                            "Types" : OBJECT_TYPE
-                        }
-                    ]
+                    "Types" : ANY_TYPE
                 }
             ]
         }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for defining solutions which are applied to a matching district
- Adds support for defining and extending the configuration that makes up the solution

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Makes it possible for other districts like the account district to have its own solution/components. Extensions of the solution allow for different ways to define how the district might work, the Tiers model is the primary one for defining components but there might be other configuration approaches that would align with being used in solutions. 

Solutions are merged into each other if multiple matches for a given district are found for an available solution, this allow for solutions to be broken up into more relevant chunks but still need to be deployed into the same segment/environment. 

Backwards compatibility is in place with the current root level Tiers object mapping to a segment level solution applied to all layers as a filter. This ensures that the transition to a object based solution is easy. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally on existing test suite. 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

