### PR TITLE
feat(cdn): add priority to cdn routes

### DIFF
--- a/providers/shared/components/cdn/id.ftl
+++ b/providers/shared/components/cdn/id.ftl
@@ -144,6 +144,12 @@
         ]
     attributes=[
         {
+            "Names" : "Priority",
+            "Description" : "The priority of this route, lower routes evaluated first",
+            "Types": NUMBER_TYPE,
+            "Default" : 100
+        },
+        {
             "Names" : "PathPattern",
             "Description" : "The path based pattern to match for this route to apply - one _default path pattern must be supplied",
             "Types" : STRING_TYPE,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Allows for setting the priority on cdn routes to control the evaluation of rules

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When working with CDN's they generally follow a rule based approach where the first rule wins. When working with rules that have overlapping patterns it's important to be able to control the route preferences. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

