### PR TITLE
feat(account): add aws es log access policy

### DIFF
--- a/legacy/account/account_es.ftl
+++ b/legacy/account/account_es.ftl
@@ -1,0 +1,58 @@
+[#if getCLODeploymentUnit()?contains("es") || (groupDeploymentUnits!false) ]
+
+    [#if deploymentSubsetRequired("generationcontract", false)]
+        [@addDefaultGenerationContract subsets=[ "template" ] /]
+    [/#if]
+
+    [@includeServicesConfiguration
+        provider=AWS_PROVIDER
+        services=[
+            AWS_CLOUDWATCH_SERVICE
+        ]
+        deploymentFramework=CLOUD_FORMATION_DEPLOYMENT_FRAMEWORK
+    /]
+
+    [#assign esLogPolicyId = formatAccountResourceId(AWS_CLOUDWATCH_LOG_RESOURCE_POLICY_RESOURCE_TYPE, "es")]
+    [#assign esLogPolicyName = formatName("account", "es")]
+
+    [#if deploymentSubsetRequired("lg", true) &&
+            isPartOfCurrentDeploymentUnit(esLogPolicyId)]
+
+        [@createLogResourcePolicy
+            id=esLogPolicyId
+            name=esLogPolicyName
+            policyDocument={
+                "Fn::Sub" : [
+                    getJSON(
+                        {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Principal": {
+                                        "Service": "es.amazonaws.com"
+                                    },
+                                    "Action": [
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": [
+                                        r'arn:aws:logs:${Region}:${AWSAccountId}:log-group:/elasticsearch/*'
+                                    ]
+                                }
+                            ]
+                        }
+                    ),
+                    {
+                        "Region" : {
+                            "Ref" : "AWS::Region"
+                        },
+                        "AWSAccountId" : {
+                            "Ref" : "AWS::AccountId"
+                        }
+                    }
+                ]
+            }
+        /]
+    [/#if]
+[/#if]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Create policy so that Elastic/OpenSearch can log to Cloudwatch

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Required for the implementation of Logging 
https://docs.aws.amazon.com/opensearch-service/latest/developerguide/createdomain-configure-slow-logs.html

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and on dev deployment

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

