### PR TITLE
feat(s3): block public access on account s3

### DIFF
--- a/legacy/account/account_audit.ftl
+++ b/legacy/account/account_audit.ftl
@@ -30,6 +30,9 @@
                 lifecycleRules=lifecycleRules
                 versioning=true
                 cannedACL="LogDeliveryWrite"
+                publicAccessBlockConfiguration=(
+                    getPublicAccessBlockConfiguration()
+                )
             /]
         [/#if]
     [#else]

--- a/legacy/account/account_console.ftl
+++ b/legacy/account/account_console.ftl
@@ -91,6 +91,9 @@
                         encrypted=true
                         kmsKeyId=consoleCMKId
                         versioning=true
+                        publicAccessBlockConfiguration=(
+                            getPublicAccessBlockConfiguration()
+                        )
                     /]
                 [/#if]
 

--- a/legacy/account/account_s3.ftl
+++ b/legacy/account/account_s3.ftl
@@ -106,6 +106,9 @@
                 kmsKeyId=accountCMKArn
                 outputId=formatAccountS3Id(bucket)
                 replicationConfiguration=replicationConfiguration
+                publicAccessBlockConfiguration=(
+                    getPublicAccessBlockConfiguration()
+                )
             /]
 
             [#if bucket == "registry" ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Blocks public access for s3 buckets deployed at the account level

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Implements https://github.com/hamlet-io/engine-plugin-aws/pull/656 for account level s3 buckets

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

