### PR TITLE
fix(output): output prefix handling

### DIFF
--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -605,10 +605,13 @@
         [#case "info"]
         [#case "loader"]
         [#case "occurrences"]
-        [#case "schemaset"]
+        [#case "schemalist"]
         [#case "unitlist"]
         [#case "validate"]
         [#case "imagedetails"]
+        [#case "releaseinfo"]
+        [#case "configuration"]
+        [#case "inputinfo"]
             [#local filename_parts =
                         mergeObjects(
                             filename_parts,
@@ -629,6 +632,21 @@
                         )
             ]
             [#break]
+
+        [#case "deployment"]
+        [#case "deploymentest"]
+        [#case "stackoutput"]
+        [#case "buildblueprint"]
+            [#break]
+
+        [#default]
+            [@fatal
+                message="Output file prefix: missing deployment detail configuration"
+                detail="each entrance needs to define thier requirment for deployment based information in file naming"
+                context={
+                    "Entrance": entrance
+                }
+            /]
     [/#switch]
 
     [#-- Deployment based prefixing --]
@@ -636,6 +654,7 @@
         [#case "deployment" ]
         [#case "deploymenttest" ]
         [#case "stackoutput"]
+        [#case "buildblueprint"]
 
             [#-- overrride the level prefix to align with older deployment groups --]
             [#local deploymentGroupDetails = getDeploymentGroupDetails(deployment_group)]

--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -634,7 +634,7 @@
             [#break]
 
         [#case "deployment"]
-        [#case "deploymentest"]
+        [#case "deploymenttest"]
         [#case "stackoutput"]
         [#case "buildblueprint"]
             [#break]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- make it required that deployment prefix handling is managed for all entrances

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
If you have defined environment variables that aren't required for a specific entrance then they can be unintentionally added to the output filename and this creates flow on effect issues for consumers of the outputs

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

