### PR TITLE
feat(waf): add rule engines

### DIFF
--- a/providers/shared/references/WAFProfile/reference.ftl
+++ b/providers/shared/references/WAFProfile/reference.ftl
@@ -25,7 +25,10 @@
             [#local result += [
                 {
                     "Conditions" : conditionList,
-                    "Action" : ruleEntry.Action
+                    "Action" : ruleEntry.Action,
+                    "Engine": rules[ruleListEntry].Engine,
+                    "Engine:RateLimit": rules[ruleListEntry]["Engine:RateLimit"],
+                    "Engine:VendorManaged" : rules[ruleListEntry]["Engine:VendorManaged"]
                 } +
                 attributeIfContent("NameSuffix", rules[ruleListEntry].NameSuffix!"")
             ] ]

--- a/providers/shared/references/WAFRule/id.ftl
+++ b/providers/shared/references/WAFRule/id.ftl
@@ -16,15 +16,98 @@
         },
         {
             "Names" : "Conditions",
+            "Description" : "User defined WAF conditions which will be used to either enforce the rule or scope it",
             "Types" : ARRAY_OF_OBJECT_TYPE,
             "Children" : [
                 {
                     "Names" : "Condition",
+                    "Description" : "The name of the WAFCondition reference object to use",
                     "Types" : STRING_TYPE
                 },
                 {
                     "Names" : "Negated",
-                    "Types" : BOOLEAN_TYPE
+                    "Description" : "Should the result of the rule be negated",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : false
+                }
+            ]
+        },
+        {
+            "Names" : "Engine",
+            "Description" : "The engine of the rule that will be used to evaluate the traffic",
+            "Values" : [ "Conditonal", "RateLimit", "VendorManaged" ],
+            "Types": STRING_TYPE,
+            "Default" : "Conditonal"
+        },
+        {
+            "Names" : "Engine:RateLimit",
+            "Description": "Measures request rate based on client IP and applies an action when it hits the rate limit",
+            "Children": [
+                {
+                    "Names" : "IPAddressSource",
+                    "Description" : "The source of the IP address to apply rate limiting to - Client IP: TCP connection address, HTTPHeader: use a header with the IP listed",
+                    "Types": STRING_TYPE,
+                    "Values" : [ "ClientIP", "HTTPHeader" ],
+                    "Default": "ClientIP"
+                },
+                {
+                    "Names": "IPAddressSource:HTTPHeader",
+                    "Description" : "HTTP Header Specific IP Address Source Config",
+                    "Children": [
+                        {
+                            "Names": "HeaderName",
+                            "Description": "The name of the HTTP header to get the client IP from",
+                            "Types": STRING_TYPE,
+                            "Default": "X-Forwarded-For"
+                        },
+                        {
+                            "Names": "ApplyLimitWhenMissing",
+                            "Description": "When the header is missing apply the rate limit",
+                            "Types": BOOLEAN_TYPE,
+                            "Default": false
+                        }
+                    ]
+                },
+                {
+                    "Names": "Limit",
+                    "Description": "The limit to activate the rule in, measured in requests / 5 mins",
+                    "Types": NUMBER_TYPE
+                }
+            ]
+        },
+        {
+            "Names": "Engine:VendorManaged",
+            "Description": "Use a Vendor managed rule to apply dynamic controls",
+            "Children" : [
+                {
+                    "Names" : "Vendor",
+                    "Description" : "The name of the vendor the managed rule belongs to",
+                    "Types" : STRING_TYPE,
+                    "Default" : ""
+                },
+                {
+                    "Names": "RuleName",
+                    "Description" : "The name of the rule to use",
+                    "Types": STRING_TYPE,
+                    "Default" : ""
+                },
+                {
+                    "Names": "RuleVersion",
+                    "Description" : "The version of the rule to use",
+                    "Types" : STRING_TYPE,
+                    "Default" : ""
+                },
+                {
+                    "Names" : "Parameters",
+                    "Description" : "Rule specific parameters used to apply additional configuration",
+                    "Types" : ANY_TYPE,
+                    "Default" : {}
+                },
+                {
+                    "Names" : "DisabledRules",
+                    "Description" : "A list of rules within the managed rule which should be disabled",
+                    "Types" : ARRAY_OF_STRING_TYPE,
+                    "Default" : []
                 }
             ]
         }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for defining more complex WAF rules which perform actions in different ways, such as applying after a rate limit has been hit or using vendor provided protections

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Web Application Firewalls are becoming more complex and featured and allow for more than just allow/deny actions. This change includes the ability to use these more complex rules as required 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

