### PR TITLE
fix: merge handling for multiple solutions

### DIFF
--- a/engine/inputdata/solution.ftl
+++ b/engine/inputdata/solution.ftl
@@ -51,7 +51,7 @@
     [/#if]
 
     [#list (blueprint.Solutions)!{} as id, solution]
-        [#local result = mergeObjects(result, { id: getCompositeObject(configuration, solution)})]
+        [#local result = mergeObjects(result, { id: solution})]
     [/#list]
 
     [#list result as id, solution]
@@ -71,7 +71,7 @@
         [/#list]
     [/#list]
 
-    [#assign solutionData = mergeObjects(solutionData, result)]
+    [#assign solutionData = getCompositeObject(mergeObjects(solutionData, result))]
 [/#macro]
 
 [#function getSolutions ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Fixes when composite objects are determined for solution config

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When a value is present in one and not in another solution the defaulting from getCompositeobject interferes

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

