### PR TITLE
feat(image): initial image component 

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -110,6 +110,8 @@
 
 [#assign HOSTING_PLATFORM_COMPONENT_TYPE = "hostingplatform"]
 
+[#assign IMAGE_COMPONENT_TYPE = "image"]
+
 [#assign INTERNALTEST_COMPONENT_TYPE = "internaltest" ]
 
 [#assign LAMBDA_COMPONENT_TYPE = "lambda"]

--- a/providers/shared/components/image/id.ftl
+++ b/providers/shared/components/image/id.ftl
@@ -1,0 +1,69 @@
+[#ftl]
+
+[@addComponent
+    type=IMAGE_COMPONENT_TYPE
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "An Application image used by other components in the solution"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "Format",
+            "Description" : "The format of the image whih defines the components that support the image",
+            "Values" : [
+                "scripts",
+                "spa",
+                "docker",
+                "dataset",
+                "contentnode",
+                "lambda",
+                "lambda_jar",
+                "openapi"
+            ]
+        },
+        {
+            "Names" : "Source",
+            "Description" : "The source of the image",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true,
+            "Values" : [ "Registry", "ContainerRegistry", "URL" ],
+            "Default" : "Registry"
+        },
+        {
+            "Names" : "Source:ContainerRegistry",
+            "Description" : "A docker container registry to source the image from",
+            "Children" : [
+                {
+                    "Names" : "Image",
+                    "Description" : "The docker image that you want to use",
+                    "Types" : STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : "Source:URL",
+            "Description" : "Download the image from an external service based on URL",
+            "Children" : [
+                {
+                    "Names" : "URL",
+                    "Description" : "The URL to the image to download",
+                    "Types" : STRING_TYPE
+                },
+                {
+                    "Names" : "ImageHash",
+                    "Description" : "The expected sha1 hash of the Url if empty any will be accepted",
+                    "Types" : STRING_TYPE,
+                    "Default" : ""
+                }
+            ]
+        }
+    ]
+/]
+
+[@addComponentDeployment
+    type=IMAGE_COMPONENT_TYPE
+    defaultGroup="application"
+/]

--- a/providers/shared/components/image/id.ftl
+++ b/providers/shared/components/image/id.ftl
@@ -26,11 +26,11 @@
         },
         {
             "Names" : "Source",
-            "Description" : "The source of the image",
+            "Description" : "The source of the image - Local: an image built locally - ContainerRegistry: a public container registry - URL: a public URL",
             "Types" : STRING_TYPE,
             "Mandatory" : true,
-            "Values" : [ "Registry", "ContainerRegistry", "URL" ],
-            "Default" : "Registry"
+            "Values" : [ "Local", "ContainerRegistry", "URL" ],
+            "Default" : "Local"
         },
         {
             "Names" : "Source:ContainerRegistry",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds the initial shared definition for an image component

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This introduces a dedicated image component which represents the application code image used by other components ( SPA, Docker, API Gateway, Lambda )

Creating a dedicated image allows for greater flexibility in how images are managed  
  - A single image component can be used by many components 
  - This is clearly defined in the solution
  - The image can be maintained separately from the consuming components 
  - Consolidates the pulling from external sources management to avoid duplication across setup routines

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

