### PR TITLE
feat: add support for deployment locks

### DIFF
--- a/engine/configuration/component.ftl
+++ b/engine/configuration/component.ftl
@@ -137,6 +137,18 @@
             "Names" : "Unit",
             "Types" : STRING_TYPE,
             "Default" : defaultUnit
+        },
+        {
+            "Names": "Locks",
+            "Description" : "Apply locks on the deployment to control what can be completed",
+            "Children": [
+                {
+                    "Names" : "Delete",
+                    "Description" : "Don't allow the deployment to be deleted",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : false
+                }
+            ]
         } +
         attributeIfTrue(
             "Values",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for locking a deployment to prevent accidental changes
- Initial support is for delete actions

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Adding deletion protection is a key recommendation from cloud vendors as an extra lock to prevent the deletion of key resources within a deployment which are generally fixed, this includes things like dbs, load balancers cdn etc, where removing the resource would require significant effort to bring back up. 

This allows for the locks to be maintained in hamlet. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

