### PR TITLE
feat(db): add proxy subcomponent

### DIFF
--- a/providers/shared/components/component.ftl
+++ b/providers/shared/components/component.ftl
@@ -65,6 +65,8 @@
     type=DB_COMPONENT_TYPE
 /]
 
+[#assign DB_PROXY_COMPONENT_TYPE = "dbproxy" ]
+
 [#assign DOCDB_COMPONENT_TYPE = "docdb" ]
 
 [#assign DIRECTORY_COMPONENT_TYPE = "directory" ]

--- a/providers/shared/components/db/id.ftl
+++ b/providers/shared/components/db/id.ftl
@@ -342,3 +342,101 @@
     type=DB_COMPONENT_TYPE
     defaultGroup="solution"
 /]
+
+[@addChildComponent
+    type=DB_PROXY_COMPONENT_TYPE
+    parent=DB_COMPONENT_TYPE
+    childAttribute="Proxies"
+    linkAttributes="Proxy"
+    properties=
+        [
+            {
+                "Type" : "Description",
+                "Value" : "A database connection pooling proxy"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "Enabled",
+            "Description": "Is the proxy enabled",
+            "Types": BOOLEAN_TYPE,
+            "Default": true
+        },
+        {
+            "Names": "TargetTypes",
+            "Description" : "The type of the proxy targets to create based on the avaialble db resources",
+            "Types": ARRAY_OF_STRING_TYPE,
+            "Values" : [ "ReadWrite", "ReadOnly" ],
+            "Default" : [ "ReadWrite" ]
+        },
+        {
+            "Names": "ConnectionBorrowTimeout",
+            "Description" : "How long to wait for a connection to be released when no other connections are available",
+            "Types": NUMBER_TYPE
+        },
+        {
+            "Names" : "MaxConnectionsPercent",
+            "Description" : "The percentage of connections that the proxy can use",
+            "Types" : NUMBER_TYPE
+        },
+        {
+            "Names" : "MaxIdleConnectionsPercent",
+            "Description" : "The percentage of idle connections that are kept active",
+            "Types" : NUMBER_TYPE
+        },
+        {
+            "Names" : "AuthorisedUsers",
+            "Description" : "Defines the users who can use the Proxy",
+            "SubObjects" : true,
+            "Children" : [
+                {
+                    "Names" : "Source",
+                    "Description" : "The source of the user credentials - Secret = a secret component, DBRoot = the root credentials used on the parent DB",
+                    "Values" : ["Secret", "DBRoot"],
+                    "Default" : "Secret"
+                },
+                {
+                    "Names" : "Source:Secret",
+                    "Children": [
+                        {
+                            "Names" : "Username",
+                            "Description" : "The username if not provided in the secret",
+                            "Types" : STRING_TYPE
+                        },
+                        {
+                            "Names" : "Link",
+                            "Description" : "A link to the secret that holds the credentials for the db - secret should contain username and password as JSON object",
+                            "AttributeSet": LINK_ATTRIBUTESET_TYPE
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "Names": "InitProxy",
+            "Description": "A SQL query for the proxy to run on the startup of a new connection",
+            "Types" : STRING_TYPE,
+            "Default" : ""
+        },
+        {
+                "Names" : "Profiles",
+                "Children": [
+                    {
+                        "Names" : "Network",
+                        "Types" : STRING_TYPE,
+                        "Default" : "default"
+                    }
+                ]
+        },
+        {
+            "Names" : "Links",
+            "SubObjects" : true,
+            "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+        },
+        {
+            "Names" : "IPAddressGroups",
+            "Types" : ARRAY_OF_STRING_TYPE,
+            "Default" : [ "_localnet" ]
+        }
+    ]
+/]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- defines the proxy subcomponent for db's which represents an automated connection pooling proxy service

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Connection pooling helps to reduce database resources when establishing connections in for short lived services like lambda functions. Instead of each database client creating a connection to the db, the proxy establishes a set of connections to the database and then clients connect to the proxy. 

The proxy then looks after distributing requests across its connections. DB proxies can also bypass load balancers which might lock connections to a particular host, when this happens autoscaling activities which add new databases might not be used to their full extent, the proxy knows when new hosts are added and will make sure database requests are spread across the hosts.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally and on active deployment

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

