### PR TITLE
fix(waf): set default WAFProfile to default

### DIFF
--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -1800,6 +1800,10 @@
     }
   },
   "WAFProfiles": {
+    "default": {
+      "Rules": [],
+      "DefaultAction": "ALLOW"
+    },
     "OWASP2017": {
       "Rules": [
         {
@@ -1827,7 +1831,7 @@
         },
         "application": {
           "HTTPSProfile": "ELBSecurityPolicy-TLS-1-2-2017-01",
-          "WAFProfile": "OWASP2017",
+          "WAFProfile": "default",
           "WAFValueSet": "default"
         },
         "classic": {
@@ -1838,17 +1842,17 @@
         "CDNHTTPSProfile": "TLSv1",
         "GatewayHTTPSProfile": "TLS_1_0",
         "ProtocolPolicy": "redirect-to-https",
-        "WAFProfile": "OWASP2017",
+        "WAFProfile": "default",
         "WAFValueSet": "default"
       },
       "spa": {
         "HTTPSProfile": "TLSv1",
-        "WAFProfile": "OWASP2017",
+        "WAFProfile": "default",
         "WAFValueSet": "default"
       },
       "cdn": {
         "HTTPSProfile": "TLSv1",
-        "WAFProfile": "OWASP2017",
+        "WAFProfile": "default",
         "WAFValueSet": "default"
       },
       "db": {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds a default WAF profile which allows for open access by default
- Aligns with other security profiles and allows for creating rules without the provided OWASP rulesets

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This aligns with the updated behaviour in https://github.com/hamlet-io/engine-plugin-aws/pull/668 which brings the WAF security configuration more in line with how the rest of the profiles work across other components. In the AWS provider if the OWASP WAF configuration isn't enable the user could not use the profile to configure the WAF rules. Creating a default open profile and using that as the default aligns with the current behaviour in AWS 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine-plugin-aws/pull/668 

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

