### PR TITLE
feat: add support for dynamic value evaulation

### DIFF
--- a/engine/bootstrap.ftl
+++ b/engine/bootstrap.ftl
@@ -21,6 +21,7 @@
 [#include "configuration/module.ftl" ]
 [#include "configuration/reference.ftl" ]
 [#include "configuration/task.ftl" ]
+[#include "configuration/dynamicvalues.ftl" ]
 
 [#-- Input data handling --]
 [#include "inputdata/inputsource.ftl" ]

--- a/engine/configuration/dynamicvalues.ftl
+++ b/engine/configuration/dynamicvalues.ftl
@@ -1,0 +1,166 @@
+[#ftl]
+
+[#assign DYNAMIC_VALUE_CONFIGURATION_SCOPE = "DyanmicValues" ]
+
+[@addConfigurationScope
+    id=DYNAMIC_VALUE_CONFIGURATION_SCOPE
+    description="Configuration of Dynamic Value providers"
+/]
+
+[#macro addDynamicValueProvider type parameterOrder parameterAttributes supportedComponentTypes=["*"] properties=[]]
+
+    [@addConfigurationSet
+        scopeId=DYNAMIC_VALUE_CONFIGURATION_SCOPE
+        id=type
+        properties=properties
+        attributes=[
+            {
+                "Names": "ComponentType",
+                "Description": "The supported component types for this dynamic value provider"
+            } +
+            ( ! supportedComponentTypes?seq_contains("*"))?then(
+                {
+                    "Values": supportedComponentTypes
+                },
+                {}
+            ),
+            {
+                "Names" : "ParameterOrder",
+                "Description" : "The order that the parameters are set in the substitution value",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : combineEntities(["type"], parameterOrder, APPEND_COMBINE_BEHAVIOUR)
+            },
+            {
+                "Names": "Parameters",
+                "Description": "The parameters in the dynamic value used for the provider",
+                "Children": combineEntities(
+                    [
+                        {
+                            "Names" : "type",
+                            "Description" : "The type of the provider",
+                            "Types" : STRING_TYPE,
+                            "Default" : type,
+                            "Values" : [ type ]
+                        }
+                    ],
+                    parameterAttributes,
+                    APPEND_COMBINE_BEHAVIOUR
+                )
+            }
+        ]
+    /]
+[/#macro]
+
+
+[#function getDynamicValueProvider type ]
+    [#local config = getConfigurationSet(DYNAMIC_VALUE_CONFIGURATION_SCOPE, type) ]
+    [#if config?has_content ]
+        [#return config ]
+    [#else]
+        [@debug
+            message="Could not find dynamic provider configuration"
+            detail={"type": type, "Available": getConfigurationSets(DYNAMIC_VALUE_CONFIGURATION_SCOPE) }
+            enabled=false
+        /]
+        [#return {} ]
+    [/#if]
+[/#function]
+
+
+[#function getDynamicValue occurrence value extraSources={} ]
+
+    [#if ( value?is_string && ! value?contains("__") ) || ! value?is_string ]
+        [#return value ]
+    [/#if]
+
+    [#local substitutions = value?split("__")?filter(x -> x?matches('^[a-zA-Z0-9_-]*:.*'))]
+    [#local replacements = {}]
+
+    [#list substitutions as substitution ]
+        [#local lookups = substitution?split(":") ]
+        [#local type = lookups[0] ]
+
+        [#local dynamicValueProvider = getDynamicValueProvider(type)]
+
+        [#if dynamicValueProvider?has_content ]
+            [#local parameterOrder = (dynamicValueProvider.Attributes?filter(x -> asArray(x.Names)?seq_contains("ParameterOrder"))[0]).Default ]
+
+            [#local parameters = {}]
+
+            [#list parameterOrder as param ]
+                [#if param?has_content]
+                    [#local parameters = mergeObjects(parameters, { param: lookups[param?index]})]
+                [/#if]
+            [/#list]
+
+            [#local attributeValues = getCompositeObject(
+                dynamicValueProvider.Attributes,
+                {
+                    "ComponentType": occurrence.Core.Type,
+                    "Parameters" : parameters
+                }
+            )]
+
+            [#local substitutionValue = parameterOrder?map( x -> attributeValues.Parameters[x])?join(":") ]
+
+            [#list (occurrence.State.ResourceGroups)?values as resourceGroup ]
+
+                [#local placement = (resourceGroup.Placement)!{} ]
+                [#if placement?has_content ]
+                    [#local functionOptions =
+                        [
+                            [placement.Provider, "dynamicvalue", type, placement.DeploymentFramework],
+                            [placement.Provider, "dynamicvalue", type ],
+                            [SHARED_PROVIDER, "dynamicvalue", type, placement.DeploymentFramework],
+                            [SHARED_PROVIDER, "dynamicvalue", type ]
+                        ]]
+
+                    [#local function = getFirstDefinedDirective(functionOptions)]
+                    [#if function?has_content]
+                        [#local replacements =  mergeObjects(
+                            replacements,
+                            { substitution : .vars[function](substitution, attributeValues.Parameters, occurrence, extraSources) }
+                        )]
+                    [#else]
+                        [@debug
+                            message="Unable to invoke any of the function options"
+                            context=macroOptions
+                            enabled=false
+                        /]
+                    [/#if]
+                [/#if]
+            [/#list]
+        [/#if]
+    [/#list]
+
+    [#list replacements as original, new ]
+        [#local value = value?replace("__${original}__", new)]
+    [/#list]
+
+    [#return value]
+[/#function]
+
+
+[#-- Resolve all Dynamic Values in a given value --]
+[#function resolveDynamicValues occurrence value extraSources={} ]
+    [#local result = {}]
+    [#if value?is_hash ]
+        [#list value as k,v ]
+            [#local result = mergeObjects(result, { k: resolveDynamicValues(occurrence, v, extraSources)})]
+        [/#list]
+
+    [#elseif value?is_sequence]
+        [#local result = []]
+        [#list value as v]
+            [#local result = combineEntities(result, resolveDynamicValues(occurrence, v extraSources))]
+        [/#list]
+
+    [#elseif value?is_string]
+        [#return getDynamicValue(occurrence, value, extraSources)]
+
+    [#else]
+        [#return value]
+    [/#if]
+
+    [#return result]
+[/#function]

--- a/engine/configuration/dynamicvalues.ftl
+++ b/engine/configuration/dynamicvalues.ftl
@@ -78,7 +78,7 @@
             [#local parameters = {}]
 
             [#list parameterOrder as param ]
-                [#if param?has_content]
+                [#if param?has_content && (lookups[param?index])?has_content ]
                     [#local parameters = mergeObjects(parameters, { param: lookups[param?index]})]
                 [/#if]
             [/#list]
@@ -117,7 +117,11 @@
     [/#list]
 
     [#list replacements as original, new ]
-        [#local value = value?replace("__${original}__", new)]
+        [#if new?is_string]
+            [#local value = value?replace("__${original}__", new)]
+        [#else]
+            [#return new]
+        [/#if]
     [/#list]
 
     [#return value]

--- a/engine/provider.ftl
+++ b/engine/provider.ftl
@@ -358,7 +358,7 @@
                 /]
             [/#list]
 
-            [#-- Determine the tasks for the provider --]
+            [#-- Determine the dynamic value providers for the provider --]
             [#local directories =
                 internalGetPluginFiles(
                     [providerMarker.Path, "dynamicvalues"],

--- a/engine/provider.ftl
+++ b/engine/provider.ftl
@@ -358,6 +358,22 @@
                 /]
             [/#list]
 
+            [#-- Determine the tasks for the provider --]
+            [#local directories =
+                internalGetPluginFiles(
+                    [providerMarker.Path, "dynamicvalues"],
+                    [
+                        ["[^/]+"]
+                    ]
+                )
+            ]
+            [#list directories as directory]
+                [@internalIncludeTemplatesInDirectory
+                    directory,
+                    ["id", "name", "dynamicvalue"]
+                /]
+            [/#list]
+
             [#-- Determine the output writers for the provider --]
             [#local directories =
                 internalGetPluginFiles(
@@ -374,7 +390,7 @@
                 /]
             [/#list]
 
-            [#-- Determine the output hanlders for the provider --]
+            [#-- Determine the output handlers for the provider --]
             [#local directories =
                 internalGetPluginFiles(
                     [providerMarker.Path, "outputhandlers"],
@@ -995,6 +1011,12 @@
     [@internalIncludeTemplatesInDirectory
         [providerMarker.Path, "tasks"],
         ["task" ]
+    /]
+
+    [#-- aws/dynamicvalues/dynamicvalue.ftl --]
+    [@internalIncludeTemplatesInDirectory
+        [providerMarker.Path, "dynamicvalues"],
+        ["dynamicvalue"]
     /]
 
     [#-- aws/resourcelabels/resourcelabel.ftl --]

--- a/providers/shared/components/runbook/setup.ftl
+++ b/providers/shared/components/runbook/setup.ftl
@@ -31,36 +31,24 @@
         [#local runBookInputs = mergeObjects(runBookInputs, {k?ensure_starts_with("input:") : v })]
     [/#list]
 
-    [#local solution = resolveDynamicValues(
-            occurrence,
-            solution,
-            {
-                "inputs": runBookInputs,
-                "stepIds": (occurrence.Occurrences![])?filter(
-                    x -> x.Configuration.Solution.Enabled && x.Core.Type == RUNBOOK_STEP_COMPONENT_TYPE
-                )?map(x -> x.Core.SubComponent.RawId )
-            }
-    )]
+    [#local dynamicInputs =  {
+            "inputs": runBookInputs,
+            "stepIds": (occurrence.Occurrences![])?filter(
+                x -> x.Configuration.Solution.Enabled && x.Core.Type == RUNBOOK_STEP_COMPONENT_TYPE
+            )?map(x -> x.Core.SubComponent.RawId ),
+            "occurrence" : occurrence
+        }]
 
     [@contractProperties
         properties=runBookInputs
     /]
 
-    [#list (occurrence.Occurrences![])?filter(x -> x.Configuration.Solution.Enabled ) as subOccurrence]
+    [#list (occurrence.Occurrences![])?filter(
+                x -> x.Configuration.Solution.Enabled )?map(
+                    x -> resolveDynamicValues(x, dynamicInputs)) as subOccurrence]
 
         [#local core = subOccurrence.Core ]
         [#local solution = subOccurrence.Configuration.Solution ]
-
-        [#local solution = resolveDynamicValues(
-                subOccurrence,
-                solution,
-                {
-                    "inputs": runBookInputs,
-                    "stepIds": (occurrence.Occurrences![])?filter(
-                        x -> x.Configuration.Solution.Enabled && x.Core.Type == RUNBOOK_STEP_COMPONENT_TYPE
-                    )?map(x -> x.Core.SubComponent.RawId )
-                }
-        )]
 
         [#local stageId = core.SubComponent.RawName]
 

--- a/providers/shared/components/runbook/setup.ftl
+++ b/providers/shared/components/runbook/setup.ftl
@@ -31,6 +31,17 @@
         [#local runBookInputs = mergeObjects(runBookInputs, {k?ensure_starts_with("input:") : v })]
     [/#list]
 
+    [#local solution = resolveDynamicValues(
+            occurrence,
+            solution,
+            {
+                "inputs": runBookInputs,
+                "stepIds": (occurrence.Occurrences![])?filter(
+                    x -> x.Configuration.Solution.Enabled && x.Core.Type == RUNBOOK_STEP_COMPONENT_TYPE
+                )?map(x -> x.Core.SubComponent.RawId )
+            }
+    )]
+
     [@contractProperties
         properties=runBookInputs
     /]
@@ -39,6 +50,17 @@
 
         [#local core = subOccurrence.Core ]
         [#local solution = subOccurrence.Configuration.Solution ]
+
+        [#local solution = resolveDynamicValues(
+                subOccurrence,
+                solution,
+                {
+                    "inputs": runBookInputs,
+                    "stepIds": (occurrence.Occurrences![])?filter(
+                        x -> x.Configuration.Solution.Enabled && x.Core.Type == RUNBOOK_STEP_COMPONENT_TYPE
+                    )?map(x -> x.Core.SubComponent.RawId )
+                }
+        )]
 
         [#local stageId = core.SubComponent.RawName]
 
@@ -68,7 +90,7 @@
                 parameters={
                     "Test" : condition.Test,
                     "Condition" : condition.Match,
-                    "Value" : getRunBookValue(condition.Value, runBookInputs, subOccurrence, occurrence)
+                    "Value" : condition.Value
                 }
                 priority=10
                 mandatory=true
@@ -80,7 +102,7 @@
         [#list mergeObjects(solution.Task.Parameters, _context.TaskParameters) as id, parameter ]
             [#local taskParameters = mergeObjects(
                 taskParameters,
-                { id : getRunBookValue(parameter, runBookInputs, subOccurrence, occurrence)}
+                { id : parameter?is_hash?then(parameter.Value, parameter) }
             )]
         [/#list]
 
@@ -95,108 +117,6 @@
         /]
     [/#list]
 [/#macro]
-
-[#-- Resolves the different inputs to contract values that engines can process --]
-[#function getRunBookValue value inputs occurrence parentOccurrence ]
-    [#if value?is_hash ]
-        [#local value = value.Value]
-    [/#if]
-
-    [#if ( value?is_string && ! value?contains("__") ) || ! value?is_string ]
-        [#return value ]
-    [/#if]
-
-    [#local substitutions = value?split("__")]
-    [#local replacements = {}]
-
-    [#list substitutions as substitution ]
-        [#if substitution?matches('^([a-zA-Z0-9_-]*:){1,2}.*')]
-            [#local lookups = substitution?split(":") ]
-            [#local source = lookups[0] ]
-
-            [#switch source?lower_case ]
-                [#case "setting" ]
-                    [#local settingName = lookups[1] ]
-
-                    [#local collectedSettings = {}]
-                    [#list (occurrence.Configuration.Settings)?values?filter(x -> x?has_content) as settingGroup ]
-                        [#list settingGroup as key, value]
-                            [#local collectedSettings = mergeObjects(collectedSettings, { key : value } )]
-                        [/#list]
-                    [/#list]
-                    [#local replacements = mergeObjects(replacements, { "__${substitution}__" : (collectedSettings[settingName].Value)!"HamletFatal: substituion failed __${substitution}__" }) ]
-                    [#break]
-
-
-                [#case "attribute"]
-                    [#local linkId = lookups[1] ]
-                    [#local attributeName = lookups[2] ]
-
-                    [#local link = (occurrence.Configuration.Solution.Links[linkId])!{}]
-                    [#local linkTarget = getLinkTarget(occurrence, link)]
-
-                    [#if ! linkTarget?has_content ]
-                        [@fatal
-                            message="Link could not be found for attribute"
-                            context={
-                                "Step"  : occurrence.Core.Component.RawId,
-                                "LinkId" : linkId,
-                                "Links" : occurrence.Configuration.Solution.Links
-                            }
-                        /]
-                    [/#if]
-
-                    [#local replacements = mergeObjects(replacements, { "__${substitution}__" : (linkTarget.State.Attributes[attributeName])!"HamletFatal: substituion failed __${substitution}__" }) ]
-                    [#break]
-
-                [#case "input"]
-                    [#if inputs?has_content]
-                        [#local inputId = lookups[1] ]
-
-                        [#if ! inputs?keys?seq_contains(inputId)?has_content ]
-                            [@fatal
-                                message="Input Id could not be found"
-                                context={
-                                    "Step" : occurrence.Core.Component.RawId,
-                                    "Input" : inputId
-                                }
-                            /]
-                        [/#if]
-                        [#local replacements = mergeObjects(replacements, { "__${substitution}__" : "__Properties:${substitution}__" }) ]
-                    [/#if]
-                    [#break]
-
-                [#case "output"]
-                    [#if parentOccurrence?has_content ]
-                        [#local stepId = lookups[1]]
-                        [#local output = lookups[2]]
-
-                        [#if ! ((parentOccurrence.Occurrences)![])?map( x -> x.Core.SubComponent.RawId)?seq_contains(stepId) ]
-                            [@fatal
-                                message="Step could not be found for output condition"
-                                context={
-                                    "Step" : occurrence.Core.Component.RawId,
-                                    "Output" :{
-                                        "StepId" : stepId,
-                                        "Output" : output
-                                    }
-                                }
-                            /]
-                        [/#if]
-
-                        [#local replacements = mergeObjects(replacements, { "__${substitution}__" : "__Properties:${substitution}__" }) ]
-                    [/#if]
-                    [#break]
-            [/#switch]
-        [/#if]
-    [/#list]
-
-    [#list replacements as original, new ]
-        [#local value = value?replace(original, new)]
-    [/#list]
-
-    [#return value]
-[/#function]
 
 [#-- Provides information on the format of the runbook and what it does --]
 [#macro shared_runbook_default_runbookinfo_generationcontract occurrence ]

--- a/providers/shared/dynamicvalues/attribute/dynamicvalue.ftl
+++ b/providers/shared/dynamicvalues/attribute/dynamicvalue.ftl
@@ -1,0 +1,46 @@
+[#ftl]
+
+[@addDynamicValueProvider
+    type=ATTRIBUTE_DYNAMIC_VALUE_TYPE
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Returns the attribute of a link configured under the components Links"
+        }
+    ]
+    parameterOrder=["linkId", "attributeName"]
+    parameterAttributes=[
+        {
+            "Names" : "linkId",
+            "Description" : "The Id of the link to get the attribute from",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "attributeName",
+            "Description" : "The name of the attribute on the link",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        }
+    ]
+    supportedComponentTypes=["*"]
+/]
+
+[#function shared_dynamicvalue_attribute value properties occurrence extraSources={} ]
+
+    [#local link = (occurrence.Configuration.Solution.Links[properties.linkId])!{}]
+    [#local linkTarget = getLinkTarget(occurrence, link)]
+
+    [#if ! linkTarget?has_content ]
+        [@fatal
+            message="Link could not be found for attribute"
+            context={
+                "Step"  : occurrence.Core.Component.RawId,
+                "LinkId" : properties.linkId,
+                "Links" : occurrence.Configuration.Solution.Links
+            }
+        /]
+    [/#if]
+
+    [#return (linkTarget.State.Attributes[properties.attributeName])!"" ]
+[/#function]

--- a/providers/shared/dynamicvalues/attribute/dynamicvalue.ftl
+++ b/providers/shared/dynamicvalues/attribute/dynamicvalue.ftl
@@ -23,24 +23,26 @@
             "Mandatory" : true
         }
     ]
-    supportedComponentTypes=["*"]
 /]
 
-[#function shared_dynamicvalue_attribute value properties occurrence extraSources={} ]
+[#function shared_dynamicvalue_attribute value properties sources={} ]
 
-    [#local link = (occurrence.Configuration.Solution.Links[properties.linkId])!{}]
-    [#local linkTarget = getLinkTarget(occurrence, link)]
+    [#if sources.occurrence?? ]
+        [#local link = (sources.occurrence.Configuration.Solution.Links[properties.linkId])!{}]
+        [#local linkTarget = getLinkTarget(sources.occurrence, link)]
 
-    [#if ! linkTarget?has_content ]
-        [@fatal
-            message="Link could not be found for attribute"
-            context={
-                "Step"  : occurrence.Core.Component.RawId,
-                "LinkId" : properties.linkId,
-                "Links" : occurrence.Configuration.Solution.Links
-            }
-        /]
+        [#if ! linkTarget?has_content ]
+            [@fatal
+                message="Link could not be found for attribute"
+                context={
+                    "Step"  : sources.occurrence.Core.Component.RawId,
+                    "LinkId" : properties.linkId,
+                    "Links" : sources.occurrence.Configuration.Solution.Links
+                }
+            /]
+        [/#if]
+
+        [#return (linkTarget.State.Attributes[properties.attributeName])!"" ]
     [/#if]
-
-    [#return (linkTarget.State.Attributes[properties.attributeName])!"" ]
+    [#return "__${vaule}__"]
 [/#function]

--- a/providers/shared/dynamicvalues/dynamicvalue.ftl
+++ b/providers/shared/dynamicvalues/dynamicvalue.ftl
@@ -1,0 +1,6 @@
+[#ftl]
+
+[#assign ATTRIBUTE_DYNAMIC_VALUE_TYPE = "attribute" ]
+[#assign INPUT_DYNAMIC_VALUE_TYPE = "input" ]
+[#assign OUTPUT_DYNAMIC_VALUE_TYPE = "output" ]
+[#assign SETTING_DYNAMIC_VALUE_TYPE = "setting" ]

--- a/providers/shared/dynamicvalues/input/dynamicvalue.ftl
+++ b/providers/shared/dynamicvalues/input/dynamicvalue.ftl
@@ -17,20 +17,29 @@
             "Mandatory" : true
         }
     ]
-    supportedComponentTypes=[
-        RUNBOOK_COMPONENT_TYPE,
-        RUNBOOK_STEP_COMPONENT_TYPE
-    ]
 /]
 
-[#function shared_dynamicvalue_input value properties occurrence extraSources={} ]
-    [#if ((extraSources.inputs)!{})?has_content]
+[#function shared_dynamicvalue_input value properties sources={} ]
 
-        [#if ! extraSources.inputs?keys?seq_contains(properties.inputId)?has_content ]
+    [#if sources.occurrence?? ]
+        [#if ! [RUNBOOK_COMPONENT_TYPE, RUNBOOK_STEP_COMPONENT_TYPE]?seq_contains(sources.occurrence.Core.Type) ]
+            [@fatal
+                message="Dynamic value type ${OUTPUT_DYNAMIC_VALUE_TYPE} only supported for runbooks"
+                context={
+                    "ComponentId" : sources.occurrence.Core.Component.RawId,
+                    "SubComponentId" : (sources.occur.Core.SubComponent.RawId)!"",
+                    "DynamicValue" : "__${value}__"
+                }
+            /]
+        [/#if]
+    [/#if]
+
+    [#if sources.inputs?? && sources.occurrence?? ]
+        [#if ! sources.inputs?keys?seq_contains(properties.inputId)?has_content ]
             [@fatal
                 message="Input Id could not be found"
                 context={
-                    "Step" : occurrence.Core.Component.RawId,
+                    "Step" : sources.occurrence.Core.Component.RawId,
                     "Input" : inputId
                 }
             /]
@@ -38,5 +47,5 @@
         [#return "__Properties:${value}__" ]
     [/#if]
 
-    [#return value]
+    [#return "__${value}__"]
 [/#function]

--- a/providers/shared/dynamicvalues/input/dynamicvalue.ftl
+++ b/providers/shared/dynamicvalues/input/dynamicvalue.ftl
@@ -1,0 +1,42 @@
+[#ftl]
+
+[@addDynamicValueProvider
+    type=INPUT_DYNAMIC_VALUE_TYPE
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Returns the value of a runbook input"
+        }
+    ]
+    parameterOrder=["inputId"]
+    parameterAttributes=[
+        {
+            "Names" : "inputId",
+            "Description" : "The Id of the runbook input",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        }
+    ]
+    supportedComponentTypes=[
+        RUNBOOK_COMPONENT_TYPE,
+        RUNBOOK_STEP_COMPONENT_TYPE
+    ]
+/]
+
+[#function shared_dynamicvalue_input value properties occurrence extraSources={} ]
+    [#if ((extraSources.inputs)!{})?has_content]
+
+        [#if ! extraSources.inputs?keys?seq_contains(properties.inputId)?has_content ]
+            [@fatal
+                message="Input Id could not be found"
+                context={
+                    "Step" : occurrence.Core.Component.RawId,
+                    "Input" : inputId
+                }
+            /]
+        [/#if]
+        [#return "__Properties:${value}__" ]
+    [/#if]
+
+    [#return value]
+[/#function]

--- a/providers/shared/dynamicvalues/output/dynamicvalue.ftl
+++ b/providers/shared/dynamicvalues/output/dynamicvalue.ftl
@@ -23,20 +23,29 @@
             "Mandatory" : true
         }
     ]
-    supportedComponentTypes=[
-        RUNBOOK_COMPONENT_TYPE,
-        RUNBOOK_STEP_COMPONENT_TYPE
-    ]
 /]
 
-[#function shared_dynamicvalue_output value properties occurrence extraSources={} ]
+[#function shared_dynamicvalue_output value properties sources={} ]
 
-    [#if ((extraSources.stepIds)!{})?has_content]
-        [#if ! (extraSources.stepIds)?seq_contains(properties.stepId) ]
+    [#if sources.occurrence?? ]
+        [#if ! [RUNBOOK_COMPONENT_TYPE, RUNBOOK_STEP_COMPONENT_TYPE]?seq_contains(sources.occurrence.Core.Type) ]
+            [@fatal
+                message="Dynamic value type ${OUTPUT_DYNAMIC_VALUE_TYPE} only supported for runbooks"
+                context={
+                    "ComponentId" : sources.occurrence.Core.Component.RawId,
+                    "SubComponentId" : (sources.occur.Core.SubComponent.RawId)!"",
+                    "DynamicValue" : "__${value}__"
+                }
+            /]
+        [/#if]
+    [/#if]
+
+    [#if sources.inputs?? && sources.occurrence?? ]
+        [#if ! (sources.stepIds)?seq_contains(properties.stepId) ]
             [@fatal
                 message="Step could not be found for output"
                 context={
-                    "Step" : occurrence.Core.Component.RawId,
+                    "Step" : sources.occurrence.Core.Component.RawId,
                     "Output" :{
                         "StepId" : properties.stepId,
                         "OutputKey" : properties.outputKey
@@ -48,5 +57,5 @@
         [#return "__Properties:${value}__"  ]
     [/#if]
 
-    [#return value]
+    [#return "__${value}__"]
 [/#function]

--- a/providers/shared/dynamicvalues/output/dynamicvalue.ftl
+++ b/providers/shared/dynamicvalues/output/dynamicvalue.ftl
@@ -1,0 +1,52 @@
+[#ftl]
+
+[@addDynamicValueProvider
+    type=OUTPUT_DYNAMIC_VALUE_TYPE
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Returns the value of a runbook step output"
+        }
+    ]
+    parameterOrder=["stepId", "outputKey"]
+    parameterAttributes=[
+        {
+            "Names" : "stepId",
+            "Description" : "The Id of the step to collect the output from",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "outputKey",
+            "Description" : "The key of the output to return",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        }
+    ]
+    supportedComponentTypes=[
+        RUNBOOK_COMPONENT_TYPE,
+        RUNBOOK_STEP_COMPONENT_TYPE
+    ]
+/]
+
+[#function shared_dynamicvalue_output value properties occurrence extraSources={} ]
+
+    [#if ((extraSources.stepIds)!{})?has_content]
+        [#if ! (extraSources.stepIds)?seq_contains(properties.stepId) ]
+            [@fatal
+                message="Step could not be found for output"
+                context={
+                    "Step" : occurrence.Core.Component.RawId,
+                    "Output" :{
+                        "StepId" : properties.stepId,
+                        "OutputKey" : properties.outputKey
+                    }
+                }
+            /]
+        [/#if]
+
+        [#return "__Properties:${value}__"  ]
+    [/#if]
+
+    [#return value]
+[/#function]

--- a/providers/shared/dynamicvalues/setting/dynamicvalue.ftl
+++ b/providers/shared/dynamicvalues/setting/dynamicvalue.ftl
@@ -1,0 +1,32 @@
+[#ftl]
+
+[@addDynamicValueProvider
+    type=SETTING_DYNAMIC_VALUE_TYPE
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Returns the value of a components setting"
+        }
+    ]
+    parameterOrder=["settingEnvKey"]
+    parameterAttributes=[
+        {
+            "Names" : "settingEnvKey",
+            "Description" : "The Key of the setting when defined as an environment variable",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        }
+    ]
+    supportedComponentTypes=["*"]
+/]
+
+[#function shared_dynamicvalue_setting value properties occurrence extraSources={} ]
+    [#local collectedSettings = {}]
+    [#list (occurrence.Configuration.Settings)?values?filter(x -> x?has_content) as settingGroup ]
+        [#list settingGroup as key, value]
+            [#local collectedSettings = mergeObjects(collectedSettings, { key : value } )]
+        [/#list]
+    [/#list]
+
+    [#return (collectedSettings[properties.settingEnvKey].Value)!""]
+[/#function]

--- a/providers/shared/dynamicvalues/setting/dynamicvalue.ftl
+++ b/providers/shared/dynamicvalues/setting/dynamicvalue.ftl
@@ -17,16 +17,18 @@
             "Mandatory" : true
         }
     ]
-    supportedComponentTypes=["*"]
 /]
 
-[#function shared_dynamicvalue_setting value properties occurrence extraSources={} ]
-    [#local collectedSettings = {}]
-    [#list (occurrence.Configuration.Settings)?values?filter(x -> x?has_content) as settingGroup ]
-        [#list settingGroup as key, value]
-            [#local collectedSettings = mergeObjects(collectedSettings, { key : value } )]
+[#function shared_dynamicvalue_setting value properties sources={} ]
+    [#if sources.occurrence??]
+        [#local collectedSettings = {}]
+        [#list (sources.occurrence.Configuration.Settings)?values?filter(x -> x?has_content) as settingGroup ]
+            [#list settingGroup as key, value]
+                [#local collectedSettings = mergeObjects(collectedSettings, { key : value } )]
+            [/#list]
         [/#list]
-    [/#list]
 
-    [#return (collectedSettings[properties.settingEnvKey].Value)!""]
+        [#return (collectedSettings[properties.settingEnvKey].Value)!""]
+    [/#if]
+    [#return "__${value}__"]
 [/#function]

--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -967,7 +967,15 @@ that doesn't match the link.
                         {
                             "State" : constructOccurrenceState(occurrence, parentOccurrence)
 
-                        } ]
+                        }]
+
+                    [#local occurrence +=
+                        {
+                            "Configuration" : {
+                                "Solution" : resolveDynamicValues(occurrence, occurrence.Configuration.Solution)
+                            }
+                        }
+                    ]
 
                     [#-- Add suboccurrences --]
                     [#local subOccurrences = [] ]

--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -969,13 +969,14 @@ that doesn't match the link.
 
                         }]
 
-                    [#local occurrence +=
-                        {
-                            "Configuration" : {
-                                "Solution" : resolveDynamicValues(occurrence, occurrence.Configuration.Solution)
+                    [#local occurrence = mergeObjects(
+                            occurrence,
+                            {
+                                "Configuration" : {
+                                    "Solution" : resolveDynamicValues(occurrence.Configuration.Solution, {"occurrence" : occurrence})
+                                }
                             }
-                        }
-                    ]
+                        )]
 
                     [#-- Add suboccurrences --]
                     [#local subOccurrences = [] ]

--- a/providers/sharedtest/inputseeders/sharedtest/id.ftl
+++ b/providers/sharedtest/inputseeders/sharedtest/id.ftl
@@ -47,6 +47,10 @@
             {
                 "Product" : {
                     "Modules" : {
+                        "dynamicvalue" : {
+                            "Provider" : "sharedtest",
+                            "Name" : "dynamicvalue"
+                        },
                         "internaltest" : {
                             "Provider" : "sharedtest",
                             "Name" : "internaltest"

--- a/providers/sharedtest/modules/dynamicvalue/module.ftl
+++ b/providers/sharedtest/modules/dynamicvalue/module.ftl
@@ -1,0 +1,96 @@
+[#ftl]
+
+[@addModule
+    name="dynamicvalue"
+    description="Internal testing for hamlet using fake component"
+    provider=SHAREDTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro sharedtest_module_dynamicvalue ]
+
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "app" : {
+                    "Components" : {
+                        "dynamicvalue" : {
+                            "Type" : "internaltest",
+                            "deployment:Unit" : "shared-dynamicvalue",
+                            "Settings" : {
+                                "ComponentSetting" : {
+                                    "Value" : "ComponentSettingValue"
+                                }
+                            },
+                            "Tags" : {
+                                "Additional" : {
+                                    "ComponentSettingTag" : {
+                                        "Value" : "__setting:ComponentSetting__"
+                                    },
+                                    "AttributeTag": {
+                                        "Value" : "__attribute:dynamicvalue_link:NAME__"
+                                    },
+                                    "CombinedValueTag" : {
+                                        "Value" : "link:__attribute:dynamicvalue_link:NAME__:setting:__setting:ComponentSetting__"
+                                    }
+                                }
+                            },
+                            "Profiles" : {
+                                "Testing" : [ "dynamicvalue" ],
+                                "Placement" : "internal"
+                            },
+                            "Links" : {
+                                "dynamicvalue_link" : {
+                                    "Tier" : "app",
+                                    "Component" : "dynamicvalue_link"
+                                }
+                            }
+                        },
+                        "dynamicvalue_link" : {
+                            "Type" : "externalservice",
+                            "Properties" : {
+                                "name" : {
+                                    "Key" : "NAME",
+                                    "Value" : "dyanmicvalue-link-attribute-name"
+                                }
+                            },
+                            "Profiles" : {
+                                "Placement" : "shared"
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "dynamicvalue" : {
+                    "internaltest" : {
+                        "TestCases" : [ "dynamicvalue" ]
+                    }
+                }
+            },
+            "TestCases" : {
+                "dynamicvalue" : {
+                    "OutputSuffix" : "config.json",
+                    "Structural" : {
+                        "JSON" : {
+                            "Match" : {
+                                "resolvedComponentSettingTag" : {
+                                    "Path" : "Occurrence.Configuration.Solution.Tags.Additional.ComponentSettingTag.Value",
+                                    "Value" : "ComponentSettingValue"
+                                },
+                                "resolvedLinkAttributeTag" : {
+                                    "Path" : "Occurrence.Configuration.Solution.Tags.Additional.AttributeTag.Value",
+                                    "Value": "dyanmicvalue-link-attribute-name"
+                                },
+                                "combinedValueTag" : {
+                                    "Path" : "Occurrence.Configuration.Solution.Tags.Additional.CombinedValueTag.Value",
+                                    "Value": "link:dyanmicvalue-link-attribute-name:setting:ComponentSettingValue"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]

--- a/providers/sharedtest/modules/internaltest/module.ftl
+++ b/providers/sharedtest/modules/internaltest/module.ftl
@@ -18,7 +18,7 @@
                             "internaltest" : {
                                 "Instances" : {
                                     "default" : {
-                                        "deployment:Unit" : "shared-internaltest-base"
+                                        "deployment:Unit" : "shared-internaltest"
                                     }
                                 },
                                 "Profiles" : {

--- a/providers/sharedtest/modules/runbook/module.ftl
+++ b/providers/sharedtest/modules/runbook/module.ftl
@@ -57,7 +57,7 @@
                                 "step2" : {
                                     "Priority" : 20,
                                     "Task" : {
-                                        "Type" : "start_ssh_shell",
+                                        "Type" : "ssh_run_command",
                                         "Parameters" : {
                                             "Username" : {
                                                 "Value" : "admin"


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Extends the dynamic value evaluation from solution configuration on runbooks to a more generic function which can be used across all components and their solution configuration 

Dynamic values can be used in solution configuration to represent a value that should be resolved at run time rather than an explicit configuration defined in the solution file. 

They can be used anywhere a string is accepted and can be used at any point in the string. They follow the format of 

`__<type>:<attributes>...__`

Where type is the type attribute assigned to a Dynamic Value Provider and the attributes section represents one or more attributes separated by `:` These attributes are used by the provider to determine the value to replace. When a replacement occurs all of the dynamic value from __ to __ ( inclusive ) are replaced with the resolved value. 

Supported dynamic value providers in this initial PR are 

- setting: looks for a setting key in the environment variable syntax for Settings and provides the setting value for the replacement 
- attribute: given the id of a link configured under the component Solution.Links Object and the name of an attribute of that component, return the attribute as the replacement
- input: used for runbooks only and returns a RunBookInput command line value for replacement
- output: used for rubooks only and is used to pass outputs between contract steps 

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
There were a couple of motivations for adding support for this feature 

- Use runbook inputs on runbook solution configuration. With moving dynamic value provides up to the occurrence level it enables the use of inputs on the runbook solution configuration. This is useful when you might want to run a runbook across multiple components ( like emptying S3 buckets ), using this approach you can make the Component parameter of the link a dynamic input value and during the occurrence processing the value will be replaced. 
- Longer or complicated values can be stored as settings and referenced using a dynamic placeholder. Some components require details like long URLS, certificates or other long string values. With dynamic values these can be stored in a settings file and then updated at runtime

With the ability for providers to add their own dynamic value providers this could be used to substitute secrets encrypted values that should be decrypted or require specific reference configuration ( [AWS CF Dynamic references](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html) to be used whenever a user wants to use them

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and with additional test cases

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

