### PR TITLE
fix: remove gen contract from stack outputs

### DIFF
--- a/providers/shared/components/shared/setup.ftl
+++ b/providers/shared/components/shared/setup.ftl
@@ -363,7 +363,7 @@
 [#macro shared_stackoutput_generationcontract occurrence]
     [#if getCLODeploymentUnit() == getOccurrenceDeploymentUnit(occurrence)
             && getCLODeploymentGroup() == getOccurrenceDeploymentGroup(occurrence)]
-        [@addDefaultGenerationContract subsets=["stack"] alternatives=[occurrence.Core.RawFullName] /]
+        [@addDefaultGenerationContract subsets=["stack"] alternatives=[occurrence.Core.RawFullName] contractCleanup=false /]
     [/#if]
 [/#macro]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Don't include the generation contract for stack outputs to avoid git conflicts when two occurrences in a deployment unit update at the same time

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When using a single deployment unit for all docker based registries if two pipelines update the image references at the same time conflicts are raised on the generation contract. We don't need to care about what was generated in a single file output so it can just be removed. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

