### PR TITLE
feat(userpool): add support callback urls solution

### DIFF
--- a/providers/shared/components/userpool/id.ftl
+++ b/providers/shared/components/userpool/id.ftl
@@ -238,6 +238,9 @@
 
 [@addChildComponent
     type=USERPOOL_CLIENT_COMPONENT_TYPE
+    parent=USERPOOL_COMPONENT_TYPE
+    childAttribute="Clients"
+    linkAttributes="Client"
     properties=
         [
             {
@@ -266,6 +269,18 @@
                         "Names" : "Enabled",
                         "Types" : BOOLEAN_TYPE,
                         "Default" : true
+                    },
+                    {
+                        "Names": "CallbackUrls",
+                        "Types" : ARRAY_OF_STRING_TYPE,
+                        "Description" : "A list of authentication CallBack Url's authorised to use this client",
+                        "Default": []
+                    },
+                    {
+                        "Names": "LogoutUrls",
+                        "Types" : ARRAY_OF_STRING_TYPE,
+                        "Description" : "A list of logout urls which are authorised to use this client when performing logouts",
+                        "Default": []
                     }
                 ]
             },
@@ -319,9 +334,6 @@
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
             }
         ]
-    parent=USERPOOL_COMPONENT_TYPE
-    childAttribute="Clients"
-    linkAttributes="Client"
 /]
 
 [@addChildComponent


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Lets users define the callback and logout urls for oauth clients as solution level configuration

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When combined with dynamic value evaluation this allows for setting the callback/logout urls without having to append paths to other component FQDNS using an external service. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

