### PR TITLE
chore(lambda): update lambda runtime versions

### DIFF
--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -81,19 +81,17 @@
                 "Description" : "Must be a valid runtime engine such as nodejs14.x. Refer https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html or https://docs.microsoft.com/en-us/azure/azure-functions/supported-languages",
                 "Values" : [
                     "dotnet6",
-                    "dotnetcore1.0",
-                    "dotnetcore2.1",
+                    "dotnetcore3.1",
                     "go1.x",
                     "java8",
                     "java11",
                     "nodejs12.x",
                     "nodejs14.x",
-                    "python2.7",
-                    "python3.6",
+                    "nodejs16.x",
                     "python3.7",
                     "python3.8",
                     "python3.9",
-                    "ruby2.5"
+                    "ruby2.7"
                 ],
                 "AdditionalValues" : true,
                 "Mandatory" : true


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Add node 16 as it is now supported and remove run-times which are either EOL, or either in (or soon to be in) the process of
deprecation by AWS.

Note that because extra values are permitted, older values will pass validation but will generate a warning.

## Motivation and Context
Keep warnings aligned to current status of lambda run-times.

## How Has This Been Tested?
Local template generation. 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

