### PR TITLE
fix(dynamicvalues): support objects in replace

### DIFF
--- a/engine/configuration/dynamicvalues.ftl
+++ b/engine/configuration/dynamicvalues.ftl
@@ -119,11 +119,18 @@
             [#local value = value?replace(original, new)]
         [#elseif new?is_number || new?is_boolean ]
             [#local value = value?replace(original, new?c)]
+        [#elseif (new?is_hash || new?is_sequence) && value == original]
+            [#local value = new]
         [#else]
-            [#local value = value?replace(
-                original,
-                "__HamletFatal: invalid dynamic value replacement type for ${original}, value must be string, number or boolean__"
-            )]
+            [@fatal
+                message="Invalid dynamic value replacement"
+                detail="The dynamic value should either be a string, number, boolean or completely replace the value with an object"
+                context={
+                    "Value": value,
+                    "DynamicValue" : original,
+                    "SubstituedValue": new
+                }
+            /]
         [/#if]
     [/#list]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds support for objects to be used in dynamic value replacements if the dynamic value reference is the only content of the string

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This fixes support for the AWS secrets manager dynamic value which returns an object reference used byb CloudFormation tor resolve the secret 
Adding the check for the object replacement being the only content of the string provides a logical way to handle replacements when dealing with objects

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

