### PR TITLE
feat: add certificate authority component

### DIFF
--- a/providers/shared/components/certificateauthority/id.ftl
+++ b/providers/shared/components/certificateauthority/id.ftl
@@ -1,0 +1,85 @@
+[#ftl]
+
+[@addComponent
+    type=CERTIFICATEAUTHORITY_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A private x509 certficate authority"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "Links",
+                "SubObjects" : true,
+                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+            },
+            {
+                "Names": "Level",
+                "Description": "The level of the authority",
+                "Values": ["Root", "Subordinate"],
+                "Default" : "Root"
+            },
+            {
+                "Names": "level:Subordinate",
+                "Children" : [
+                    {
+                        "Names" : "MaxLevels",
+                        "Description" : "The maximum number of subordinate CA's permitted under this CA",
+                        "Types": NUMBER_TYPE,
+                        "Default": 0
+                    },
+                    {
+                        "Names": "ParentAuthority",
+                        "Children": [
+                            {
+                                "Names": "Link",
+                                "AttributeSet": LINK_ATTRIBUTESET_TYPE
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "Names": "Validity",
+                "Description" : "Certificate Validity",
+                "Children": [
+                    {
+                        "Names" : "Length",
+                        "Description" : "How long (in days) the certificate is valid for",
+                        "Types" : NUMBER_TYPE,
+                        "Default" : 1095
+                    }
+                ]
+            },
+            {
+                "Names" : "Subject",
+                "Children" : [
+                    {
+                        "Names" : "CommonName",
+                        "Description" : "The Common name of the root CA",
+                        "Children" : hostNameChildConfiguration
+                    }
+                ]
+            },
+            {
+                "Names": "KeyAlgorithm",
+                "Description": "The algorithm used for the private key",
+                "Values" : [ "EC_prime256v1", "EC_secp384r1", "RSA_2048", "RSA_4096"],
+                "Default": "RSA_2048"
+            },
+            {
+                "Names": "SigningAlgorithm",
+                "Description": "The algorithm used for signing certificates",
+                "Values": [ "SHA256WITHECDSA", "SHA256WITHRSA", "SHA384WITHECDSA", "SHA384WITHRSA", "SHA512WITHECDSA", "SHA512WITHRSA"],
+                "Default": "SHA256WITHRSA"
+            }
+        ]
+/]
+
+[@addComponentDeployment
+    type=CERTIFICATEAUTHORITY_COMPONENT_TYPE
+    defaultGroup="solution"
+/]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -24,6 +24,8 @@
 [#assign CDN_COMPONENT_TYPE = "cdn"]
 [#assign CDN_ROUTE_COMPONENT_TYPE = "cdnroute" ]
 
+[#assign CERTIFICATEAUTHORITY_COMPONENT_TYPE = "certificateauthority"]
+
 [#assign CLIENTVPN_COMPONENT_TYPE = "clientvpn" ]
 
 [#assign COMPUTECLUSTER_COMPONENT_TYPE = "computecluster"]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for defining a certificate authority component

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for creating private certificate authorities using managed services. This is useful when managing PKI for services that need direct access to public and private keys while maintaining a trust chain which can be defined across all users of the service

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and with AWS provider

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

