### PR TITLE
feat(lambda): versioned lambda retention policy

### DIFF
--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -190,6 +190,13 @@
                         "Types" : STRING_TYPE,
                         "Description" : "A sha256 hash of the code zip file",
                         "Default" : ""
+                    },
+                    {
+                        "Names" : "DeletionPolicy",
+                        "Types" : STRING_TYPE,
+                        "Description" : "What should happen to the superceded version when new version on deploy?",
+                        "Values" : [ "Delete", "Retain" ],
+                        "Default" : "Retain"
                     }
                 ]
             },


### PR DESCRIPTION

## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
When a new version is created on each deploy, provide control over whether the old versions are deleted or retained.

The default is to retain in line with the previous hard coded value.

## Motivation and Context
The need to delete has become more relevant as versioned lambdas are needed to preprovision lambda instances.

## How Has This Been Tested?
Local template creation. Customer deployment

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

