### PR TITLE
feat(globaldb): add enable support for indexes

### DIFF
--- a/providers/shared/components/globaldb/id.ftl
+++ b/providers/shared/components/globaldb/id.ftl
@@ -52,6 +52,12 @@
                 "SubObjects" : true,
                 "Children" : [
                     {
+                        "Names" : "Enabled",
+                        "Description" : "Enable the creation of the secondary index",
+                        "Types": BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
                         "Names" : "Name",
                         "Description" : "Index name",
                         "Types" : STRING_TYPE


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Add the ability to enable/disable secondary indexes

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Adds the ability to control the use of indexes using qualification

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

