### PR TITLE
feat(lambda): lambda alias

### DIFF
--- a/providers/shared/components/id.ftl
+++ b/providers/shared/components/id.ftl
@@ -116,6 +116,7 @@
 [#assign EVENTSTREAM_ATTRIBUTE_TYPE = "stream"]
 [#assign SECRET_ATTRIBUTE_TYPE = "secret"]
 [#assign RESULT_ATTRIBUTE_TYPE = "result" ]
+[#assign VERSION_ATTRIBUTE_TYPE = "version" ]
 
 [#-- special attribute type to handle references --]
 [#assign REFERENCE_ATTRIBUTE_TYPE = "ref" ]

--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -199,6 +199,11 @@
                         "Description" : "What should happen to the superceded version when new version on deploy?",
                         "Values" : [ "Delete", "Retain" ],
                         "Default" : "Retain"
+                    },
+                    {
+                        "Names" : "Alias",
+                        "Types" : STRING_TYPE,
+                        "Description" : "Provide a logical name pointing to the most recent version"
                     }
                 ]
             },


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
When deploying a fixed lambda version, provide the option of a lambda alias to avoid the need to update references when a new version of the lambda is created.


## Motivation and Context
- simplify deployment management

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

