### PR TITLE
fix: split expand base configuration

### DIFF
--- a/engine/configuration/component.ftl
+++ b/engine/configuration/component.ftl
@@ -473,7 +473,7 @@
         [/#if]
     [/#if]
 
-    [#local attributes = expandCompositeConfiguration(attributes, true, false)]
+    [#local attributes = expandBaseCompositeConfiguration(attributes)]
 
     [#if provider == SHARED_ATTRIBUTES ]
         [#-- Special processing for profiles --]

--- a/engine/configuration/configuration.ftl
+++ b/engine/configuration/configuration.ftl
@@ -49,8 +49,8 @@ already prefixed attribute.
     [#local result = [] ]
     [#local prefix = prefix?ensure_ends_with(":") ]
 
-    [#local attributes = expandCompositeConfiguration(attributes, true, false)]
-    [#local extensions = expandCompositeConfiguration(extensions, true, false)]
+    [#local attributes = expandBaseCompositeConfiguration(attributes)]
+    [#local extensions = expandBaseCompositeConfiguration(extensions)]
 
     [#-- First extend existing attributes --]
     [#list asArray(attributes) as attribute]

--- a/engine/configuration/reference.ftl
+++ b/engine/configuration/reference.ftl
@@ -39,7 +39,7 @@
         scopeId=REFERENCE_CONFIGURATION_SCOPE
         id=type
         properties=referenceProperties
-        attributes=attributes
+        attributes=expandBaseCompositeConfiguration(attributes)
     /]
 [/#macro]
 

--- a/providers/shared/views/schema/setup.ftl
+++ b/providers/shared/views/schema/setup.ftl
@@ -96,7 +96,9 @@
                         convertAttributesToJsonSchemaProperties(
                             compressCompositeConfiguration(
                                 normaliseCompositeConfiguration(
-                                    definition.Attributes
+                                    expandBaseCompositeConfiguration(
+                                        definition.Attributes
+                                    )
                                 )
                             )
                         )


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Splits the expand base configuration attribute sets into a separate function so that it can be processed before the expansion of children
- adds support for nested base attributes that might be in place on children

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Schema generation was failing as child base attributes weren't expanded. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

