### PR TITLE
refactor(apigateway): authorization models

### DIFF
--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -107,9 +107,7 @@ object.
                 "Types" : STRING_TYPE,
                 "Values" : [
                     "IP",
-                    "SIG4ORIP", "SIG4_OR_IP",
                     "AUTHORISER_OR_IP", "AUTHORIZER_OR_IP",
-                    "SIG4ANDIP", "SIG4_AND_IP",
                     "AUTHORISER_AND_IP", "AUTHORIZER_AND_IP"
                 ],
                 "Default" : "IP"

--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -102,9 +102,15 @@ object.
                 "Default" : []
             },
             {
-                "Names" : "Authentication",
+                "Names" : ["AuthorisationModel", "AuthorizationModel", "Authentication"],
                 "Types" : STRING_TYPE,
-                "Values" : ["IP", "SIG4ORIP", "SIG4ANDIP"],
+                "Values" : [
+                    "IP",
+                    "SIG4ORIP", "SIG4_OR_IP",
+                    "AUTHORISER_OR_IP", "AUTHORIZER_OR_IP",
+                    "SIG4ANDIP", "SIG4_AND_IP",
+                    "AUTHORISER_AND_IP", "AUTHORIZER_AND_IP"
+                ],
                 "Default" : "IP"
             },
             {

--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -103,6 +103,7 @@ object.
             },
             {
                 "Names" : ["AuthorisationModel", "AuthorizationModel", "Authentication"],
+                "Description" : "Model to use where IP filtering is part of the desired authorization approach",
                 "Types" : STRING_TYPE,
                 "Values" : [
                     "IP",


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Support additional model values for the case of IP filtering in combination with a lambda authorizer. Also rename the config attribute to more correctly reflect its purpose in controlling authorization rather than authentication.

## Motivation and Context
When used with a lambda authorizer, the default value of "IP" incorrectly provides an explict ALLOW  rather than relying on it to come from the policy provided by the authorizer. By providing explicit values to be used with the authorizer, the configuration can be validated as appropriate.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

