### PR TITLE
feat(lb): define external or internal for lb endpoints

### DIFF
--- a/providers/shared/components/lb/id.ftl
+++ b/providers/shared/components/lb/id.ftl
@@ -345,6 +345,12 @@
                         "Description" : "Static endpoints for the load balancing port",
                         "Children"  : [
                             {
+                                "Names" : "External",
+                                "Description" : "If the static endpoint is inside the local network or external",
+                                "Types": BOOLEAN_TYPE,
+                                "Default" : true
+                            },
+                            {
                                 "Names" : "Links",
                                 "SubObjects" : true,
                                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Allows for controlling if a static endpoint is internal or external to the local network of the load balancer

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
REquired for some load balancers to ensure traffic is routed properly

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

