### PR TITLE
feat: add support for links as image sources

### DIFF
--- a/providers/shared/components/adaptor/id.ftl
+++ b/providers/shared/components/adaptor/id.ftl
@@ -43,7 +43,12 @@
                         "Description" : "The source of the image - registry: the local hamlet registry - url: an external public url - none: no source image",
                         "Types" : STRING_TYPE,
                         "Mandatory" : true,
-                        "Values" : [ "registry", "url", "none" ],
+                        "Values" : [
+                            "link",
+                            "registry",
+                            "url",
+                            "none"
+                        ],
                         "Default" : "registry"
                     },
                     {
@@ -62,6 +67,10 @@
                                 "Default" : ""
                             }
                         ]
+                    },
+                    {
+                        "Names": "Link",
+                        "AttributeSet": LINK_ATTRIBUTESET_TYPE
                     }
                 ]
             },

--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -320,7 +320,7 @@ object.
                         "Description" : "The source of the image - registry: the local hamlet registry - url: an external public url - none: no source image",
                         "Types" : STRING_TYPE,
                         "Mandatory" : true,
-                        "Values" : [ "registry", "url", "none" ],
+                        "Values" : [ "link", "registry", "url", "none" ],
                         "Default" : "registry"
                     },
                     {
@@ -339,6 +339,10 @@ object.
                                 "Default" : ""
                             }
                         ]
+                    },
+                    {
+                        "Names": "Link",
+                        "AttributeSet": LINK_ATTRIBUTESET_TYPE
                     }
                 ]
             }

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -125,7 +125,7 @@
                         "Description" : "The source of the image - registry is the hamlet registry",
                         "Types" : STRING_TYPE,
                         "Mandatory" : true,
-                        "Values" : [ "registry", "url", "none" ],
+                        "Values" : [ "link", "registry", "url", "none" ],
                         "Default" : "registry"
                     },
                     {
@@ -144,6 +144,10 @@
                                 "Default" : ""
                             }
                         ]
+                    },
+                    {
+                        "Names": "Link",
+                        "AttributeSet": LINK_ATTRIBUTESET_TYPE
                     }
                 ]
             },

--- a/providers/shared/components/contentnode/id.ftl
+++ b/providers/shared/components/contentnode/id.ftl
@@ -29,7 +29,7 @@
                         "Description" : "The source of the image - registry: the local hamlet registry - url: an external public url",
                         "Types" : STRING_TYPE,
                         "Mandatory" : true,
-                        "Values" : [ "registry", "url" ],
+                        "Values" : [ "link", "registry", "url" ],
                         "Default" : "registry"
                     },
                     {
@@ -48,6 +48,10 @@
                                 "Default" : ""
                             }
                         ]
+                    },
+                    {
+                        "Names": "Link",
+                        "AttributeSet": LINK_ATTRIBUTESET_TYPE
                     }
                 ]
             }

--- a/providers/shared/components/datapipeline/id.ftl
+++ b/providers/shared/components/datapipeline/id.ftl
@@ -72,7 +72,7 @@
                         "Description" : "The source of the image - registry: the local hamlet registry - url: an external public url",
                         "Types" : STRING_TYPE,
                         "Mandatory" : true,
-                        "Values" : [ "registry", "url" ],
+                        "Values" : [ "link", "registry", "url" ],
                         "Default" : "registry"
                     },
                     {
@@ -91,6 +91,10 @@
                                 "Default" : ""
                             }
                         ]
+                    },
+                    {
+                        "Names": "Link",
+                        "AttributeSet": LINK_ATTRIBUTESET_TYPE
                     }
                 ]
             }

--- a/providers/shared/components/dataset/id.ftl
+++ b/providers/shared/components/dataset/id.ftl
@@ -42,7 +42,7 @@
                         "Description" : "The source of the image - registry: the local hamlet registry - url: an external public url",
                         "Types" : STRING_TYPE,
                         "Mandatory" : true,
-                        "Values" : [ "registry", "url" ],
+                        "Values" : [ "link", "registry", "url" ],
                         "Default" : "registry"
                     },
                     {
@@ -61,6 +61,10 @@
                                 "Default" : ""
                             }
                         ]
+                    },
+                    {
+                        "Names": "Link",
+                        "AttributeSet": LINK_ATTRIBUTESET_TYPE
                     }
                 ]
             }

--- a/providers/shared/components/healthcheck/id.ftl
+++ b/providers/shared/components/healthcheck/id.ftl
@@ -69,7 +69,7 @@
                             "Description" : "The source of the image - registry: the local hamlet registry - url: an external public url - none: no source image",
                             "Types" : STRING_TYPE,
                             "Mandatory" : true,
-                            "Values" : [ "registry", "url", "none" ],
+                            "Values" : [ "link", "registry", "url", "none" ],
                             "Default" : "registry"
                         },
                         {
@@ -88,6 +88,10 @@
                                     "Default" : ""
                                 }
                             ]
+                        },
+                        {
+                            "Names": "Link",
+                            "AttributeSet": LINK_ATTRIBUTESET_TYPE
                         },
                         {
                             "Names" : "ScriptFileName",

--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -251,7 +251,7 @@
                         "Description" : "The source of the image - registry is the hamlet registry",
                         "Types" : STRING_TYPE,
                         "Mandatory" : true,
-                        "Values" : [ "registry", "url", "extension" ],
+                        "Values" : [ "link", "registry", "url", "extension" ],
                         "Default" : "registry"
                     },
                     {
@@ -288,6 +288,10 @@
                                 "Default" : '//'
                             }
                         ]
+                    },
+                    {
+                        "Names": "Link",
+                        "AttributeSet": LINK_ATTRIBUTESET_TYPE
                     }
                 ]
             }

--- a/providers/shared/components/mobileapp/id.ftl
+++ b/providers/shared/components/mobileapp/id.ftl
@@ -49,7 +49,7 @@
                         "Description" : "The source of the image - registry: the local hamlet registry - url: an external public url",
                         "Types" : STRING_TYPE,
                         "Mandatory" : true,
-                        "Values" : [ "registry", "url" ],
+                        "Values" : [ "link", "registry", "url" ],
                         "Default" : "registry"
                     },
                     {
@@ -68,6 +68,11 @@
                                 "Default" : ""
                             }
                         ]
+                    },
+                    {
+                        "Names": "Link",
+                        "Description" : "The link to an image",
+                        "AttributeSet": LINK_ATTRIBUTESET_TYPE
                     }
                 ]
             }

--- a/providers/shared/components/spa/id.ftl
+++ b/providers/shared/components/spa/id.ftl
@@ -65,7 +65,7 @@
                         "Description" : "The source of the image - registry is the hamlet registry",
                         "Types" : STRING_TYPE,
                         "Mandatory" : true,
-                        "Values" : [ "registry", "url" ],
+                        "Values" : [ "link", "registry", "url" ],
                         "Default" : "registry"
                     },
                     {
@@ -84,6 +84,11 @@
                                 "Default" : ""
                             }
                         ]
+                    },
+                    {
+                        "Names": "Link",
+                        "Description" : "The link to an image",
+                        "AttributeSet": LINK_ATTRIBUTESET_TYPE
                     }
                 ]
             }

--- a/providers/shared/components/template/id.ftl
+++ b/providers/shared/components/template/id.ftl
@@ -94,7 +94,7 @@
                         "Description" : "The source of the image - registry is the hamlet registry",
                         "Types" : STRING_TYPE,
                         "Mandatory" : true,
-                        "Values" : [ "registry", "url" ],
+                        "Values" : [ "link", "registry", "url" ],
                         "Default" : "registry"
                     },
                     {
@@ -113,6 +113,11 @@
                                 "Default" : ""
                             }
                         ]
+                    },
+                    {
+                        "Names": "Link",
+                        "Description" : "The link to an image",
+                        "AttributeSet": LINK_ATTRIBUTESET_TYPE
                     }
                 ]
             }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds configuration for using a link as the source of an image

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This supports the introduction of the image component so that image references and sources can be found. This can also be used as a replacement for the shared_build file but managed through the solution.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

