### PR TITLE
feat(cloudtrail): support for account cloudtrail

### DIFF
--- a/legacy/account/account_audit.ftl
+++ b/legacy/account/account_audit.ftl
@@ -1,6 +1,15 @@
 [#-- Auditing configuration --]
 [#if getCLODeploymentUnit()?contains("audit") || (groupDeploymentUnits!false) ]
 
+    [@includeServicesConfiguration
+        provider=AWS_PROVIDER
+        services=[
+            AWS_SIMPLE_STORAGE_SERVICE,
+            AWS_CLOUDTRAIL_SERVICE
+        ]
+        deploymentFramework=getCLODeploymentFramework()
+    /]
+
     [#if accountObject.Seed?has_content]
 
         [#if deploymentSubsetRequired("generationcontract", false)]
@@ -12,6 +21,8 @@
         [#if deploymentSubsetRequired("audit", true)]
             [#assign lifecycleRules = []]
 
+            [#assign auditBucketId = formatAccountS3Id("audit")]
+
             [#if accountObject.Audit.Expiration?has_content ]
                 [#assign lifecycleRules +=
                     getS3LifecycleRule(
@@ -21,9 +32,73 @@
             [/#if]
 
             [#assign sqsNotifications = []]
+            [#assign auditBucketPolicyStatements = []]
+
+            [#if (accountObject.ProviderAuditing.StorageLocations)?values?filter( x -> x.Type == "Object")?size == 1 ]
+
+                [#assign cloudTrailObjectStore = (accountObject.ProviderAuditing.StorageLocations)?values?filter(x -> x.Type == "Object")?first ]
+
+                [#assign auditBucketPolicyStatements = combineEntities(
+                    auditBucketPolicyStatements,
+                    getS3BucketStatement(
+                        [
+                            "s3:GetBucketAcl"
+                        ],
+                        auditBucketId,
+                        "",
+                        "",
+                        {
+                            "Service": "cloudtrail.amazonaws.com"
+                        },
+                        {
+                            "StringEquals" : {
+                                "aws:SourceArn": formatRegionalArn(
+                                    "cloudtrail",
+                                    r'trail/' + getAccountCloudTrailProviderAuditingName()
+                                )
+                            }
+                        }
+                    ) +
+                    getS3Statement(
+                        [
+                            "s3:PutObject"
+                        ],
+                        auditBucketId,
+                        formatRelativePath(
+                            getAccountCloudTrailProviderAuditingS3Prefix(),
+                            "AWSLogs"
+                        ),
+                        "*",
+                        {
+                            "Service": "cloudtrail.amazonaws.com"
+                        },
+                        {
+                            "StringEquals": {
+                                "aws:SourceArn": formatRegionalArn(
+                                    "cloudtrail",
+                                    formatRelativePath(
+                                        "trail",
+                                        getAccountCloudTrailProviderAuditingName()
+                                    )
+                                ),
+                                "s3:x-amz-acl": "bucket-owner-full-control"
+                            }
+                        }
+                    ),
+                    APPEND_COMBINE_BEHAVIOUR
+                )]
+            [/#if]
+
+            [#if auditBucketPolicyStatements?has_content ]
+                [@createBucketPolicy
+                    id=formatAccountResourceId(AWS_S3_BUCKET_POLICY_RESOURCE_TYPE, auditBucketId)
+                    bucketId=auditBucketId
+                    statements=auditBucketPolicyStatements
+                /]
+            [/#if]
 
             [@createS3Bucket
-                id=formatAccountS3Id("audit")
+                id=auditBucketId
                 name=formatName("account", "audit", accountObject.Seed)
                 encrypted=s3EncryptionEnabled
                 encryptionSource="AES256"

--- a/legacy/account/account_cloudtrail.ftl
+++ b/legacy/account/account_cloudtrail.ftl
@@ -1,0 +1,141 @@
+[#-- AWS CloudTrail log forwarding --]
+[#if getCLODeploymentUnit()?contains("cloudtrail") || (groupDeploymentUnits!false) ]
+    [#if deploymentSubsetRequired("generationcontract", false)]
+        [@addDefaultGenerationContract subsets="template" /]
+    [/#if]
+
+    [@includeServicesConfiguration
+        provider=AWS_PROVIDER
+        services=[
+            AWS_IDENTITY_SERVICE,
+            AWS_CLOUDWATCH_SERVICE,
+            AWS_SIMPLE_STORAGE_SERVICE,
+            AWS_CLOUDTRAIL_SERVICE,
+            AWS_KEY_MANAGEMENT_SERVICE
+        ]
+        deploymentFramework=getCLODeploymentFramework()
+    /]
+
+    [#assign cloudTrailId = formatAccountResourceId(AWS_CLOUDTRAIL_TRAIL_RESOURCE_TYPE)]
+    [#assign cloudTrailName = getAccountCloudTrailProviderAuditingName()]
+    [#assign cloudTrailRoleId = formatAccountResourceId(AWS_IAM_ROLE_RESOURCE_TYPE, "cloudtrail")]
+    [#assign cloudTrailCloudWatchLogGroupId = formatAccountResourceId(AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE, "cloudtrail" )]
+    [#assign cloudTrailCloudWatchLogGroupName = formatAbsolutePath(
+        "cloudtrail",
+        accountObject.ProviderAuditing.Scope,
+        (accountObject.ProviderAuditing.Scope == "Account")?then(
+            accountObject.ProviderId,
+            ((tenantObject.Name)!tenantObject.Id)
+        )
+    )]
+
+    [#assign accountCMKId = formatAccountCMKTemplateId()]
+    [#assign accountCMKArn = getExistingReference(accountCMKId, ARN_ATTRIBUTE_TYPE, getCLOSegmentRegion())]
+
+    [#assign cloudtrailS3BucketId = formatAccountS3Id("audit")]
+    [#assign cloudtrailS3KeyPrefix = ""]
+    [#assign cloudtrailCloudWatchLogsRequired = false]
+
+    [#list accountObject.ProviderAuditing.StorageLocations as id, storageLocation ]
+        [#if storageLocation.Type == "Object" ]
+            [#assign cloudtrailS3KeyPrefix = getAccountCloudTrailProviderAuditingS3Prefix()]
+        [/#if]
+
+        [#if storageLocation.Type == "Logs"]
+            [#assign cloudtrailCloudWatchLogsRequired = true ]
+        [/#if]
+    [/#list]
+
+    [#if deploymentSubsetRequired("iam", true)
+            && isPartOfCurrentDeploymentUnit(cloudTrailRoleId)
+            && cloudtrailCloudWatchLogsRequired ]
+
+        [@createRole
+            id=cloudTrailRoleId
+            trustedServices=[
+                "cloudtrail.amazonaws.com"
+            ]
+            policies=[
+                getPolicyDocument(
+                    cwLogsPolicy(
+                        [
+                            "logs:CreateLogStream",
+                            "logs:PutLogEvents"
+                        ],
+                        cloudTrailCloudWatchLogGroupName
+                    ),
+                    "logging"
+                )
+            ]
+        /]
+    [/#if]
+
+    [#if deploymentSubsetRequired("lg", true)
+            && isPartOfCurrentDeploymentUnit(cloudTrailCloudWatchLogGroupId)
+            && cloudtrailCloudWatchLogsRequired]
+
+        [#if (accountObject.Logging.Encryption.Enabled)!false  ]
+            [#if ! getExistingReference(accountCMKId)?has_content ]
+                [@fatal
+                    message="Account CMK not found"
+                    detail="Run the cmk deployment at the account level to create the CMK"
+                /]
+            [/#if]
+        [/#if]
+
+        [@createLogGroup
+            id=cloudTrailCloudWatchLogGroupId
+            name=cloudTrailCloudWatchLogGroupName
+            kmsKeyId=accountCMKArn
+        /]
+    [/#if]
+
+    [#if deploymentSubsetRequired("cloudtrail", true)]
+
+        [#if accountObject.ProviderAuditing.StorageLocations?values?filter( x -> x.Type == "Object")?size != 1 ]
+            [@fatal
+                message="S3 Cloud Trail must have a single Object store to put logs in"
+                detail="Add a Object type storage location for Provider Auditing"
+                context={
+                    "Account": accountObject.Id,
+                    "ProviderAuditing" : accountObject.ProviderAuditing
+                }
+            /]
+        [/#if]
+
+        [#if accountObject.ProviderAuditing.StorageLocations?values?filter( x -> x.Type == "Logs")?size > 1 ]
+            [@fatal
+                message="Only 1 CloudWatch Log group can be defined for Cloud Trail Logging"
+                detail="Remove any extra Logs storage locations from your Provider Auditing"
+                context={
+                    "Account": accountObject.Id,
+                    "ProviderAuditing" : accountObject.ProviderAuditing
+                }
+            /]
+        [/#if]
+
+        [@createCloudTrailTrail
+            id=cloudTrailId
+            name=cloudTrailName
+            enabled=accountObject.ProviderAuditing.Enabled
+            s3BucketId=cloudtrailS3BucketId
+            s3KeyPrefix=cloudtrailS3KeyPrefix
+            organizationTrail=(accountObject.ProviderAuditing.Scope == "Tenancy")?then(true, false)
+            multiRegion=true
+            logFileValidation=true
+            includeGlobalServices=true
+            insightSelectors=(accountObject.ProviderAuditing["aws:InsightReporting"])?then(
+                getCloudTrailTrailInsightSelectors(
+                    ["CallRate", "ErrorRate"]
+                ),
+                []
+            )
+            cloudWatchLogGroupId=cloudtrailCloudWatchLogsRequired?then(cloudTrailCloudWatchLogGroupId, "")
+            cloudWatchLogsRoleId=cloudtrailCloudWatchLogsRequired?then(cloudTrailRoleId, "")
+            kmsKeyId=(accountObject.ProviderAuditing.Encryption.Enabled)?then(
+                formatAccountCMKTemplateId(),
+                ""
+            )
+        /]
+    [/#if]
+[/#if]

--- a/providers/shared/layers/Account/id.ftl
+++ b/providers/shared/layers/Account/id.ftl
@@ -322,6 +322,65 @@
                     ]
                 }
             ]
+        },
+        {
+            "Names": "ProviderAuditing",
+            "Description": "Logging of cloud service provider actions",
+            "Children" : [
+                {
+                    "Names": "Enabled",
+                    "Description" : "Is the logging service enabled",
+                    "Types": BOOLEAN_TYPE,
+                    "Default" : true
+                },
+                {
+                    "Names" : "Scope",
+                    "Description" : "The Scope of the logging sent to this account - Account = this account, Tenancy = all accounts in tenancy",
+                    "Types" : STRING_TYPE,
+                    "Values" : [ "Account", "Tenancy"],
+                    "Default" : "Account"
+                },
+                {
+                    "Names": "Encryption",
+                    "Description" : "Manage at-rest encryption of data storage",
+                    "Children" : [
+                        {
+                            "Names" : "Enabled",
+                            "Types" : BOOLEAN_TYPE,
+                            "Default" : true
+                        }
+                    ]
+                },
+                {
+                    "Names" : "StorageLocations",
+                    "Description": "Where to store the audit logs",
+                    "SubObjects": true,
+                    "Children" : [
+                        {
+                            "Names" : "Type",
+                            "Description" : "The type of storage to use",
+                            "Values" : [ "Object", "Logs" ],
+                            "Default" : "Object"
+                        },
+                        {
+                            "Names": "Type:Object",
+                            "Children" : [
+                                {
+                                    "Names" : "Prefix",
+                                    "Description" : "A prefix to apply to objects store in logs - _provider = use the providers service name",
+                                    "Default" : "_provider"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "Names": "aws:InsightReporting",
+                    "Description" : "Enable proactive insight monitor logging",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : true
+                }
+            ]
         }
     ]
 /]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for creating an account level cloudtrail trail to track management api calls and store them in the account audit bucket

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Cloudtrail auditing provides a log of all activities performed within a cloud provider subscription. They usually focus on management plane calls but can be configured to support some data plane calls for deeply integrated services. 

This adds support for the management activities and closes #679

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and on test deployment 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine-plugin-aws/pull/687

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

