### PR TITLE
feat(correspondent): add  support for channel configuration

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -41,6 +41,7 @@
 [#assign CONTENTHUB_NODE_COMPONENT_TYPE = "contentnode"]
 
 [#assign CORRESPONDENT_COMPONENT_TYPE = "correspondent"]
+[#assign CORRESPONDENT_CHANNEL_COMPONENT_TYPE = "correspondentchannel"]
 
 [#assign DATAFEED_COMPONENT_TYPE = "datafeed" ]
 

--- a/providers/shared/components/correspondent/id.ftl
+++ b/providers/shared/components/correspondent/id.ftl
@@ -24,3 +24,81 @@
     defaultGroup="solution"
     defaultPriority=70
 /]
+
+
+[@addChildComponent
+    type=CORRESPONDENT_CHANNEL_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A channel used to send correspondence"
+            }
+        ]
+    attributes=
+        [
+            {
+                "Names" : "Enabled",
+                "Types": BOOLEAN_TYPE,
+                "Default" : true
+            },
+            {
+                "Names" : "Engine",
+                "Description": "The service used to send correspondence",
+                "Types" : STRING_TYPE,
+                "Values" : [ "apns", "apns_sandbox", "firebase" ],
+                "Mandatory" : true
+            },
+            {
+                "Names" : "engine:Firebase",
+                "Description" : "Specific channel configuration for Firebase/Google notification services",
+                "Children" : [
+                    {
+                        "Names" : "APIKey",
+                        "Description" : "The setting or link name to use for the API Key - setting:_setting name_ - link: _link name_",
+                        "Types" : STRING_TYPE
+                    }
+                ]
+            },
+            {
+                "Names" : "engine:APNS",
+                "Description" : "Specific channel configuration for Apple Notification Services",
+                "Children" : [
+                    {
+                        "Names": "Certificate",
+                        "Description" : "The push notification public certificate",
+                        "Types" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "PrivateKey",
+                        "Description" : "The push notification private key",
+                        "Types" : STRING_TYPE
+                    }
+                ]
+            },
+            {
+                "Names" : "engine:APNSSandbox",
+                "Description" : "Specific channel configuration for Apple Sandbox Notification Services",
+                "Children" : [
+                    {
+                        "Names": "Certificate",
+                        "Description" : "The push notification public certificate",
+                        "Types" : STRING_TYPE
+                    },
+                    {
+                        "Names" : "PrivateKeySource",
+                        "Description" : "The push notification private key",
+                        "Types" : STRING_TYPE
+                    }
+                ]
+            },
+            {
+                "Names" : "Links",
+                "SubObjects" : true,
+                "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+            }
+        ]
+    parent=CORRESPONDENT_COMPONENT_TYPE
+    childAttribute="Channels"
+    linkAttributes=["Channel"]
+/]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- adds support for defining the configuration required for mobile push notifications

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Used when setting up correspondent services like AWS pinpoint for notifications to mobile devices

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

