### PR TITLE
feat(dynamicvalue): add IP Address group support

### DIFF
--- a/providers/shared/dynamicvalues/dynamicvalue.ftl
+++ b/providers/shared/dynamicvalues/dynamicvalue.ftl
@@ -5,3 +5,4 @@
 [#assign INPUT_DYNAMIC_VALUE_TYPE = "input" ]
 [#assign OUTPUT_DYNAMIC_VALUE_TYPE = "output" ]
 [#assign SETTING_DYNAMIC_VALUE_TYPE = "setting" ]
+[#assign IPADDRESSGROUP_DYNAMIC_VALUE_TYPE = "ipaddressgroup"]

--- a/providers/shared/dynamicvalues/ipaddressgroup/dynamicvalue.ftl
+++ b/providers/shared/dynamicvalues/ipaddressgroup/dynamicvalue.ftl
@@ -1,0 +1,29 @@
+[#ftl]
+
+[@addDynamicValueProvider
+    type=IPADDRESSGROUP_DYNAMIC_VALUE_TYPE
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Returns the resolved CIDR Addresses from IPAddressGroups defined in the solution"
+        }
+    ]
+    parameterOrder=[
+        "groupId"
+    ]
+    parameterAttributes=[
+        {
+            "Names" : "groupId",
+            "Description" : "The Id of the IPAddressGroups",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        }
+    ]
+/]
+
+[#function shared_dynamicvalue_ipaddressgroup value properties sources={} ]
+    [#if sources.occurrence?? ]
+        [#local cidrs = getGroupCIDRs(properties.groupId, true, occurrence)]
+        [#return cidrs!"__HamletWarning: IP Address group ${groupId} could not be resolved__" ]
+    [/#if]
+[/#function]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds dynamic value evaluation for IP Address groups returns the evaluated CIDR addresses with support for occurrence based groups as well

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
While IPAddress Groups have explicit configuration control for most access control, they might also need to be used in settings or other scenarios like WAF Value Sets. 

This allows them to be included in these places without having to use freemarker extensions to get the data. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

