### PR TITLE
fix(wafrule): engine type spelling

### DIFF
--- a/providers/shared/references/WAFRule/id.ftl
+++ b/providers/shared/references/WAFRule/id.ftl
@@ -35,9 +35,9 @@
         {
             "Names" : "Engine",
             "Description" : "The engine of the rule that will be used to evaluate the traffic",
-            "Values" : [ "Conditonal", "RateLimit", "VendorManaged" ],
+            "Values" : [ "Conditional", "RateLimit", "VendorManaged" ],
             "Types": STRING_TYPE,
-            "Default" : "Conditonal"
+            "Default" : "Conditional"
         },
         {
             "Names" : "Engine:RateLimit",


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Align spelling of default engine to that used in the AWS specific logic.

## Motivation and Context
AWS WAF support is incorrectly detecting the default engine type.

As the additional engine types were only recently added, it felt more appropriate to correct the spelling
rather than leave the misspelling in place and add the correct spelling to the possible values.

## How Has This Been Tested?
Local template generation.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

