### PR TITLE
feat(logstore): add dedicated log storage component

### DIFF
--- a/providers/shared/attributesets/attributeset.ftl
+++ b/providers/shared/attributesets/attributeset.ftl
@@ -6,6 +6,7 @@
 [#assign COMPUTEIMAGE_ATTRIBUTESET_TYPE = "computeimage"]
 [#assign CONTTAINERTASK_ATTRIBUTESET_TYPE = "containertask"]
 [#assign CONTEXTPATH_ATTRIBUTESET_TYPE = "contextpath"]
+[#assign CONTEXTPATH_FULLPATH_ATTRIBUTESET_TYPE = "contextpath_fullpath"]
 [#assign CORE_PROFILE_ATTRIBUTESET_TYPE = "core_profile"]
 [#assign DISTRICT_ATTRIBUTESET_TYPE = "district"]
 [#assign ECS_COMPUTEIMAGE_ATTRIBUTESET_TYPE = "ecs_computeimage"]

--- a/providers/shared/attributesets/contextpath_fullpath/id.ftl
+++ b/providers/shared/attributesets/contextpath_fullpath/id.ftl
@@ -1,0 +1,86 @@
+[#ftl]
+
+[@addExtendedAttributeSet
+    type=CONTEXTPATH_FULLPATH_ATTRIBUTESET_TYPE
+    baseType=CONTEXTPATH_ATTRIBUTESET_TYPE
+    provider=SHARED_PROVIDER
+    properties=[
+        {
+                "Type"  : "Description",
+                "Value" : "Creates a Segment unique context path by default"
+        }]
+    attributes=[
+        {
+            "Names" : "Style",
+            "Types" : STRING_TYPE,
+            "Description" : "Provide the value as a single string or a file system style path",
+            "Values" : [ "path" ],
+            "Default" : "path"
+        },
+                {
+            "Names" : "IncludeInPath",
+            "Children" : [
+                {
+                    "Names" : "Account",
+                    "Description" : "The name of the Account",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Names" : "ProviderId",
+                    "Description" : "The Provider Id for the account",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : false
+                }
+                {
+                    "Names" : "Product",
+                    "Description" : "The name of the product",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Names" : "Environment",
+                    "Description" : "The name of the environment",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Names" : "Segment",
+                    "Description" : "The name of the segment",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Names" : "Tier",
+                    "Description" : "The name of the tier",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default": true
+                },
+                {
+                    "Names" : "Component",
+                    "Description" : "The name of the component",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Names" : "Instance",
+                    "Description" : "The name of the instance",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Names" : "Version",
+                    "Description" : "The name of the version",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Names" : ["Custom", "Host"],
+                    "Description" : "Include a custom string",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default": false
+                }
+            ]
+        }
+    ]
+/]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -120,6 +120,8 @@
     type=LB_COMPONENT_TYPE
 /]
 
+[#assign LOGSTORE_COMPONENT_TYPE = "logstore"]
+
 [#assign MOBILEAPP_COMPONENT_TYPE = "mobileapp"]
 
 [#assign MOBILENOTIFIER_COMPONENT_TYPE = "mobilenotifier" ]

--- a/providers/shared/components/logstore/id.ftl
+++ b/providers/shared/components/logstore/id.ftl
@@ -12,6 +12,12 @@
     attributes=
         [
             {
+                "Names" : "Engine",
+                "Description": "The service used to store the logs",
+                "Types" : [ STRING_TYPE ],
+                "Values" : []
+            },
+            {
                 "Names" : "Links",
                 "SubObjects" : true,
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE

--- a/providers/shared/components/logstore/id.ftl
+++ b/providers/shared/components/logstore/id.ftl
@@ -1,0 +1,59 @@
+[#ftl]
+
+[@addComponent
+    type=LOGSTORE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "Defines a standalong log store used to capture function base logs"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "Links",
+                "SubObjects" : true,
+                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+            },
+            {
+                "Names" : [ "Extensions", "Fragment", "Container" ],
+                "Description" : "Extensions to invoke as part of component processing",
+                "Types" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
+                "Names" : "Lifecycle",
+                "Description" : "The lifecycle policy for the log store",
+                "Children" : [
+                    {
+                        "Names": "Expiration",
+                        "Description" : "The time in days to keep logs for, _operations follows the layer expiration policy",
+                        "Types" : [ STRING_TYPE, NUMBER_TYPE],
+                        "Default" : "_operations"
+                    }
+                ]
+            },
+            {
+                "Names" : "Profiles",
+                "Children" : [
+                    {
+                        "Names" : "Logging",
+                        "Description" : "Profile to define where logs are forwarded to from this component",
+                        "Types" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
+            },
+            {
+                "Names" : "Path",
+                "Description" : "The log store path based on occurrence attributes",
+                "AttributeSet" : CONTEXTPATH_FULLPATH_ATTRIBUTESET_TYPE
+            }
+        ]
+/]
+
+[@addComponentDeployment
+    type=LOGSTORE_COMPONENT_TYPE
+    defaultGroup="segment"
+/]

--- a/providers/shared/references/LogFileGroup/id.ftl
+++ b/providers/shared/references/LogFileGroup/id.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[@addReference 
+[@addReference
     type=LOGFILEGROUP_REFERENCE_TYPE
     pluralType="LogFileGroups"
     properties=[
@@ -14,6 +14,23 @@
             "Names" : "LogFiles",
             "Types" : ARRAY_OF_STRING_TYPE,
             "Mandatory" : true
+        },
+        {
+            "Names" : "LogStore",
+            "Children" : [
+                {
+                    "Names" : ["Destination"],
+                    "Description" : "The type of logstore to use for this log file group - component is local and link is an external store",
+                    "Types" : [STRING_TYPE],
+                    "Values" : ["component", "link"],
+                    "Default" : "component"
+                },
+                {
+                    "Names" : "Link",
+                    "Description" : "A link to an external log store",
+                    "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+                }
+            ]
         }
     ]
 /]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Defines the log store component used to create an independent log store from other components 

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for the creation of a log store that is written to by another component with content that doesn't relate to the execution of that content. 

This could be something like a lambda function which writes log events it receives, so the lambda log group is for running the function and capturing issues in running the function, where the log store is the formatted event content it was processing. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

