### PR TITLE
feat(cdn): extended support for managing complex requirements

### DIFF
--- a/providers/shared/attributesets/attributeset.ftl
+++ b/providers/shared/attributesets/attributeset.ftl
@@ -3,6 +3,8 @@
 [#assign ALERT_ATTRIBUTESET_TYPE = "alert" ]
 [#assign AUTOSCALEGROUP_ATTRIBUTESET_TYPE = "autoscalegroup"]
 [#assign BACKUPWINDOW_ATTRIBUTESET_TYPE = "backupwindow" ]
+[#assign CDNORIGIN_ATTRIBUTESET_TYPE = "cdnorigin"]
+[#assign CDNTTL_ATTRIBUTESET_TYPE = "cdnttl"]
 [#assign COMPUTEIMAGE_ATTRIBUTESET_TYPE = "computeimage"]
 [#assign CONTTAINERTASK_ATTRIBUTESET_TYPE = "containertask"]
 [#assign CONTEXTPATH_ATTRIBUTESET_TYPE = "contextpath"]

--- a/providers/shared/attributesets/cdnorigin/id.ftl
+++ b/providers/shared/attributesets/cdnorigin/id.ftl
@@ -1,0 +1,96 @@
+[#ftl]
+
+[@addAttributeSet
+    type=CDNORIGIN_ATTRIBUTESET_TYPE
+    properties=[
+        {
+                "Type"  : "Description",
+                "Value" : "Configuration for a CDN origin"
+        }]
+    attributes=[
+        {
+            "Names" : "ConnectionTimeout",
+            "Description" : "How long to wait until a response is received from the origin",
+            "Types" : NUMBER_TYPE,
+            "Default" : 30
+        },
+        {
+            "Names" : "TLSProtocols",
+            "Description" : "When using a TLS backend the protocols the CDN will use as a client",
+            "Types" : ARRAY_OF_STRING_TYPE,
+            "Values" : [ "TLSv1.2", "TLSv1.1", "TLSv1", "SSLv3" ],
+            "Default" : [ "TLSv1.2" ]
+        },
+        {
+            "Names" : "BasePath",
+            "Description" : "The base path at the origin destination",
+            "Types" : STRING_TYPE,
+            "Default" : ""
+        },
+        {
+            "Names" : "Link",
+            "Mandatory" : true,
+            "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+        },
+        {
+            "Names" : "RequestForwarding",
+            "Description" : "Controls how the request is forwarded to the origin",
+            "Children" : [
+                {
+                    "Names" : "AdditionalHeaders",
+                    "Description": "Headers to add when forwarding the request to the origin",
+                    "SubObjects": true,
+                    "Children" : [
+                        {
+                            "Names" : "Name",
+                            "Description" : "The name of the header ( object id used if not provided)",
+                            "Types": STRING_TYPE
+                        },
+                        {
+                            "Names": "Value",
+                            "Description" : "The value of the header",
+                            "Types": STRING_TYPE,
+                            "Mandatory": true
+                        }
+                    ]
+                },
+                {
+                    "Names": "Policy",
+                    "Description": "How the request forwarding policy is determined - LinkType = Use a predefined policy for the link type, custom = your own",
+                    "Values" : [ "LinkType", "Custom" ],
+                    "Default" : "LinkType"
+                },
+                {
+                    "Names" : "Policy:Custom",
+                    "Children" : [
+                        {
+                            "Names" : "Cookies",
+                            "Description" : "A list of cookie names to forward to the origin ( _all - all cookies )",
+                            "Types" : ARRAY_OF_STRING_TYPE,
+                            "Default" : [ "_all" ]
+                        },
+                        {
+                            "Names" : "Headers",
+                            "Description" : "A list of header keys to forward to the origin ( _all - all headers, _cdn - CDN included headers )",
+                            "Types" : ARRAY_OF_STRING_TYPE,
+                            "Default" : [ "_all" ]
+                        },
+                        {
+                            "Names" : "QueryParams",
+                            "Description" : "A list of query parameter names to forward ( _all - all parameters )",
+                            "Types" : ARRAY_OF_STRING_TYPE,
+                            "Default" : [ "_all" ]
+                        },
+                        {
+                            "Names" : "Methods",
+                            "Description" : "The HTTP Methods that will be forwarded to the origin",
+                            "Types" : ARRAY_OF_STRING_TYPE,
+                            "Values" : [ "GET", "HEAD", "OPTIONS", "PUT", "PATCH", "POST", "DELETE"],
+                            "Default" : [ "GET", "HEAD", "OPTIONS", "PUT", "PATCH", "POST", "DELETE"]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+/]

--- a/providers/shared/attributesets/cdnttl/id.ftl
+++ b/providers/shared/attributesets/cdnttl/id.ftl
@@ -1,0 +1,30 @@
+[#ftl]
+
+[@addAttributeSet
+    type=CDNTTL_ATTRIBUTESET_TYPE
+    properties=[
+        {
+                "Type"  : "Description",
+                "Value" : "Configuration for the cache TTL of a CDN"
+        }]
+    attributes=[
+        {
+            "Names" : "Default",
+            "Description" : "The default cache time when the origin has not specified a time - seconds",
+            "Types" : NUMBER_TYPE,
+            "Default" : 600
+        },
+        {
+            "Names" : "Maximum",
+            "Description" : "The maximum time that an origin can specify to cache content - seconds",
+            "Types" : NUMBER_TYPE,
+            "Default" : 31536000
+        },
+        {
+            "Names" : "Minimum",
+            "Description" : "The minimum time that an origin can specify to cache content - seconds",
+            "Types" : NUMBER_TYPE,
+            "Default" : 0
+        }
+    ]
+/]

--- a/providers/shared/components/cdn/id.ftl
+++ b/providers/shared/components/cdn/id.ftl
@@ -388,7 +388,7 @@
 [@addChildComponent
     type=CDN_RESPONSE_POLICY_COMPONENT_TYPE
     parent=CDN_COMPONENT_TYPE
-    childAttribute="ResponsePolicy"
+    childAttribute="ResponsePolicys"
     linkAttributes="ResponsePolicy"
     properties=
         [

--- a/providers/shared/components/cdn/id.ftl
+++ b/providers/shared/components/cdn/id.ftl
@@ -63,6 +63,12 @@
                 "SubObjects" : true,
                 "Children" : [
                     {
+                        "Names" : "Enabled",
+                        "Description" : "Enable the response override",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : true
+                    }
+                    {
                         "Names" : "ErrorCode",
                         "Description" : "The code to trigger the response for",
                         "Types" : NUMBER_TYPE,
@@ -388,7 +394,7 @@
 [@addChildComponent
     type=CDN_RESPONSE_POLICY_COMPONENT_TYPE
     parent=CDN_COMPONENT_TYPE
-    childAttribute="ResponsePolicys"
+    childAttribute="ResponsePolicies"
     linkAttributes="ResponsePolicy"
     properties=
         [

--- a/providers/shared/components/cdn/id.ftl
+++ b/providers/shared/components/cdn/id.ftl
@@ -161,58 +161,97 @@
             "AttributeSet" : LINK_ATTRIBUTESET_TYPE
         },
         {
-            "Names" : "Origin",
-            "Description" : "The service which provides the content for the cdn to distribute",
+            "Names" : "CachePolicy",
+            "Description" : "The Cache Policy to use Default - use the Default CDN policy or Custom for custom policy defined on the CDN",
+            "Types" : STRING_TYPE,
+            "Values": [ "Default", "Custom"],
+            "Default" : "Default"
+        },
+        {
+            "Names": "CachePolicy:Custom",
+            "Description" : "Configuration for the Custom Cache policy",
             "Children" : [
                 {
-                    "Names" : "ConnectionTimeout",
-                    "Description" : "How long to wait until a response is received from the origin",
-                    "Types" : NUMBER_TYPE,
-                    "Default" : 30
+                    "Names" : "Id",
+                    "Description" : "The Id of the CachePolicy",
+                    "Types" : STRING_TYPE
                 },
                 {
-                    "Names" : "TLSProtocols",
-                    "Description" : "When using a TLS backend the protocols the CDN will use as a client",
-                    "Types" : ARRAY_OF_STRING_TYPE,
-                    "Values" : [ "TLSv1.2", "TLSv1.1", "TLSv1", "SSLv3" ],
-                    "Default" : [ "TLSv1.2" ]
-                },
-                {
-                    "Names" : "BasePath",
-                    "Description" : "The base path at the origin destination",
+                    "Names" : "Instance",
+                    "Description" : "The instance id of the CachePolicy",
                     "Types" : STRING_TYPE,
                     "Default" : ""
                 },
                 {
-                    "Names" : "Link",
-                    "Mandatory" : true,
-                    "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+                    "Names" : "Version",
+                    "Description" : "The version id of the CachePolicy",
+                    "Types" : STRING_TYPE,
+                    "Default" : ""
                 }
             ]
         },
         {
-            "Names" : "CachingTTL",
-            "Description" : "Default Time To Live values for cache management",
+            "Names" : "ResponsePolicy",
+            "Description" : "A Response Policy to use for the route",
             "Children" : [
                 {
-                    "Names" : "Default",
-                    "Description" : "The default cache time when the origin has not specified a time - seconds",
-                    "Types" : NUMBER_TYPE,
-                    "Default" : 600
+                    "Names" : "Id",
+                    "Description" : "The Id of the origin in the CDN Origins",
+                    "Types" : STRING_TYPE
                 },
                 {
-                    "Names" : "Maximum",
-                    "Description" : "The maximum time that an origin can specify to cache content - seconds",
-                    "Types" : NUMBER_TYPE,
-                    "Default" : 31536000
+                    "Names" : "Instance",
+                    "Description" : "The instance id of the origin to use",
+                    "Types" : STRING_TYPE,
+                    "Default" : ""
                 },
                 {
-                    "Names" : "Minimum",
-                    "Description" : "The minimum time that an origin can specify to cache content - seconds",
-                    "Types" : NUMBER_TYPE,
-                    "Default" : 0
+                    "Names" : "Version",
+                    "Description" : "The version id of the origin to use",
+                    "Types" : STRING_TYPE,
+                    "Default" : ""
                 }
             ]
+        },
+        {
+            "Names" : "OriginSource",
+            "Description" : "Use an origin for the route only ( defined under the Origin object) or CDN for subcomponent origins",
+            "Types" : STRING_TYPE,
+            "Values" : [ "Route", "CDN", "Placeholder"],
+            "Default": "Route"
+        },
+        {
+            "Names" : "OriginSource:CDN",
+            "Description" : "Configuration for the CDN origin source",
+            "Children" : [
+                {
+                    "Names" : "Id",
+                    "Description" : "The Id of the origin in the CDN Origins",
+                    "Types" : STRING_TYPE
+                },
+                {
+                    "Names" : "Instance",
+                    "Description" : "The instance id of the origin to use",
+                    "Types" : STRING_TYPE,
+                    "Default" : ""
+                },
+                {
+                    "Names" : "Version",
+                    "Description" : "The version id of the origin to use",
+                    "Types" : STRING_TYPE,
+                    "Default" : ""
+                }
+            ]
+        },
+        {
+            "Names" : [ "OriginSource:Route", "Origin"],
+            "Description" : "The origin the route forwards requests to",
+            "AttributeSet" : CDNORIGIN_ATTRIBUTESET_TYPE
+        },
+        {
+            "Names" : "CachingTTL",
+            "Description" : "Default Time To Live values for cache management",
+            "AttributeSet" : CDNTTL_ATTRIBUTESET_TYPE
         },
         {
             "Names" : "Compress",
@@ -291,4 +330,259 @@
             ]
         }
     ]
+/]
+
+[@addChildComponent
+    type=CDN_CACHE_POLICY_COMPONENT_TYPE
+    parent=CDN_COMPONENT_TYPE
+    childAttribute="CachePolicies"
+    linkAttributes="CachePolicy"
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A policy for how content should be cached"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "Cookies",
+            "Description" : "A list of cookie names that will be included in cache entry ( _all - all cookies )",
+            "Types" : ARRAY_OF_STRING_TYPE,
+            "Default" : ["_all"]
+        },
+        {
+            "Names" : "Headers",
+            "Description" : "A list of header names that will be included in the cache entry ( _all - all cookies)",
+            "Types" : ARRAY_OF_STRING_TYPE,
+            "Default" : []
+        },
+        {
+            "Names" : "QueryParams",
+            "Description" : "A list of query parameter names to be included in the cache entry ( _all - all parameters )",
+            "Types" : ARRAY_OF_STRING_TYPE,
+            "Default" : ["_all"]
+        },
+        {
+            "Names" : "CompressionEncoding",
+            "Description" : "A list of compression processes that are normalised and included in the cache policy",
+            "Types" : ARRAY_OF_STRING_TYPE,
+            "Values" : [ "gzip", "brotli"],
+            "Default": [ "gzip", "brotli" ]
+        },
+        {
+            "Names" : "Methods",
+            "Description" : "A list of HTTP methods which will allow caching",
+            "Types" : ARRAY_OF_STRING_TYPE,
+            "Values" : [ "GET", "HEAD", "OPTIONS" ],
+            "Default" : [ "GET", "HEAD" ]
+        },
+        {
+            "Names" : "TTL",
+            "Description" : "Default Time To Live values for cache management",
+            "AttributeSet" : CDNTTL_ATTRIBUTESET_TYPE
+        }
+    ]
+/]
+
+[@addChildComponent
+    type=CDN_RESPONSE_POLICY_COMPONENT_TYPE
+    parent=CDN_COMPONENT_TYPE
+    childAttribute="ResponsePolicy"
+    linkAttributes="ResponsePolicy"
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A policy to control how the CDN controls responses"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "HeaderInjection",
+            "Description" : "Include headers as part of the response",
+            "Children" : [
+                {
+                    "Names": "CORS",
+                    "Description" : "Manage the CORS Headers that will be included",
+                    "Children" : [
+                        {
+                            "Names" : "Enabled",
+                            "Description" : "Manage CORS responses from the CDN",
+                            "Types" : BOOLEAN_TYPE,
+                            "Default" : false
+                        },
+                        {
+                            "Names" : "PreferOrigin",
+                            "Description" : "Prefer the headers provided by the origin over these",
+                            "Types" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Names" : "AccessControlAllowCredentials",
+                            "Description" : "Include the Allow Credentials header",
+                            "Types": BOOLEAN_TYPE,
+                            "Default": false
+                        },
+                        {
+                            "Names": "AccessControlAllowMethods",
+                            "Description" : "A list of methods permitted on this route",
+                            "Types": ARRAY_OF_STRING_TYPE,
+                            "Default": [ "ALL" ]
+                        },
+                        {
+                            "Names": "AccessControlAllowHeaders",
+                            "Description" : "A list of methods permitted on this route",
+                            "Types": ARRAY_OF_STRING_TYPE,
+                            "Default": [ "*" ]
+                        },
+                        {
+                            "Names" : "AccessControlAllowOrigins",
+                            "Description" : "A list of origins permitted on this route",
+                            "Types": ARRAY_OF_STRING_TYPE,
+                            "Default" : [
+                                "*"
+                            ]
+                        },
+                        {
+                            "Names" : "AccessControlExposeHeaders",
+                            "Description" : "A list of headers that will be exposed",
+                            "Types": ARRAY_OF_STRING_TYPE,
+                            "Default" : [
+                                "*"
+                            ]
+                        },
+                        {
+                            "Names" : "AccessControlMaxAgeSec",
+                            "Description" : "How long the CORS headers are cached for",
+                            "Types" : NUMBER_TYPE,
+                            "Default" : 3600
+                        }
+                    ]
+                },
+                {
+                    "Names": "Security",
+                    "Description" : "Manage the standard security that will be included",
+                    "Children" : [
+                        {
+                            "Names" : "Enabled",
+                            "Description" : "Manage Security header repsponses with the CDN",
+                            "Types" : BOOLEAN_TYPE,
+                            "Default" : false
+                        },
+                        {
+                            "Names" : "PreferOrigin",
+                            "Description" : "Prefer the headers provided by the origin over these",
+                            "Types" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Names" : "ContentSecurityPolicy",
+                            "Description" : "Include a ContentSecurityPolicy header",
+                            "Types": STRING_TYPE,
+                            "Default" : ""
+                        },
+                        {
+                            "Names": "ContentTypeOptions",
+                            "Description" : "Set the X-Content-Type-Options to nosniff",
+                            "Types": BOOLEAN_TYPE,
+                            "Default": true
+                        },
+                        {
+                            "Names" : "FrameOptions",
+                            "Description" : "Control the X-Frame-Options header",
+                            "Types": STRING_TYPE,
+                            "Values" : [ "DENY", "SAMEORIGIN"],
+                            "Default" : "DENY"
+                        },
+                        {
+                            "Names" : "ReferrerPolicy",
+                            "Description" : "Set the Referrer-Policy that is used",
+                            "Types": STRING_TYPE,
+                            "Values" : [
+                                "no-referrer",
+                                "no-referrer-when-downgrade",
+                                "origin",
+                                "origin-when-cross-origin",
+                                "same-origin",
+                                "strict-origin",
+                                "strict-origin-when-cross-origin"
+                                "unsafe-url"
+                            ],
+                            "Default" : "strict-origin-when-cross-origin"
+                        }
+                    ]
+                },
+                {
+                    "Names" : "StrictTransportSecurity",
+                    "Description" : "Set how HSTS manages requests",
+                    "Children" : [
+                        {
+                            "Names" : "Enabled",
+                            "Description" : "Enable the inclusion of HSTS",
+                            "Types": BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Names" : "PreferOrigin",
+                            "Description" : "Prefer the headers provided by the origin over these",
+                            "Types" : BOOLEAN_TYPE,
+                            "Default" : true
+                        },
+                        {
+                            "Names": "MaxAge",
+                            "Description": "How long the HSTS policy should be valid for",
+                            "Types": NUMBER_TYPE,
+                            "Default": 31536000
+                        },
+                        {
+                            "Names": "IncludeSubdomains",
+                            "Description": "Should subdomains be included in the policy",
+                            "Type": BOOLEAN_TYPE,
+                            "Default" : false
+                        }
+                    ]
+                },
+                {
+                    "Names": "Additional",
+                    "Default": "Custom headers to include in the responses",
+                    "SubObjects": true,
+                    "Children" : [
+                        {
+                            "Names" : "Name",
+                            "Description" : "The name of the header ( object id used if not provided)",
+                            "Types": STRING_TYPE
+                        },
+                        {
+                            "Names": "Value",
+                            "Description" : "The value of the header",
+                            "Types": STRING_TYPE,
+                            "Mandatory": true
+                        },
+                        {
+                            "Names" : "PreferOrigin",
+                            "Description" : "Prefer the origin value over this value",
+                            "Types" : BOOLEAN_TYPE,
+                            "Default" : false
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+/]
+
+[@addChildComponent
+    type=CDN_ORIGIN_COMPONENT_TYPE
+    parent=CDN_COMPONENT_TYPE
+    childAttribute="Origins"
+    linkAttributes="Origin"
+    properties=
+        [
+            {
+                "Type"  : "Description",
+                "Value" : "A Origin which serves content"
+            }
+        ]
+    attributes=getAttributeSet(CDNORIGIN_ATTRIBUTESET_TYPE).Attributes
 /]

--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -23,6 +23,9 @@
 
 [#assign CDN_COMPONENT_TYPE = "cdn"]
 [#assign CDN_ROUTE_COMPONENT_TYPE = "cdnroute" ]
+[#assign CDN_ORIGIN_COMPONENT_TYPE = "cdnorigin" ]
+[#assign CDN_CACHE_POLICY_COMPONENT_TYPE = "cdncachepolicy" ]
+[#assign CDN_RESPONSE_POLICY_COMPONENT_TYPE = "cdnresponsepolicy" ]
 
 [#assign CERTIFICATEAUTHORITY_COMPONENT_TYPE = "certificateauthority"]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for route independent origins similar to the lb backend
- Adds support for route independent cache policies to share across routes
- Adds support for response header injection if supported by the cdn
- Creates attribute sets to support the split of origins across routes and origins

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The primary motivation for this change is to handle complex CDN scenarios where a collection of different routes all need to forward to a single origin but each route has different caching and processing requirements. 
Splitting them out and making it possible to use the same origin on multiple routes can reduce the resource requirements within a deployment as we don't duplicate the origin configuration across each route. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

