### PR TITLE
fix: cmdb write output for occurrences

### DIFF
--- a/providers/shared/services/resource.ftl
+++ b/providers/shared/services/resource.ftl
@@ -28,3 +28,28 @@
     )
   ]
 [/#function]
+
+
+[#function getOccurrenceResourceIds resources ]
+    [#local resourceIds = []]
+
+    [#list resources as key,value ]
+        [#if value?is_hash && value.Id?? ]
+            [#local resourceIds = combineEntities(resourceIds, [ value.Id ], UNIQUE_COMBINE_BEHAVIOUR)]
+
+        [#elseif value?is_hash ]
+            [#list value as key, value ]
+                [#if value?is_hash ]
+                    [#local resourceIds = combineEntities(resourceIds, getOccurrenceResourceIds(value))]
+                [#elseif value?is_sequence]
+                    [#local resourceids = combineEntities(
+                      resourceIds,
+                      value?filter(x-> x?is_hash || x?is_sequence)?map(x -> getOccurrenceResourceIds(x))
+                    )]
+                [/#if]
+            [/#list]
+        [/#if]
+    [/#list]
+
+    [#return resourceIds ]
+[/#function]

--- a/providers/shared/tasks/cmdb_write_stack_output/id.ftl
+++ b/providers/shared/tasks/cmdb_write_stack_output/id.ftl
@@ -11,7 +11,7 @@
     attributes=[
         {
             "Names" : "StackOutputContent",
-            "Description" : "The key value parirs to write to the file as a JSON escaped string",
+            "Description" : "The key value pairs to write to the file as a JSON escaped string",
             "Types" : STRING_TYPE,
             "Mandatory" : true
         },


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds a resource lookup to determine the occurrence a provided stack output belongs 
- Adds alternatives to the stackoutput for each occurrence in a deployment, if a resource matched in the process above is found then the output goes into that alternative

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
- ensures that occurrences within the same deployment don't override outputs generated by the output task
- When using the runbook before the output between occurrences was overriden

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

