### PR TITLE
fix(firewall): rename type attribute on firewall rules

### DIFF
--- a/providers/shared/components/firewall/id.ftl
+++ b/providers/shared/components/firewall/id.ftl
@@ -126,7 +126,7 @@
                 "Mandatory" : true
             },
             {
-                "Names" : "Type",
+                "Names" : "RuleType",
                 "Description" : "The type of rule to be applied",
                 "Types" : STRING_TYPE,
                 "Values" : [ "NetworkTuple", "HostFilter", "Complex" ],


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Change from Type to RuleType on firewall rules to avoid conflict with the global Type attribute

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When using the Type attribute on the Parent component the Type on the rule was being overridden if it wasn't set on each firewall rule 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

