### PR TITLE
refactor: remove app public permissions attribute

### DIFF
--- a/providers/shared/attributesets/containerhost/id.ftl
+++ b/providers/shared/attributesets/containerhost/id.ftl
@@ -114,11 +114,6 @@
                     "Names" : "AppData",
                     "Types" : BOOLEAN_TYPE,
                     "Default" : false
-                },
-                {
-                    "Names" : "AppPublic",
-                    "Types" : BOOLEAN_TYPE,
-                    "Default" : false
                 }
             ]
         },

--- a/providers/shared/attributesets/containerservice/id.ftl
+++ b/providers/shared/attributesets/containerservice/id.ftl
@@ -58,11 +58,6 @@
                     "Names" : "AppData",
                     "Types" : BOOLEAN_TYPE,
                     "Default" : true
-                },
-                {
-                    "Names" : "AppPublic",
-                    "Types" : BOOLEAN_TYPE,
-                    "Default" : true
                 }
             ]
         },

--- a/providers/shared/attributesets/containertask/id.ftl
+++ b/providers/shared/attributesets/containertask/id.ftl
@@ -49,11 +49,6 @@
                     "Names" : "AppData",
                     "Types" : BOOLEAN_TYPE,
                     "Default" : true
-                },
-                {
-                    "Names" : "AppPublic",
-                    "Types" : BOOLEAN_TYPE,
-                    "Default" : true
                 }
             ]
         },

--- a/providers/shared/components/bastion/id.ftl
+++ b/providers/shared/components/bastion/id.ftl
@@ -99,11 +99,6 @@
                         "Names" : "AppData",
                         "Types" : BOOLEAN_TYPE,
                         "Default" : false
-                    },
-                    {
-                        "Names" : "AppPublic",
-                        "Types" : BOOLEAN_TYPE,
-                        "Default" : false
                     }
                 ]
             },

--- a/providers/shared/components/computecluster/id.ftl
+++ b/providers/shared/components/computecluster/id.ftl
@@ -78,11 +78,6 @@
                         "Names" : "AppData",
                         "Types" : BOOLEAN_TYPE,
                         "Default" : false
-                    },
-                    {
-                        "Names" : "AppPublic",
-                        "Types" : BOOLEAN_TYPE,
-                        "Default" : false
                     }
                 ]
             },

--- a/providers/shared/components/datapipeline/id.ftl
+++ b/providers/shared/components/datapipeline/id.ftl
@@ -34,11 +34,6 @@
                         "Names" : "AppData",
                         "Types" : BOOLEAN_TYPE,
                         "Default" : true
-                    },
-                    {
-                        "Names" : "AppPublic",
-                        "Types" : BOOLEAN_TYPE,
-                        "Default" : true
                     }
                 ]
             },

--- a/providers/shared/components/ec2/id.ftl
+++ b/providers/shared/components/ec2/id.ftl
@@ -100,11 +100,6 @@
                         "Names" : "AppData",
                         "Types" : BOOLEAN_TYPE,
                         "Default" : false
-                    },
-                    {
-                        "Names" : "AppPublic",
-                        "Types" : BOOLEAN_TYPE,
-                        "Default" : false
                     }
                 ]
             },

--- a/providers/shared/components/federatedrole/id.ftl
+++ b/providers/shared/components/federatedrole/id.ftl
@@ -126,11 +126,6 @@
                         "Names" : "AppData",
                         "Types" : BOOLEAN_TYPE,
                         "Default" : false
-                    },
-                    {
-                        "Names" : "AppPublic",
-                        "Types" : BOOLEAN_TYPE,
-                        "Default" : false
                     }
                 ]
             }

--- a/providers/shared/components/healthcheck/id.ftl
+++ b/providers/shared/components/healthcheck/id.ftl
@@ -205,11 +205,6 @@
                     "Names" : "AppData",
                     "Types" : BOOLEAN_TYPE,
                     "Default" : true
-                },
-                {
-                    "Names" : "AppPublic",
-                    "Types" : BOOLEAN_TYPE,
-                    "Default" : true
                 }
             ]
         },

--- a/providers/shared/components/lambda/id.ftl
+++ b/providers/shared/components/lambda/id.ftl
@@ -154,11 +154,6 @@
                         "Names" : "AppData",
                         "Types" : BOOLEAN_TYPE,
                         "Default" : true
-                    },
-                    {
-                        "Names" : "AppPublic",
-                        "Types" : BOOLEAN_TYPE,
-                        "Default" : true
                     }
                 ]
             },

--- a/providers/shared/components/user/id.ftl
+++ b/providers/shared/components/user/id.ftl
@@ -74,11 +74,6 @@
                         "Names" : "AppData",
                         "Types" : BOOLEAN_TYPE,
                         "Default" : true
-                    },
-                    {
-                        "Names" : "AppPublic",
-                        "Types" : BOOLEAN_TYPE,
-                        "Default" : true
                     }
                 ]
             }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Remove the AppPublic permissions option as it's not longer available and isn't in use

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The App Public permissions option was not a recommended practice and there wasn't use of it across know deployments. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

