### PR TITLE
feat(entrance): stackoutput entrance

### DIFF
--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -635,6 +635,7 @@
     [#switch entrance ]
         [#case "deployment" ]
         [#case "deploymenttest" ]
+        [#case "stackoutput"]
 
             [#-- overrride the level prefix to align with older deployment groups --]
             [#local deploymentGroupDetails = getDeploymentGroupDetails(deployment_group)]

--- a/providers/shared/components/shared/setup.ftl
+++ b/providers/shared/components/shared/setup.ftl
@@ -358,3 +358,17 @@
         [/#if]
     [/#list]
 [/#macro]
+
+[#-- Stack Output File --]
+[#macro shared_stackoutput_generationcontract occurrence]
+    [@addDefaultGenerationContract subsets=["stack"] /]
+[/#macro]
+
+[#macro shared_stackoutput occurrence ]
+    [#list getCommandLineOptions()["StackOutputContent"] as key,value ]
+        [@stackOutput
+            key=key
+            value=value
+        /]
+    [/#list]
+[/#macro]

--- a/providers/shared/entrances/entrance.ftl
+++ b/providers/shared/entrances/entrance.ftl
@@ -16,5 +16,6 @@
 [#assign SCHEMALIST_ENTRANCE_TYPE        = "schemalist" ]
 [#assign OCCURRENCES_ENTRANCE_TYPE       = "occurrences" ]
 [#assign RELEASEINFO_ENTRANCE_TYPE       = "releaseinfo" ]
+[#assign STACKOUTPUT_ENTRANCE_TYPE       = "stackoutput" ]
 [#assign UNITLIST_ENTRANCE_TYPE          = "unitlist" ]
 [#assign VALIDATE_ENTRANCE_TYPE          = "validate" ]

--- a/providers/shared/entrances/stackoutput/entrance.ftl
+++ b/providers/shared/entrances/stackoutput/entrance.ftl
@@ -1,0 +1,50 @@
+[#ftl]
+
+[#-- Entrance logic --]
+[#macro shared_entrance_stackoutput ]
+
+    [#local deploymentGroupDetails = getDeploymentGroupDetails(getDeploymentGroup())]
+
+    [@generateOutput
+        deploymentFramework=getCLODeploymentFramework()
+        type=getCLODeploymentOutputType()
+        format=getCLODeploymentOutputFormat()
+        level=getDeploymentLevel()
+        include=(.vars[deploymentGroupDetails.CompositeTemplate])!""
+    /]
+[/#macro]
+
+[#-- Add seeder for command line options --]
+[#macro shared_entrance_stackoutput_inputsteps ]
+
+    [@registerInputSeeder
+        id=STACKOUTPUT_ENTRANCE_TYPE
+        description="Entrance"
+    /]
+
+    [@addSeederToConfigPipeline
+        stage=COMMANDLINEOPTIONS_SHARED_INPUT_STAGE
+        seeder=STACKOUTPUT_ENTRANCE_TYPE
+    /]
+
+[/#macro]
+
+[#-- Set the required flow/view --]
+[#function stackoutput_configseeder_commandlineoptions filter state]
+
+    [#return
+        addToConfigPipelineClass(
+            state,
+            COMMAND_LINE_OPTIONS_CONFIG_INPUT_CLASS,
+            {
+                "Deployment" : {
+                    "Framework" : {
+                        "Name" : DEFAULT_DEPLOYMENT_FRAMEWORK
+                    }
+                },
+                "StackOutputContent" : ((StackOutputContent)!"{}")?eval_json
+            }
+        )
+    ]
+
+[/#function]

--- a/providers/shared/entrances/stackoutput/id.ftl
+++ b/providers/shared/entrances/stackoutput/id.ftl
@@ -1,0 +1,23 @@
+[#ftl]
+
+[@addEntrance
+    type=STACKOUTPUT_ENTRANCE_TYPE
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "Writes the provided content as a stack output"
+            }
+        ]
+    commandlineoptions=[
+        {
+            "Names" : "StackOutputContent",
+            "Description" : "A JSON escaped string that will be used as the contents of the output file",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "*",
+            "Types" : ANY_TYPE
+        }
+    ]
+/]

--- a/providers/shared/inputseeders/shared/id.ftl
+++ b/providers/shared/inputseeders/shared/id.ftl
@@ -109,6 +109,7 @@
                 [#-- Input data control --]
                 "Input" : {
                     "Source" : inputSource!"composite",
+                    "RootDir": (rootDir)!"",
                     "Filter" :
                         attributeIfContent("DistrictType", districtType!SEGMENT_DISTRICT_TYPE) +
                         attributeIfContent("Tenant", tenant!"") +

--- a/providers/shared/tasks/cmdb_write_stack_output/id.ftl
+++ b/providers/shared/tasks/cmdb_write_stack_output/id.ftl
@@ -1,0 +1,91 @@
+[#ftl]
+
+[@addTask
+    type=CMDB_WRITE_STACK_OUTPUT
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Write a stack output as part of a runbook"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "StackOutputContent",
+            "Description" : "The key value parirs to write to the file as a JSON escaped string",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "DeploymentUnit",
+            "Description" : "The deployment unit the stack belongs to",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "DeploymentGroup",
+            "Description" : "The deployment group the stack belongs to",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names": "GenerationFramework",
+            "Description" : "The framework to use for generating the template",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "GenerationProviders",
+            "Description" : "A list of generation providers used for the engine",
+            "Types": STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "GenerationInputSource",
+            "Description" : "The input source used for te engine",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        }
+        {
+            "Names" : "RootDir",
+            "Description" : "The CMDB root directory path",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "DistrictType",
+            "Description" : "The type of district used in the deployment",
+            "Types" : STRING_TYPE,
+            "Mandatory": true
+        },
+        {
+            "Names": "Tenant",
+            "Description" : "The Name of the tenant layer",
+            "Types" : STRING_TYPE,
+            "Default" : ""
+        },
+        {
+            "Names": "Account",
+            "Description" : "The Name of the account layer",
+            "Types" : STRING_TYPE,
+            "Default" : ""
+        },
+        {
+            "Names": "Product",
+            "Description" : "The Name of the product layer",
+            "Types" : STRING_TYPE,
+            "Default" : ""
+        },
+        {
+            "Names": "Environment",
+            "Description" : "The Name of the environment layer",
+            "Types" : STRING_TYPE,
+            "Default" : ""
+        },
+        {
+            "Names": "Segment",
+            "Description" : "The Name of the segment layer",
+            "Types" : STRING_TYPE,
+            "Default" : ""
+        }
+    ]
+/]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds the stackoutput entrance which generates a stack output file based on the provided stack output inputs
- Adds a task to call the stackoutput entrance from a runbook
- Adds the CMDB Root dir as a common input parameter

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for runbooks to contribute stack outputs for components. This also supports the migration to deployment contracts in the future with the potential to collect all stack outputs generated during a deployment and write them to a single file. 

This would remove the need for multiple pseduo stack outputs and have a single stack output state file.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

