### PR TITLE
feat: enable logging by default

### DIFF
--- a/providers/shared/components/directory/id.ftl
+++ b/providers/shared/components/directory/id.ftl
@@ -50,7 +50,7 @@
                     {
                         "Names" : "Enabled",
                         "Types" : BOOLEAN_TYPE,
-                        "Default" : false
+                        "Default" : true
                     }
                 ]
             },

--- a/providers/shared/components/es/id.ftl
+++ b/providers/shared/components/es/id.ftl
@@ -112,7 +112,7 @@
             {
                 "Names" : "Logging",
                 "Types" : BOOLEAN_TYPE,
-                "Default" : false
+                "Default" : true
             },
             {
                 "Names" : "AllowMajorVersionUpdates",

--- a/providers/shared/components/lb/id.ftl
+++ b/providers/shared/components/lb/id.ftl
@@ -15,7 +15,7 @@
                 "Names" : "Logs",
                 "Description" : "Enable request logging for requests",
                 "Types" : BOOLEAN_TYPE,
-                "Default" : false
+                "Default" : true
             },
             {
                 "Names" : "Engine",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Ensure that components that can control their logging output have logging enabled by default

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Logging is usually only remembered when troubleshooting an issue, and enabling it that point often means you miss something that was going wrong. Along with that its also cheaper to have logging enabled than it is to spend on troubleshooting issues without logs. 

So new recommendation from hamlet side of things is to enable logging by default whenever we can. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

