### PR TITLE
fix(account_s3): remove s3 registry initialisation

### DIFF
--- a/legacy/account/account_s3.ftl
+++ b/legacy/account/account_s3.ftl
@@ -268,17 +268,7 @@
                     [
                         "function sync_code_bucket() {"
                     ] +
-                        scriptSyncContent +
-                    [
-                        "}",
-                        "#",
-                        "case $\{STACK_OPERATION} in",
-                        "  create|update)",
-                        "    sync_code_bucket || return $?",
-                        "    initialise_registries ${s3RegistryIds} || return $?",
-                        "    ;;",
-                        " esac"
-                    ]
+                        scriptSyncContent
             /]
         [/#if]
     [/#if]

--- a/legacy/account/account_s3.ftl
+++ b/legacy/account/account_s3.ftl
@@ -268,7 +268,11 @@
                     [
                         "function sync_code_bucket() {"
                     ] +
-                        scriptSyncContent
+                        scriptSyncContent +
+                    [
+                        "}",
+                        "sync_code_bucket || exit $?"
+                    ]
             /]
         [/#if]
     [/#if]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Remove the setup of registry markers in the account registry bucket
- Removes the code bucket sync

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
With the move to fixed registry prefixes to store images the need to initialise the registry isn't really there any more. This is currently causing issues as the s3RegistryIds variable was removed in other image updates
We no longer have components which rely on the code sync process so this has been removed as well

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

