### PR TITLE
fix: add generation contract for unitlist view

### DIFF
--- a/providers/shared/views/unitlist/setup.ftl
+++ b/providers/shared/views/unitlist/setup.ftl
@@ -1,5 +1,9 @@
 [#ftl]
 
+[#macro shared_view_unitlist_generationcontract ]
+    [@addDefaultGenerationContract subsets=[ "managementcontract" ] /]
+[/#macro]
+
 [#macro shared_view_unitlist_managementcontract ]
 
     [#-- Look through all pointSets to determine all of the possible deployments that exist --]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Add generation contract for uitlist view

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When generating a unitlist for the account level district as there are no occurrences the account layer the generation contract isn't triggered. Adding it into the view ensures that the generation contract is populated when there are no components. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

