### PR TITLE
feat(image): adds support for images in occurrence

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -955,30 +955,6 @@
 
 [/#function]
 
-[#function getBuildScript filesArrayName region registry product occurrence filename buildUnit=""]
-    [#return
-        [
-            "copyFilesFromBucket" + " " +
-              region + " " +
-              getRegistryEndPoint(registry, occurrence) + " " +
-              formatRelativePath(
-                getRegistryPrefix(registry, occurrence),
-                getOccurrenceBuildProduct(occurrence, product),
-                getOccurrenceBuildScopeExtension(occurrence),
-                buildUnit?has_content?then(
-                    buildUnit,
-                    getOccurrenceBuildUnit(occurrence)
-                ),
-                getOccurrenceBuildReference(occurrence)) + " " +
-                "\"$\{tmpdir}\" || return $?",
-            "#",
-            "addToArray" + " " +
-               filesArrayName + " " +
-               "\"$\{tmpdir}/" + filename + "\"",
-            "#"
-        ] ]
-[/#function]
-
 [#function getLocalFileScript filesArrayName filepath filename=""]
     [#return
         valueIfContent(
@@ -1030,83 +1006,6 @@
         ]
     ]
 
-[/#function]
-
-[#function getImageFromUrlScript region product environment segment occurrence sourceURL imageFormat registryFile expectedImageHash="" createZip=false  ]
-
-    [#local registryBucket = getRegistryEndPoint(imageFormat, occurrence) ]
-    [#local registryPrefix =
-        formatRelativePath(
-            getRegistryPrefix(imageFormat, occurrence),
-            getOccurrenceBuildProduct(occurrence, product),
-            getOccurrenceBuildScopeExtension(occurrence),
-            occurrence.Core.Name
-        )
-    ]
-    [#local buildUnit = occurrence.Core.Name ]
-
-    [#return
-        [
-            r'if [[ "${HAMLET_SKIP_IMAGE_PULL}" != "true" ]]; then',
-            r'   get_url_image_to_registry ' +
-            r'     "' + sourceURL + r'" ' +
-            r'     "' + expectedImageHash + r'" ' +
-            r'     "' + imageFormat + r'" ' +
-            r'     "' + region + r'" ' +
-            r'     "' + registryBucket + r'" ' +
-            r'     "' + registryPrefix + r'" ' +
-            r'     "' + registryFile + r'" ' +
-            r'     "' + product + r'" ' +
-            r'     "' + environment + r'" ' +
-            r'     "' + segment + r'" ' +
-            r'     "' + buildUnit + r'" ' +
-            r'     "' + createZip?c + r'" || exit $?',
-            r'   # refresh settings to include new build file',
-            r'',
-            r'   assemble_settings "${GENERATION_DATA_DIR}" "${COMPOSITE_SETTINGS}"'
-            r'else',
-            r'   info "Skipping image pull as HAMLET_SKIP_IMAGE_PULL is set"',
-            r'fi'
-        ]
-    ]
-[/#function]
-
-[#function getImageFromContainerRegistryScript
-        product
-        environment
-        segment
-        occurrence
-        containerId
-        sourceImage
-        imageFormat
-        registryHost
-        registryProvider
-        region=""
-    ]
-
-    [#local settingNamespace = formatName(occurrence.Core.RawName, containerId)]
-
-    [#return
-        [
-            r'if [[ "${HAMLET_SKIP_IMAGE_PULL}" != "true" ]]; then',
-            r'  get_image_from_container_registry' +
-            r'   "' + sourceImage + r'" ' +
-            r'   "' + imageFormat + r'" ' +
-            r'   "' + product + r'" ' +
-            r'   "' + environment + r'" ' +
-            r'   "' + segment + r'" ' +
-            r'   "' + settingNamespace + r'" ' +
-            r'   "' + registryHost + r'" ' +
-            r'   "' + registryProvider + r'" ' +
-            r'   "' + region + r'" || exit $? ',
-            r'   # refresh settings to include new build file',
-            r'',
-            r'   assemble_settings "${GENERATION_DATA_DIR}" "${COMPOSITE_SETTINGS}"',
-            r'else',
-            r'   info "Skipping image pull as HAMLET_SKIP_IMAGE_PULL is set"',
-            r'fi'
-        ]
-    ]
 [/#function]
 
 [#function getResourceFromId resources id ]

--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -1,41 +1,5 @@
 [#ftl]
 
-[#-- Registry definitions --]
-
-[#function getRegistryEndpointValue occurrence qualifiers ]
-
-    [#return
-        contentIfContent(
-            getOccurrenceSettingValue(
-                occurrence, asFlattenedArray(["Registries", qualifiers, "Endpoint"]), true),
-            getOccurrenceSettingValue(
-                    occurrence, asFlattenedArray(["Registries", qualifiers, "Registry"]), true)
-        )
-    ]
-[/#function]
-
-
-[#function getRegistryEndPoint type occurrence region="" ]
-
-    [#if !(region?has_content) ]
-        [#local region = occurrence.State.ResourceGroups["default"].Placement.Region ]
-    [/#if]
-
-    [#return
-        contentIfContent(
-            getRegistryEndpointValue(occurrence, [type, "RegionEndpoints", region]),
-            contentIfContent(
-                getRegistryEndpointValue(occurrence, [type ]),
-                "HamletFatal: Unknown registry of type " + type
-            )
-        )
-    ]
-[/#function]
-
-[#function getRegistryPrefix type occurrence ]
-    [#return getOccurrenceSettingValue(occurrence, ["Registries", type, "Prefix"], true) ]
-[/#function]
-
 [#-- Environment Variable Management --]
 [#function addVariableToContext context name value upperCase=true]
     [#return

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -129,6 +129,14 @@
     [#return result]
 [/#function]
 
+[#function getOccurrenceImage occurrence id="default" defaultWhenMissing=true ]
+    [#if id != "default" && defaultWhenMissing]
+        [#return ((occurrence.State.Images[id])!occurrence.State.Images["default"])!{}]
+    [/#if]
+
+    [#return (occurrence.State.Images[id])!{}]
+[/#function]
+
 [#function getOccurrenceNetwork occurrence]
     [#return getTierNetwork(occurrence.Core.Tier.Id)]
 [/#function]
@@ -344,6 +352,8 @@
                     "Environment" : {
                         "Build" :
                             getSettingsAsEnvironment(occurrence.Configuration.Settings.Build),
+                        "Image" :
+                            getSettingsAsEnvironment(occurrence.Configuration.Settings.Image),
                         "General" :
                             internalGetOccurrenceSettingsAsEnvironment(
                                 occurrence,
@@ -409,6 +419,7 @@
         [#-- Default resource group state --]
         [#local state =
             {
+                "Images": {},
                 "Resources" : {},
                 "Roles" : {
                     "Inbound" : {},
@@ -530,6 +541,40 @@
         [/#if]
     [/#list]
     [#return result ]
+[/#function]
+
+[#function constructOccurrenceImageSettings occurrence ]
+    [#if ((occurrence.State.Images)!{})?has_content]
+        [#local occurrence = mergeObjects(
+            occurrence,
+            {
+                "Configuration" : {
+                    "Settings" : {
+                        "Image": {
+                            "IMAGE_REFERENCE": {
+                                "Value": ((occurrence.State.Images)?values?map(x -> x?is_hash?then((x.Reference)!"", ""))?join(","))!""
+                            },
+                            "IMAGE_TAG": {
+                                "Value":  ((occurrence.State.Images)?values?map(x -> x?is_hash?then((x.Tag)!"", ""))?join(","))!""
+                            }
+                        }
+                    }
+                }
+            }
+        )]
+
+        [#local occurrence = mergeObjects(
+            occurrence,
+            {
+                "Configuration" : {
+                    "Environment" : {
+                        "Image" : getSettingsAsEnvironment(occurrence.Configuration.Settings.Image)
+                    }
+                }
+            }
+        )]
+    [/#if]
+    [#return occurrence]
 [/#function]
 
 [#--------------------------------------------------------

--- a/engine/occurrence.ftl
+++ b/engine/occurrence.ftl
@@ -352,8 +352,6 @@
                     "Environment" : {
                         "Build" :
                             getSettingsAsEnvironment(occurrence.Configuration.Settings.Build),
-                        "Image" :
-                            getSettingsAsEnvironment(occurrence.Configuration.Settings.Image),
                         "General" :
                             internalGetOccurrenceSettingsAsEnvironment(
                                 occurrence,

--- a/engine/setContext.ftl
+++ b/engine/setContext.ftl
@@ -74,8 +74,8 @@
     [#return getExistingReference(formatAccountS3Id("code"), REGION_ATTRIBUTE_TYPE)]
 [/#function]
 
-[#function getRegistryBucket]
-    [#return getExistingReference(formatAccountS3Id("registry")) ]
+[#function getRegistryBucket region=""]
+    [#return getExistingReference(formatAccountS3Id("registry"), "", region) ]
 [/#function]
 
 [#function getRegistryBucketRegion]

--- a/providers/shared/extensions/extension.ftl
+++ b/providers/shared/extensions/extension.ftl
@@ -195,14 +195,12 @@
     ]
 [/#macro]
 
-[#macro Attributes name="" image="" version="" essential=true]
+[#macro Attributes name="" essential=true]
     [#assign _context +=
         {
             "Essential" : essential
         } +
-        attributeIfContent("Name", name) +
-        attributeIfContent("Image", image) +
-        attributeIfContent("ImageVersion", version)
+        attributeIfContent("Name", name)
     ]
 [/#macro]
 

--- a/providers/shared/flows/components/flow.ftl
+++ b/providers/shared/flows/components/flow.ftl
@@ -1024,6 +1024,9 @@ that doesn't match the link.
 
                         }]
 
+                    [#-- Add Image settings after we have built the image in state --]
+                    [#local occurrence = constructOccurrenceImageSettings(occurrence)]
+
                     [#-- Add suboccurrences --]
                     [#local subOccurrences = [] ]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for Images as part of the occurrence which represent a code image that can be used by an application component
- Removes common functions for registry lookups as registries are managed via the image definition for the provider
- Removes the configuration for docker image attributes around name and version in favour of the container image properties
- Moves image pull scripts from the common provider over to the aws provider as they are specific to AWS images

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Standardising and consolidating the image manage process allows us to align how images can be used across all components and introduce more solution based ways to manage images. Providing their own section in state allows for the definition of a standard image structure that can be used across providers. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

