### PR TITLE
feat(network): add prefix control for flow logs

### DIFF
--- a/providers/shared/components/network/id.ftl
+++ b/providers/shared/components/network/id.ftl
@@ -52,6 +52,21 @@
                                         "Description" : "A prefix for the s3 bucket destination",
                                         "Types" : STRING_TYPE,
                                         "Default" : "FlowLogs/"
+                                    },
+                                    {
+                                        "Names": "IncludeInPrefix",
+                                        "Description": "Context specific details to include in the prefix",
+                                        "Types": ARRAY_OF_STRING_TYPE,
+                                        "Values" : [
+                                            "Prefix",
+                                            "FullAbsolutePath",
+                                            "Id"
+                                        ],
+                                        "Default": [
+                                            "Prefix",
+                                            "FullAbsolutePath",
+                                            "Id"
+                                        ]
                                     }
                                 ]
                             }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- control what is included as part of the prefix when creating flow logs that are saved to s3

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for knowing what is included in the prefix and to allow for the cloud provider to pick the prefix if none are provided

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

