### PR TITLE
!refactor(mobileapp): mobileapp solution config

### DIFF
--- a/providers/shared/components/mobileapp/id.ftl
+++ b/providers/shared/components/mobileapp/id.ftl
@@ -12,15 +12,46 @@
     attributes=
         [
             {
-                "Names" : "Engine",
-                "Types" : STRING_TYPE,
-                "Default" : "expo",
+                "Names" : "AppFrameworks",
+                "Description": "A list of app frameworks used to generate the app",
+                "Types" : ARRAY_OF_STRING_TYPE,
+                "Default" : ["expo"],
                 "Values" : ["expo"]
+            },
+            {
+                "Names" : "AppFrameworks:expo",
+                "Description": "Expo specific configuration",
+                "Children" : [
+                    {
+                        "Names": "ReleaseChannel",
+                        "Description": "The release channel of the app",
+                        "Types": STRING_TYPE,
+                        "Default": "__setting:ENVIRONMENT__"
+                    },
+                    {
+                        "Names": "IdOverride",
+                        "Description": "Override the existing id used in the expo app",
+                        "Types": STRING_TYPE,
+                        "Default": "__setting:ENVIRONMENT__"
+                    }
+                ]
             },
             {
                 "Names" : "Links",
                 "SubObjects" : true,
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+            },
+            {
+                "Names": "EncryptionPrefix",
+                "Description": "A prefix appended to any encrypted values in the solution configuration",
+                "Default": "base64:"
+            },
+            {
+                "Names": "VersionSource",
+                "Description": "How to determine the version Id of the app",
+                "Types": STRING_TYPE,
+                "Values" : ["AppFrameworks", "AppReference"],
+                "Default" : "AppFrameworks"
             },
             {
                 "Names" : "BuildFormats",
@@ -29,16 +60,230 @@
                 "Values" : [ "ios", "android" ]
             },
             {
-                "Names" : [ "Extensions", "Fragment", "Container" ],
-                "Description" : "Extensions to invoke as part of component processing",
-                "Types" : ARRAY_OF_STRING_TYPE,
-                "Default" : []
+                "Names" : "BuildFormats:ios",
+                "Description": "IOS specific distribution configuration",
+                "Children" : [
+                    {
+                        "Names": "ProjectRootDir",
+                        "Description": "Within the src code image the path to the root of the ios project",
+                        "Types": STRING_TYPE,
+                        "Default": "ios"
+                    },
+                    {
+                        "Names": "BundleIdOverride",
+                        "Description" : "An override of the app bundle Id",
+                        "Types" : STRING_TYPE
+                    }
+                    {
+                        "Names": "DisplayNameOverride",
+                        "Description": "An override value for the display name",
+                        "Types": STRING_TYPE
+                    },
+                    {
+                        "Names": "NonExemptEncryption",
+                        "Description": "Does the app use non-exempt encryption",
+                        "Types": BOOLEAN_TYPE,
+                        "Default": false
+                    },
+                    {
+                        "Names": "CodeSignIdentityPrefix",
+                        "Description": "The prefix of code signing identity from the distribution certificate",
+                        "Types": STRING_TYPE,
+                        "Values": [ "iPhone Distribution", "Apple Distribution"],
+                        "Default": "iPhone Distribution"
+                    },
+                    {
+                        "Names": "AppleTeamId",
+                        "Description": "The id of the apple developer team the app will be signed for",
+                        "Types": STRING_TYPE
+                    },
+                    {
+                        "Names": "ExportMethod",
+                        "Description": "The method of distribution for the signed app",
+                        "Types": STRING_TYPE,
+                        "Values": [ "app-store", "ad-hoc", "enterprise", "developer" ],
+                        "Default": "app-store"
+                    },
+                    {
+                        "Names" : "TestFlight",
+                        "Description": "The configuration for TestFlight uploads when using AppStore export",
+                        "Children" : [
+                            {
+                                "Names" : "Enabled",
+                                "Description" : "Enable upload to TestFilght - requires app-store ExportMethod",
+                                "Types": BOOLEAN_TYPE,
+                                "Default": true
+                            },
+                            {
+                                "Names": "AppId",
+                                "Description": "The Id of the app in app store connect",
+                                "Types": STRING_TYPE
+                            },
+                            {
+                                "Names": "Username",
+                                "Description": "The username of the testflight user for the upload",
+                                "Types": STRING_TYPE
+                            },
+                            {
+                                "Names": "Password",
+                                "Description": "The password of the testflight user for the upload",
+                                "Types": STRING_TYPE
+                            }
+                        ]
+                    },
+                    {
+                        "Names": "DistributionCertificateFileName",
+                        "Description": "The file name of the distribution certificate stored in the asFile settings",
+                        "Types": STRING_TYPE,
+                        "Default": "ios_distribution.p12"
+                    },
+                    {
+                        "Names": "DistributionCertificatePassword",
+                        "Description": "The password used to unlock the distribution certificate file",
+                        "Types": STRING_TYPE
+                    },
+                    {
+                        "Names": "ProvisioningProfileFileName",
+                        "Description": "The file name of the provisioning profile stored in the asFile settings",
+                        "Types": STRING_TYPE,
+                        "Default": "ios_profile.mobileprovision"
+                    }
+                ]
             },
             {
-                "Names" : "UseOTAPrefix",
-                "Description" : "Include the OTA Prefix in the OTA Url",
-                "Types" : BOOLEAN_TYPE,
-                "Default" : true
+                "Names" : "BuildFormats:android",
+                "Children" : [
+                    {
+                        "Names": "ProjectRootDir",
+                        "Description": "Within the src code image the path to the root of the android project",
+                        "Types": STRING_TYPE,
+                        "Default": "android"
+                    },
+                    {
+                        "Names" : "BundleIdOverride",
+                        "Description" : "An override of the app bundle Id",
+                        "Types": STRING_TYPE
+                    }
+                    {
+                        "Names" : "KeyStore",
+                        "Description": "Configuration of the keystore used to sign the app",
+                        "Children" : [
+                            {
+                                "Names": "FileName",
+                                "Description": "The file name of the keystore stored in the asFile settings",
+                                "Types": STRING_TYPE,
+                                "Default": "android_keystore.jks"
+                            }
+                            {
+                                "Names" : "Password",
+                                "Description": "The password required to unlock the keystore",
+                                "Types" : STRING_TYPE
+                            },
+                            {
+                                "Names" : "KeyAlias",
+                                "Description": "The alias of the key in the keystore to use for signing the app",
+                                "Types" : STRING_TYPE
+                            },
+                            {
+                                "Names": "KeyPassword",
+                                "Description": "The password required to unlock the key",
+                                "Types" : STRING_TYPE
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "PlayStore",
+                        "Description": "Configuration for uploading the app to the Google Playstore",
+                        "Children" : [
+                            {
+                                "Names": "Enabled",
+                                "Description": "Enable PlayStore upload",
+                                "Types" : BOOLEAN_TYPE,
+                                "Default" : false
+                            },
+                            {
+                                "Names" : "JSONKeyFileName",
+                                "Description": "The filename of the JSON Key stored in asFile settings used to authenticate with the PlayStore",
+                                "Types" : STRING_TYPE,
+                                "Default" : "playstore_json_key.json"
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "Firebase",
+                        "Description": "Configuration for uploading the app to Firebase",
+                        "Children" : [
+                            {
+                                "Names": "Enabled",
+                                "Description": "Enable Firebase upload",
+                                "Types": BOOLEAN_TYPE,
+                                "Default": false
+                            },
+                            {
+                                "Names": "AppId",
+                                "Description": "The Id of the app in Firebase to use for uploading the signed app",
+                                "Types": STRING_TYPE
+                            },
+                            {
+                                "Names": "JSONKeyFileName",
+                                "Types": STRING_TYPE,
+                                "Description": "The filename of the JSON Key stored in asFile settings used to authenticate with Firebase",
+                                "Default": "firebase_json_key.json"
+                            }
+                        ]
+                    },
+                    {
+                        "Names": "GoogleServices",
+                        "Description": "Service configuration for access to google push services",
+                        "Children" : [
+                            {
+                                "Names": "JSONKeyFileName",
+                                "Types" : STRING_TYPE,
+                                "Description": "The filename of the JSON Key stored in asFile settings used to authenticate with Firebase",
+                                "Default" : "google-services.json"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "Names": "Badge",
+                "Description": "Adds a badge to the app icon",
+                "Children" : [
+                    {
+                        "Names": "Enabled",
+                        "Description": "Enable adding badge to app icons",
+                        "Types": BOOLEAN_TYPE,
+                        "Default" : false
+                    },
+                    {
+                        "Names" : "Value",
+                        "Description": "The value in  the badge",
+                        "Types": STRING_TYPE,
+                        "Default": "__setting:ENVIRONMENT__"
+                    },
+                    {
+                        "Names": ["Color", "Colour"],
+                        "Description": "The colour of the badgethe badge",
+                        "Types": STRING_TYPE,
+                        "Values": [
+                            "brightgreen",
+                            "green",
+                            "yellow",
+                            "orange",
+                            "red",
+                            "blue",
+                            "lightgrey"
+                        ],
+                        "Default": "blue"
+                    }
+                ]
+            },
+            {
+                "Names": [ "Extensions", "Fragment", "Container" ],
+                "Description": "Extensions to invoke as part of component processing",
+                "Types": ARRAY_OF_STRING_TYPE,
+                "Default": []
             },
             {
                 "Names" : "Image",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
- Moves all mobileapp configuration from settings over to solution configuration
- Adds support for controlling the filenames of file based settings. This allows for users to identify a specific version of a certificate or profile that is in use
- Adds support for defining a badge that is added to app icons

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The primary motivation for this move is to make the complex configuration options required to publish mobile apps documented, type checked and validated via the engine before they are passed to downstream processes. This makes it easier to discover the available options and to support the migration from bash run tasks to our runbook tasks in the future. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- Current settings will need to be mapped to the new configuration settings this can either be through qualification of the values on the solution file or the use of dynamic values to resolve the existing settings in place. 
-  File based settings ( certificates, json keys etc, will still need to be stored as settings) 

