### PR TITLE
refactor: move multiAZ to standard component configuraiton

### DIFF
--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -1718,22 +1718,13 @@ are added.
 
 [#macro validateCompositeObject attributes=[] objects=[] ]
 
-    [#-- Common Parameters that are used throughout        --]
-    [#-- but are as-yet unaccounted for in the             --]
-    [#-- composite object definitions.                     --]
-    [#-- TODO(rossmurr4y): add commonParams to definitions --]
-    [#local commonParams = [
-        "multiAZ", "MultiAZ"]
-    ]
-
     [#local attributes = normaliseCompositeConfiguration(attributes)]
 
     [#local validKeys = asFlattenedArray(attributes?map(c -> (c?is_hash && c.Names??)?then(c.Names, c)))]
     [#list asFlattenedArray(objects) as object]
         [#list object?keys as key]
             [#if !(validKeys?seq_contains("*")) &&
-                    !(validKeys?seq_contains(key)) &&
-                    !(commonParams?seq_contains(key))]
+                    !(validKeys?seq_contains(key)) ]
 
                 [@fatal
                     message="Invalid Attribute Found."

--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -273,7 +273,7 @@
     [#return getOccurrenceProfile(occurrence, "Processor", PROCESSOR_REFERENCE_TYPE, profileName, type)]
 [/#function]
 
-[#function getProcessorCounts processorProfile multiAz=false desiredCount="" minCount="" maxCount="" ]
+[#function getProcessorCounts processorProfile multiAZ=false desiredCount="" minCount="" maxCount="" ]
 
     [#local fixedMaxCount = maxCount?has_content?then(
                                 maxCount,

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -354,10 +354,6 @@
         [#assign rotateKeys = segmentObject.RotateKeys ]
 
         [#assign network = segmentObject.Network ]
-        [#assign internetAccess = network.InternetAccess]
-
-        [#assign natEnabled = internetAccess && segmentObject.NAT.Enabled ]
-        [#assign natHosted = segmentObject.NAT.Hosted]
 
         [#assign sshEnabled = segmentObject.Bastion.Enabled ]
         [#assign sshActive = sshEnabled && segmentObject.Bastion.Active ]
@@ -385,29 +381,6 @@
 
         [#assign flowlogsOffline =
                         getActiveLayerAttributes( ["Operations", "FlowLogs", "Offline"], [ SEGMENT_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE ], "" )[0] ]
-    [/#if]
-
-    [#-- Solution --]
-    [#if isLayerActive(SOLUTION_LAYER_TYPE) ]
-        [#assign solutionObject = getActiveLayer(SOLUTION_LAYER_TYPE) ]
-        [#if ((solutionObject.Id)!"")?has_content ]
-            [#assign solnMultiAZ =
-                        getActiveLayerAttributes( ["MultiAZ" ], [ SOLUTION_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE ], false )[0] ]
-            [#assign RDSAutoMinorVersionUpgrade =
-                        getActiveLayerAttributes( ["RDS", "AutoMinorVersionUpgrade" ], [ SEGMENT_LAYER_TYPE, SOLUTION_LAYER_TYPE, ENVIRONMENT_LAYER_TYPE ], true )[0] ]
-
-            [#assign natPerAZ = natEnabled &&
-                                (
-                                    (natHosted && solnMultiAZ) ||
-                                    ((segmentObject.NAT.MultiAZ)!false)
-                                ) ]
-
-        [#else]
-            [#-- Handle global vars when solution is not defined --]
-            [#assign solnMultiAZ = false]
-            [#assign RDSAutoMinorVersionUpgrade = false]
-            [#assign natPerAZ = false]
-        [/#if]
     [/#if]
 
     [#-- Deployment Profiles use the standard CMDB override mechanism --]

--- a/providers/shared/components/bastion/id.ftl
+++ b/providers/shared/components/bastion/id.ftl
@@ -17,6 +17,12 @@
                 "Default" : false
             },
             {
+                "Names" : [ "MultiAZ", "MultiZone"],
+                "Description" : "Deploy resources to multiple Availablity Zones",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
                 "Names" : [ "Extensions", "Fragment", "Container" ],
                 "Description" : "Extensions to invoke as part of component processing",
                 "Types" : ARRAY_OF_STRING_TYPE,

--- a/providers/shared/components/cache/id.ftl
+++ b/providers/shared/components/cache/id.ftl
@@ -30,6 +30,12 @@
                 "Types" : STRING_TYPE
             },
             {
+                "Names" : [ "MultiAZ", "MultiZone"],
+                "Description" : "Deploy resources to multiple Availablity Zones",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
                 "Names" : "IPAddressGroups",
                 "Description" : "The source ip addresses that can access the cache",
                 "Types" : ARRAY_OF_STRING_TYPE,

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -332,6 +332,12 @@
         "Default" : []
     },
     {
+        "Names" : [ "MultiAZ", "MultiZone"],
+        "Description" : "Deploy resources to multiple Availablity Zones",
+        "Types" : BOOLEAN_TYPE,
+        "Default" : false
+    },
+    {
         "Names" : "FixedIP",
         "Types" : BOOLEAN_TYPE,
         "Default" : false
@@ -544,6 +550,12 @@
         "Default" : "ec2"
     },
     {
+        "Names" : [ "MultiAZ", "MultiZone"],
+        "Description" : "Deploy resources to multiple Availablity Zones",
+        "Types" : BOOLEAN_TYPE,
+        "Default" : false
+    },
+    {
         "Names" : "Containers",
         "SubObjects" : true,
         "AttributeSet" : CONTTAINERTASK_ATTRIBUTESET_TYPE
@@ -727,6 +739,12 @@
         "Types" : STRING_TYPE,
         "Values" : [ "ec2" ],
         "Default" : "ec2"
+    },
+    {
+        "Names" : [ "MultiAZ", "MultiZone"],
+        "Description" : "Deploy resources to multiple Availablity Zones",
+        "Types" : BOOLEAN_TYPE,
+        "Default" : false
     },
     {
         "Names" : "Containers",

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -87,6 +87,12 @@
                 ]
             },
             {
+                "Names" : [ "MultiAZ", "MultiZone"],
+                "Description" : "Deploy resources to multiple Availablity Zones",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
                 "Names" : "AutoScaling",
                 "AttributeSet" : AUTOSCALEGROUP_ATTRIBUTESET_TYPE
             },

--- a/providers/shared/components/datavolume/id.ftl
+++ b/providers/shared/components/datavolume/id.ftl
@@ -12,6 +12,12 @@
     attributes=
         [
             {
+                "Names" : [ "MultiAZ", "MultiZone"],
+                "Description" : "Deploy resources to multiple Availablity Zones",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
                 "Names" : "Zones",
                 "Description" : "A list of zoneIds to create virtual machines in, default is _all which will use all zones or the first for SingleAz",
                 "Types" : ARRAY_OF_STRING_TYPE,

--- a/providers/shared/components/db/id.ftl
+++ b/providers/shared/components/db/id.ftl
@@ -40,6 +40,12 @@
                 "Types" : STRING_TYPE
             },
             {
+                "Names" : [ "MultiAZ", "MultiZone"],
+                "Description" : "Deploy resources to multiple Availablity Zones",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
                 "Names" : "IPAddressGroups",
                 "Types" : ARRAY_OF_STRING_TYPE,
                 "Default" : [ "_localnet" ]
@@ -178,13 +184,14 @@
             },
             {
                 "Names" : "AllowMajorVersionUpgrade",
-                "Description" : "If the EngineVersion paramter is updated allow for major version updates to run",
+                "Description" : "If the EngineVersion parameter is updated allow for major version updates to run",
                 "Types" : BOOLEAN_TYPE,
                 "Default" : true
             },
             {
                 "Names" : "AutoMinorVersionUpgrade",
-                "Types" : BOOLEAN_TYPE
+                "Types" : BOOLEAN_TYPE,
+                "Default": true
             },
             {
                 "Names" : "DatabaseName",

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -18,6 +18,12 @@
                 "Default" : [ "_all" ]
             },
             {
+                "Names" : [ "MultiAZ", "MultiZone"],
+                "Description" : "Deploy resources to multiple Availablity Zones",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
                 "Names" : "FixedIP",
                 "Types" : BOOLEAN_TYPE,
                 "Default" : false

--- a/providers/shared/components/es/id.ftl
+++ b/providers/shared/components/es/id.ftl
@@ -24,6 +24,12 @@
                 "Mandatory" : true
             },
             {
+                "Names" : [ "MultiAZ", "MultiZone"],
+                "Description" : "Deploy resources to multiple Availablity Zones",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
                 "Names" : "AdvancedOptions",
                 "SubObjects" : true,
                 "Children" : [

--- a/providers/shared/components/fileshare/id.ftl
+++ b/providers/shared/components/fileshare/id.ftl
@@ -24,6 +24,12 @@
                 "Default" : "NFS"
             },
             {
+                "Names" : [ "MultiAZ", "MultiZone"],
+                "Description" : "Deploy resources to multiple Availablity Zones",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
                 "Names": "Size",
                 "Description" : "The size in Gb of the file share",
                 "Types": NUMBER_TYPE

--- a/providers/shared/components/filetransfer/id.ftl
+++ b/providers/shared/components/filetransfer/id.ftl
@@ -23,6 +23,12 @@
                 "Default" : []
             },
             {
+                "Names" : [ "MultiAZ", "MultiZone"],
+                "Description" : "Deploy resources to multiple Availablity Zones",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
                 "Names" : [ "Certificate", "Hostname" ],
                 "Children" : certificateChildConfiguration
             },

--- a/providers/shared/components/firewall/id.ftl
+++ b/providers/shared/components/firewall/id.ftl
@@ -18,6 +18,12 @@
                 "Mandatory" : true
             },
             {
+                "Names" : [ "MultiAZ", "MultiZone"],
+                "Description" : "Deploy resources to multiple Availablity Zones",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
                 "Names" : "Profiles",
                 "Children" : [
                     {

--- a/providers/shared/components/gateway/id.ftl
+++ b/providers/shared/components/gateway/id.ftl
@@ -62,6 +62,12 @@
                 ]
             },
             {
+                "Names" : [ "MultiAZ", "MultiZone"],
+                "Description" : "Deploy resources to multiple Availablity Zones",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
                 "Names" : "Endpoints",
                 "Description" : "Endpoint Engine resources",
                 "SubObjects" : true,

--- a/providers/shared/components/lb/id.ftl
+++ b/providers/shared/components/lb/id.ftl
@@ -63,6 +63,12 @@
                 "AttributeSet" : ALERT_ATTRIBUTESET_TYPE
             },
             {
+                "Names" : [ "MultiAZ", "MultiZone"],
+                "Description" : "Deploy resources to multiple Zones for high availablity",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
                 "Names" : "Links",
                 "SubObjects" : true,
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE

--- a/providers/shared/components/queuehost/id.ftl
+++ b/providers/shared/components/queuehost/id.ftl
@@ -28,6 +28,12 @@
                 "Default" : [ "_localnet" ]
             },
             {
+                "Names" : [ "MultiAZ", "MultiZone"],
+                "Description" : "Deploy resources to multiple Availablity Zones",
+                "Types" : BOOLEAN_TYPE,
+                "Default" : false
+            },
+            {
                 "Names" : "Links",
                 "SubObjects" : true,
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
@@ -89,7 +95,7 @@
                 "AttributeSet" : MAINTENANCEWINDOW_ATTRIBUTESET_TYPE
             },
             {
-                "Names" : "AutoMinorUpgrade",
+                "Names" : ["AutoMinorVersionUpgrade", "AutoMinorUpgrade"],
                 "Types" : BOOLEAN_TYPE,
                 "Default" : true
             },

--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -16,7 +16,6 @@
                     "Name" : key
                 } + value ]
 
-            [#assign multiAZ = component.MultiAZ!solnMultiAZ]
             [#local occurrenceStart = .now]
             [#list requiredOccurrences(
                 getOccurrences(tier, component),

--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -2070,11 +2070,11 @@
       }
     },
     "DisableAutoMinorVersionUpgrade": {
-      "Description": "Disable DisableAutoMinorVersionUpgrade option on all components that support it",
+      "Description": "Disable AutoMinorVersionUpgrade option on all components that support it",
       "Modes": {
         "*": {
           "*": {
-            "DisableAutoMinorVersionUpgrade": false
+            "AutoMinorVersionUpgrade": false
           }
         }
       }

--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -45,7 +45,11 @@
       "Title": "Beta Environment",
       "Description": "Preproduction environment according to DTO classification",
       "Category": "stg",
-      "MultiAZ": true,
+      "Profiles": {
+        "Deployment": [
+          "MultiAZ"
+        ]
+      },
       "Operations": {
         "Expiration": 90
       },
@@ -107,7 +111,11 @@
       "Title": "Preproduction Environment",
       "Description": "Deployment, performance, volume testing",
       "Category": "stg",
-      "MultiAZ": true,
+      "Profiles": {
+        "Deployment": [
+          "MultiAZ"
+        ]
+      },
       "Operations": {
         "Expiration": 90
       },
@@ -120,7 +128,11 @@
       "Title": "Staging Environment",
       "Description": "Deployment, performance, volume testing. Staging is used both as a specific environment and as a category of environments.",
       "Category": "stg",
-      "MultiAZ": true,
+      "Profiles": {
+        "Deployment": [
+          "MultiAZ"
+        ]
+      },
       "Operations": {
         "Expiration": 90
       },
@@ -133,7 +145,12 @@
       "Title": "Production Environment",
       "Description": "Kind of obvious...",
       "Category": "prod",
-      "MultiAZ": true,
+      "Profiles": {
+        "Deployment": [
+          "MultiAZ",
+          "DisableAutoMinorVersionUpgrade"
+        ]
+      },
       "Operations": {
         "Expiration": 365
       },
@@ -906,7 +923,7 @@
         "Timeout": "5"
       }
     },
-    "winrm" : {
+    "winrm": {
       "Port": 5985,
       "Protocol": "TCP",
       "IPProtocol": "tcp",
@@ -917,7 +934,7 @@
         "Timeout": "5"
       }
     },
-    "winrm-tls" : {
+    "winrm-tls": {
       "Port": 5986,
       "Protocol": "TCP",
       "IPProtocol": "tcp",
@@ -1836,7 +1853,7 @@
           "MarginTime": 540,
           "FuzzPercentage": 100
         },
-        "StartupAction" : "add",
+        "StartupAction": "add",
         "ReplayWindowSize": 1024,
         "DeadPeerDetectionTimeout": 30,
         "DeadPeerDetectionAction": "clear",
@@ -1947,11 +1964,11 @@
         "DeploymentFramework": "default"
       }
     },
-    "shared" : {
-      "default" : {
-        "Provider" : "shared",
-        "Region" : "shared",
-        "DeploymentFramework" : "default"
+    "shared": {
+      "default": {
+        "Provider": "shared",
+        "Region": "shared",
+        "DeploymentFramework": "default"
       }
     }
   },
@@ -1959,28 +1976,30 @@
     "segment": {
       "Priority": 100,
       "Level": "segment",
-      "DistrictType" : "segment",
-      "OutputPrefix" : "seg",
+      "DistrictType": "segment",
+      "OutputPrefix": "seg",
       "ResourceSets": {}
     },
     "solution": {
       "Priority": 200,
       "Level": "solution",
-      "DistrictType" : "segment",
-      "OutputPrefix" : "soln",
+      "DistrictType": "segment",
+      "OutputPrefix": "soln",
       "ResourceSets": {}
     },
     "application": {
       "Priority": 300,
       "Level": "application",
-      "DistrictType" : "segment",
-      "OutputPrefix" : "app",
+      "DistrictType": "segment",
+      "OutputPrefix": "app",
       "ResourceSets": {}
     }
   },
   "DeploymentModes": {
-    "_orphan" : {
-      "Operations": [ "delete" ],
+    "_orphan": {
+      "Operations": [
+        "delete"
+      ],
       "Membership": "orphaned",
       "Priority": {
         "GroupFilter": ".*",
@@ -1988,7 +2007,9 @@
       }
     },
     "update": {
-      "Operations": [ "update" ],
+      "Operations": [
+        "update"
+      ],
       "Membership": "priority",
       "Priority": {
         "GroupFilter": ".*",
@@ -1996,7 +2017,9 @@
       }
     },
     "maintenance": {
-      "Operations": [ "update" ],
+      "Operations": [
+        "update"
+      ],
       "Membership": "priority",
       "Priority": {
         "GroupFilter": ".*",
@@ -2004,7 +2027,9 @@
       }
     },
     "hibernate": {
-      "Operations": [ "update" ],
+      "Operations": [
+        "update"
+      ],
       "Membership": "priority",
       "Priority": {
         "GroupFilter": ".*",
@@ -2012,7 +2037,9 @@
       }
     },
     "stop": {
-      "Operations": [ "delete" ],
+      "Operations": [
+        "delete"
+      ],
       "Membership": "priority",
       "Priority": {
         "GroupFilter": ".*",
@@ -2020,11 +2047,36 @@
       }
     },
     "stopstart": {
-      "Operations": [ "delete", "update" ],
+      "Operations": [
+        "delete",
+        "update"
+      ],
       "Membership": "priority",
       "Priority": {
         "GroupFilter": ".*",
         "Order": "LowestFirst"
+      }
+    }
+  },
+  "DeploymentProfiles": {
+    "MultiAZ": {
+      "Description": "Enable MultiAZ on all components that support it",
+      "Modes": {
+        "*": {
+          "*": {
+            "MultiAZ": true
+          }
+        }
+      }
+    },
+    "DisableAutoMinorVersionUpgrade": {
+      "Description": "Disable DisableAutoMinorVersionUpgrade option on all components that support it",
+      "Modes": {
+        "*": {
+          "*": {
+            "DisableAutoMinorVersionUpgrade": false
+          }
+        }
       }
     }
   }

--- a/providers/shared/layers/Environment/id.ftl
+++ b/providers/shared/layers/Environment/id.ftl
@@ -41,11 +41,6 @@
             "Types" : STRING_TYPE
         },
         {
-            "Names" : "MultiAZ",
-            "Types" : BOOLEAN_TYPE,
-            "Default" : false
-        }
-        {
             "Names" : "Profiles",
             "Children" : [
                 {
@@ -136,16 +131,6 @@
                 {
                     "Names" : "Segment",
                     "Types" : STRING_TYPE
-                }
-            ]
-        },
-        {
-            "Names" : "RDS",
-            "Children" : [
-                {
-                    "Names" : "AutoMinorVersionUpgrade",
-                    "Types" : BOOLEAN_TYPE,
-                    "Default" : true
                 }
             ]
         },

--- a/providers/shared/layers/Segment/id.ftl
+++ b/providers/shared/layers/Segment/id.ftl
@@ -174,40 +174,10 @@
             ]
         },
         {
-            "Names" : "NAT",
-            "Children" : [
-                {
-                    "Names" : "Enabled",
-                    "Types" : BOOLEAN_TYPE,
-                    "Default" : true
-                },
-                {
-                    "Names" : "Hosted",
-                    "Types" : BOOLEAN_TYPE,
-                    "Default" : false
-                },
-                {
-                    "Names" : "MultiAZ",
-                    "Types" : BOOLEAN_TYPE,
-                    "Default" : false
-                }
-            ]
-        },
-        {
             "Names" : "RotateKeys",
             "Types" : BOOLEAN_TYPE,
             "Default" : true
         },
-        {
-            "Names" : "RDS",
-            "Children" : [
-                {
-                    "Names" : "AutoMinorVersionUpgrade",
-                    "Types" : BOOLEAN_TYPE,
-                    "Default" : true
-                }
-            ]
-        }
         {
             "Names" : "S3",
             "Children" : [

--- a/providers/shared/layers/Solution/id.ftl
+++ b/providers/shared/layers/Solution/id.ftl
@@ -50,19 +50,6 @@
             "Names" : "LinkRefs",
             "SubObjects" : true,
             "AttributeSet" : LINK_ATTRIBUTESET_TYPE
-        },
-        {
-            "Names" : "MultiAZ",
-            "Types" : BOOLEAN_TYPE
-        },
-        {
-            "Names" : "RDS",
-            "Children" : [
-                {
-                    "Names" : "AutoMinorVersionUpgrade",
-                    "Types" : BOOLEAN_TYPE
-                }
-            ]
         }
     ]
 /]

--- a/providers/shared/views/blueprint/setup.ftl
+++ b/providers/shared/views/blueprint/setup.ftl
@@ -93,7 +93,6 @@
 
         [#if component?is_hash]
 
-            [#assign multiAZ = component.MultiAZ!solnMultiAZ]
             [#local componentType = getComponentType(component)]
 
             [#-- Only include deployed Occurrences --]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
- Adds a MultiAZ attribute to all components which currently use MultiAZ in both the aws and azure providers
- Removes the MultiAZ flag on layers that had it configured
- Adds a deployment profile for multiAZ environment control to replicate the current behaviour
- Remove layer support for minor version updates
- Adds deployment profile to control minor version updates per env
- Removes NAT controls at the segment level as they are no longer used

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This simplifies where component configuration is sourced from and controlled and allows for removing the Solution layer which isn't really a layer following review of the expected implementation of solutions

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- If Deployment Profiles have been defined on the environment object they will override the default ones set for these properties. They will need to be added to the array. 

