### PR TITLE
feat: Support user defined runtime engines with only a warning

### DIFF
--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -1491,20 +1491,37 @@ are added.
                         [#if attribute.Values?has_content]
                             [#list asArray(providedValue) as value]
                                 [#if !(attribute.Values?seq_contains(value)) ]
-                                    [#local messages +=
-                                        [
-                                            {
-                                                "Severity" : "fatal",
-                                                "Message" : "Attribute value is not one of the expected values",
-                                                "Context" : {
-                                                    "Name" : providedName,
-                                                    "Value" : value,
-                                                    "ExpectedValues" : attribute.Values,
-                                                    "Candidate" : providedCandidate
+                                    [#if ((attribute.AdditionalValues)!false)]
+                                        [#local messages +=
+                                            [
+                                                {
+                                                    "Severity" : "warning",
+                                                    "Message" : "Attribute value "+value+" is not one of the typical values, but will be passed through",
+                                                    "Context" : {
+                                                        "Name" : providedName,
+                                                        "Value" : value,
+                                                        "ExpectedValues" : attribute.Values,
+                                                        "Candidate" : providedCandidate
+                                                    }
                                                 }
-                                            }
+                                            ]
                                         ]
-                                    ]
+                                    [#else]
+                                        [#local messages +=
+                                            [
+                                                {
+                                                    "Severity" : "fatal",
+                                                    "Message" : "Attribute value is not one of the expected values",
+                                                    "Context" : {
+                                                        "Name" : providedName,
+                                                        "Value" : value,
+                                                        "ExpectedValues" : attribute.Values,
+                                                        "Candidate" : providedCandidate
+                                                    }
+                                                }
+                                            ]
+                                        ]
+                                    [/#if]
                                 [/#if]
                             [/#list]
                         [/#if]
@@ -1546,6 +1563,13 @@ are added.
             [#if mode?contains("logs") ]
                 [#list messages as message]
                     [#switch message.Severity]
+                        [#case "warning"]
+                            [@warning
+                                message=message.Message
+                                context=message.Context!{}
+                                detail=message.Detail!{}
+                            /]
+                            [#break]
                         [#case "fatal"]
                         [#default]
                             [@fatal
@@ -1693,6 +1717,7 @@ are added.
                     "DefaultBehaviour" : attribute.DefaultBehaviour!"ignore",
                     "DefaultProvided" : attribute.Default??,
                     "Values" : asArray(attribute.Values![]),
+                    "AdditionalValues" : attribute.AdditionalValues!false,
                     "Children" : normaliseCompositeConfiguration(
                         asArray(attribute.Children![])
                     ),

--- a/engine/base.ftl
+++ b/engine/base.ftl
@@ -1496,7 +1496,7 @@ are added.
                                             [
                                                 {
                                                     "Severity" : "warning",
-                                                    "Message" : "Attribute value "+value+" is not one of the typical values, but will be passed through",
+                                                    "Message" : "Attribute value \"" + value + "\" is not one of the typical values, but will be passed through",
                                                     "Context" : {
                                                         "Name" : providedName,
                                                         "Value" : value,

--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -79,6 +79,23 @@
                 "Names" : "RunTime",
                 "Types" : STRING_TYPE,
                 "Description" : "Must be a valid runtime engine such as nodejs14.x. Refer https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html or https://docs.microsoft.com/en-us/azure/azure-functions/supported-languages",
+                "Values" : [
+                    "dotnet6",
+                    "dotnetcore1.0",
+                    "dotnetcore2.1",
+                    "go1.x",
+                    "java8",
+                    "java11",
+                    "nodejs12.x",
+                    "nodejs14.x",
+                    "python2.7",
+                    "python3.6",
+                    "python3.7",
+                    "python3.8",
+                    "python3.9",
+                    "ruby2.5"
+                ],
+                "AdditionalValues" : true,
                 "Mandatory" : true
             },
             {

--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -78,22 +78,7 @@
             {
                 "Names" : "RunTime",
                 "Types" : STRING_TYPE,
-                "Values" : [
-                    "dotnet6",
-                    "dotnetcore1.0",
-                    "dotnetcore2.1",
-                    "go1.x",
-                    "java8",
-                    "java11",
-                    "nodejs12.x",
-                    "nodejs14.x",
-                    "python2.7",
-                    "python3.6",
-                    "python3.7",
-                    "python3.8",
-                    "python3.9",
-                    "ruby2.5"
-                ],
+                "Description" : "Must be a valid runtime engine such as nodejs14.x. Refer https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html or https://docs.microsoft.com/en-us/azure/azure-functions/supported-languages",
                 "Mandatory" : true
             },
             {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
New attribute AdditionalValues which downgrades a mismatch in Values (currently only on Runtime) to a warning and allows non-specified values

## Motivation and Context
Fixes https://github.com/hamlet-io/engine/issues/1640

## How Has This Been Tested?
Locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

