### PR TITLE
fix: set tier indexes for tiers not in network

### DIFF
--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -410,6 +410,33 @@
         "NetworkACL": "open"
       }
     },
+    "docs": {
+      "Name": "documentation",
+      "Title": "Docs Tier",
+      "Description": "Non-network Tier For documentation generation",
+      "Index": 37,
+      "Network": {
+        "Enabled": false
+      }
+    },
+    "gbl": {
+      "Name": "global",
+      "Title": "Global Tier",
+      "Description": "Components which are used for Global Services",
+      "Index": 38,
+      "Network": {
+        "Enabled": false
+      }
+    },
+    "external": {
+      "Name": "external",
+      "Title": "External Tier",
+      "Description": "Components which represent resources external to, or not managed by, hamlet",
+      "Index": 39,
+      "Network": {
+        "Enabled": false
+      }
+    },
     "shared": {
       "Name": "shared",
       "Title": "Shared Tier",
@@ -425,30 +452,6 @@
         },
         "RouteTable": "external",
         "NetworkACL": "open"
-      }
-    },
-    "docs": {
-      "Name": "documentation",
-      "Title": "Docs Tier",
-      "Description": "Non-network Tier For documentation generation",
-      "Network": {
-        "Enabled": false
-      }
-    },
-    "gbl": {
-      "Name": "global",
-      "Title": "Global Tier",
-      "Description": "Components which are used for Global Services",
-      "Network": {
-        "Enabled": false
-      }
-    },
-    "external": {
-      "Name": "external",
-      "Title": "External Tier",
-      "Description": "Components which represent resources external to, or not managed by, hamlet",
-      "Network": {
-        "Enabled": false
       }
     }
   },


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds indexes to the tiers added to masterdata that aren't in the current network order array
- This ensures there aren't collisions in the tiers when they are referenced

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Template generation was failing when working with networks that had their own tier configuration defined. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

