### PR TITLE
fix: only include active layers based on district type

### DIFF
--- a/engine/inputdata/layer.ftl
+++ b/engine/inputdata/layer.ftl
@@ -11,16 +11,18 @@
 
 [#-- Fetch the current configuration for a layer --]
 [#-- Assumes layer is expected to be active --]
-[#function getActiveLayer type ]
+[#function getActiveLayer type required=true ]
     [#local activeData = getActiveLayers() ]
     [#-- Layer may not be active depending on the input filter --]
     [#if activeData[type]?? ]
         [#return activeData[type] ]
     [#else]
-        [@fatal
-            message="Could not find layer"
-            detail=type
-        /]
+        [#if required]
+            [@fatal
+                message="Could not find required active layer"
+                detail=type
+            /]
+        [/#if]
         [#return {} ]
     [/#if]
 [/#function]
@@ -123,13 +125,6 @@
 
 [#-- Determine if the layer is active based on the provided input filter --]
 [#function internalIsActiveLayer configuration filter ]
-    [#-- Temporarily assume that if a layer is known, it is active --]
-    [#-- This is mainly to handle the solution layer. Future       --]
-    [#-- refactoring will see it removed as a layer and handled by --]
-    [#-- more general solution handling code                       --]
-    [#-- TODO(mfl): Remove once solution is no longer a layer      --]
-    [#return true]
-
     [#if getFilterAttribute(filter, configuration.Configuration.InputFilterAttributes[0].Id)?has_content]
         [#-- Assume only one attribute per filter --]
         [#return true]

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -384,39 +384,29 @@
     [/#if]
 
     [#-- Deployment Profiles use the standard CMDB override mechanism --]
-    [#-- Deployment profiles for tenant and account are provided for  --]
-    [#-- backwards compatability                                      --]
-
-    [#assign deploymentProfiles =
-        forceProfileComponentTypesToLowerCase(
-            mergeObjects(
-                blueprintObject.DeploymentProfiles!{},
-                productObject.DeploymentProfiles!{},
-                tenantObject.DeploymentProfiles!{},
-                accountObject.DeploymentProfiles!{}
-            )
-        )
-    ]
+    [#assign deploymentProfiles = (blueprintObject.DeploymentProfiles)!{} ]
+    [#list getActiveLayerAttributes(["DeploymentProfiles"]) as  deploymentProfile ]
+        [#assign deploymentProfiles = mergeObjects(
+            deploymentProfiles,
+            forceProfileComponentTypesToLowerCase(deploymentProfile)
+        )]
+    [/#list]
 
     [#-- Policy Profiles reflect the desired enforcement hierarchy --]
-    [#assign policyProfiles =
-        forceProfileComponentTypesToLowerCase(
-            mergeObjects(
-                blueprintObject.PolicyProfiles!{},
-                productObject.PolicyProfiles!{},
-                accountObject.PolicyProfiles!{},
-                tenantObject.PolicyProfiles!{}
-            )
-        )
-    ]
+    [#assign policyProfiles = (blueprintObject.PolicyProfiles)!{} ]
+    [#list getActiveLayerAttributes(["PolicyProfiles"]) as policyProfile ]
+        [#assign policyProfiles = mergeObjects(
+            policyProfiles,
+            forceProfileComponentTypesToLowerCase(policyProfile)
+        )]
+    [/#list]
 
-    [#-- Cludge for now to get placement profiles working --]
-    [#assign placementProfiles =
-        (blueprintObject.PlacementProfiles)!{} +
-        mergeObjects(
-            (productObject.PlacementProfiles)!{},
-            (tenantObject.PlacementProfiles)!{}
-        ) ]
+    [#assign placementProfiles = (blueprintObject.PlacementProfiles)!{} ]
+    [#list getActiveLayerAttributes(["PlacementProfiles"], [ TENANT_LAYER_TYPE, PRODUCT_LAYER_TYPE] ) as placementProfile ]
+        [#assign placementProfiles = mergeObjects(
+            placementProfiles, placementProfile
+        )]
+    [/#list]
 
     [#-- Country Groups --]
     [#assign countryGroups = getReferenceData(COUNTRYGROUP_REFERENCE_TYPE, true) ]

--- a/providers/shared/layers/Product/id.ftl
+++ b/providers/shared/layers/Product/id.ftl
@@ -134,7 +134,7 @@
 [#-- Temporary function --]
 [#-- TODO(mfl) remove once integrated into the input pipeline --]
 [#function getProductLayerRegion ]
-    [#local product = getActiveLayer(PRODUCT_LAYER_TYPE) ]
+    [#local product = getActiveLayer(PRODUCT_LAYER_TYPE, false) ]
     [#return (product[getCLODeploymentUnit()].Region)!product.Region!"" ]
 [/#function]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Uses the district type to define the layers that are considered active
- Control handling of missing layes when explicit lookups are used
- Use active layer data filtering instead of explicit layers for setContext data

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When running a reference data query in the account level the template generation fails as base layer data was being included for other layers when it didn't need to include it.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locallly

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

