### PR TITLE
fix: schema entrance output filename

### DIFF
--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -606,6 +606,7 @@
         [#case "loader"]
         [#case "occurrences"]
         [#case "schemalist"]
+        [#case "schema"]
         [#case "unitlist"]
         [#case "validate"]
         [#case "imagedetails"]
@@ -642,7 +643,7 @@
         [#default]
             [@fatal
                 message="Output file prefix: missing deployment detail configuration"
-                detail="each entrance needs to define thier requirment for deployment based information in file naming"
+                detail="Each entrance needs to define their requirement for deployment based information in file naming"
                 context={
                     "Entrance": entrance
                 }


### PR DESCRIPTION

## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
- add configuration for the output prefix to be used with the `schema` entrance
- correct the spelling of the error where the prefix for an entrance is not known

## Motivation and Context
tram build failing

## How Has This Been Tested?
Local execution of the `create-schemas` entrance

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

