### PR TITLE
feat(userpool): control enabling hostedUI

### DIFF
--- a/providers/shared/components/userpool/id.ftl
+++ b/providers/shared/components/userpool/id.ftl
@@ -198,6 +198,12 @@
                 "Description" : "Provision a managed endpoint for login and oauth endpoints",
                 "Children" : [
                     {
+                        "Names": "Enabled",
+                        "Description": "Setup a custom hosted ui endpoint for login and oauth",
+                        "Types": BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
                         "Names" : [ "Certificate", "Hostname" ],
                         "AttributeSet" : CERTIFICATE_ATTRIBUTESET_TYPE
                     }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for enabling/disabling the hostedUI

## Motivation and Context
<!--- Why make this change? Link to any existing issues here --
For AWS when you rename a hosted UI you need to remove the existing one before adding the new one. So this allows for it to be done without having to remove the Certificate object configuration 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

