### PR TITLE
fix: stackoutput generation and image upload runbooks

### DIFF
--- a/providers/shared/components/runbook/setup.ftl
+++ b/providers/shared/components/runbook/setup.ftl
@@ -59,7 +59,8 @@
                 "Environment" : {},
                 "Links" : contextLinks,
                 "TaskParameters" : solution.Task.Parameters,
-                "Conditions" : solution.Conditions
+                "Conditions" : solution.Conditions,
+                "Inputs": runBookInputs
             }
         ]
         [#local _context = invokeExtensions(subOccurrence, _context, {}, [], false, "runbook")]

--- a/providers/shared/extensions/runbook_image_reference_output/extension.ftl
+++ b/providers/shared/extensions/runbook_image_reference_output/extension.ftl
@@ -15,10 +15,11 @@
 
 [#macro shared_extension_runbook_image_reference_output_runbook_setup occurrence ]
 
-    [#local image = (_context.Links["image"])!{}]
-    [#if ! image?has_content]
+    [#local imageLink = (_context.Links["image"])!{}]
+    [#if ! imageLink?has_content ]
         [#return]
     [/#if]
+    [#local image = imageLink.State.Images[_context.Inputs["input:ImageId"]] ]
 
     [#assign _context = mergeObjects(
         _context,
@@ -26,12 +27,12 @@
             "TaskParameters" : {
                 "StackOutputContent" : getJSON(
                     {
-                        image.State.Resources.image.Id: "__input:Reference__",
-                        formatId(image.State.Resources.image.Id, NAME_ATTRIBUTE_TYPE): "__input:Tag__"
+                        image.Id: "__input:Reference__",
+                        formatId(image.Id, NAME_ATTRIBUTE_TYPE): "__input:Tag__"
                     }
                 ),
-                "DeploymentUnit" : getOccurrenceDeploymentUnit(image),
-                "DeploymentGroup" : getOccurrenceDeploymentGroup(image)
+                "DeploymentUnit" : getOccurrenceDeploymentUnit(imageLink),
+                "DeploymentGroup" : getOccurrenceDeploymentGroup(imageLink)
             }
         }
     )]

--- a/providers/shared/extensions/runbook_registry_object_filename/extension.ftl
+++ b/providers/shared/extensions/runbook_registry_object_filename/extension.ftl
@@ -15,17 +15,18 @@
 
 [#macro shared_extension_runbook_registry_object_filename_runbook_setup occurrence ]
 
-    [#local image = (_context.Links["image"])!{}]
-    [#if ! image?has_content]
+    [#local imageLink = (_context.Links["image"])!{}]
+    [#if ! imageLink?has_content ]
         [#return]
     [/#if]
+    [#local image = imageLink.State.Images[_context.Inputs["input:ImageId"]] ]
 
     [#assign _context = mergeObjects(
         _context,
         {
             "TaskParameters" : {
                 "DestinationPath" : {
-                    "Value" : "__output:zip_stage_path:path__/" + (image.State.Resources["image"].ImageFileName)!""
+                    "Value" : "__output:zip_stage_path:path__/" + (image.ImageFileName)!""
                 }
             }
         }

--- a/providers/shared/extensions/runbook_registry_type_condition/extension.ftl
+++ b/providers/shared/extensions/runbook_registry_type_condition/extension.ftl
@@ -15,17 +15,18 @@
 
 [#macro shared_extension_runbook_registry_type_condition_runbook_setup occurrence ]
 
-    [#local image = (_context.Links["image"])!{}]
-    [#if ! image?has_content]
+    [#local imageLink = (_context.Links["image"])!{}]
+    [#if ! imageLink?has_content ]
         [#return]
     [/#if]
+    [#local image = imageLink.State.Images[_context.Inputs["input:ImageId"]] ]
 
     [#assign _context = mergeObjects(
         _context,
         {
             "Conditions" : {
                 "registry_type" : {
-                    "Test" : (image.State.Resources["image"].RegistryType)!""
+                    "Test" : image.RegistryType
                 }
             }
         }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Not sure how but the stackoutput generation entrance seems to have been partially removed.
- Adds the output process back in to generate stack output files in the engine
- Adds the resolved inputs for runbooks into the context of steps
- Fixes how a components image is looked up when pushing images via runbook

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Added as a collection of fixes found when testing out the image push method for docker containers using the runbook method

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

