### PR TITLE
feat(es): encryption and hostname control

### DIFF
--- a/providers/shared/components/es/id.ftl
+++ b/providers/shared/components/es/id.ftl
@@ -24,6 +24,11 @@
                 "Mandatory" : true
             },
             {
+                "Names" : [ "Certificate", "Hostname" ],
+                "Description" : "Configure a custom hostname for the service",
+                "AttributeSet" : CERTIFICATE_ATTRIBUTESET_TYPE
+            },
+            {
                 "Names" : [ "MultiAZ", "MultiZone"],
                 "Description" : "Deploy resources to multiple Availablity Zones",
                 "Types" : BOOLEAN_TYPE,
@@ -37,7 +42,7 @@
                         "Names" : "Id",
                         "Types" : STRING_TYPE
                     },
-                    {
+                    { 
                         "Names" : "Value",
                         "Types" : STRING_TYPE
                     }

--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -1859,7 +1859,9 @@
         "SSLCertificateAuthority": "rds-ca-2019"
       },
       "es": {
-        "ProtocolPolicy": "https-only"
+        "ProtocolPolicy": "https-only",
+        "HTTPSProfile": "Policy-Min-TLS-1-2-2019-07",
+        "NodeTransitEncryption": false
       },
       "IPSecVPN": {
         "IKEVersions": [

--- a/providers/shared/references/SecurityProfile/id.ftl
+++ b/providers/shared/references/SecurityProfile/id.ftl
@@ -18,7 +18,8 @@
                     "Children" : [
                         {
                             "Names" : "HTTPSProfile",
-                            "Types" : STRING_TYPE
+                            "Types" : STRING_TYPE,
+                            "Description" : "Defines the TLS encryption profile used for HTTPS connections"
                         }
                     ]
                 },
@@ -27,7 +28,8 @@
                     "Children" : [
                         {
                             "Names" : "HTTPSProfile",
-                            "Types" : STRING_TYPE
+                            "Types" : STRING_TYPE,
+                            "Description" : "Defines the TLS encryption profile used for HTTPS connections"
                         },
                         {
                             "Names" : "WAFProfile",
@@ -44,7 +46,8 @@
                     "Children" : [
                         {
                             "Names" : "HTTPSProfile",
-                            "Types" : STRING_TYPE
+                            "Types" : STRING_TYPE,
+                            "Description" : "Defines the TLS encryption profile used for HTTPS connections"
                         }
                     ]
                 }
@@ -55,11 +58,13 @@
             "Children" : [
                 {
                     "Names" : [ "CDNHTTPSProfile", "HTTPSProfile"],
-                    "Types" : STRING_TYPE
+                    "Types" : STRING_TYPE,
+                    "Description" : "Defines the TLS encryption profile used for HTTPS connections"
                 },
                 {
                     "Names" : "GatewayHTTPSProfile",
                     "Types" : STRING_TYPE,
+                    "Description" : "Defines the TLS encryption profile used for HTTPS connections",
                     "Default" : "TLS_1_0"
                 },
                 {
@@ -81,6 +86,7 @@
             "Children" : [
                 {
                     "Names" : "HTTPSProfile",
+                    "Description" : "Defines the TLS encryption profile used for HTTPS connections",
                     "Types" : STRING_TYPE
                 },
                 {
@@ -107,8 +113,20 @@
             "Children" : [
                 {
                     "Names" : "ProtocolPolicy",
+                    "Description": "Define the protocols the ES endpoints are available on",
                     "Types" : STRING_TYPE,
-                    "Values" : [ "https-only", "http-https", "http-only" ]
+                    "Values" : [ "https-only", "http-https", "http-only" ],
+                    "Default" : "https-only"
+                },
+                {
+                    "Names" : "HTTPSProfile",
+                    "Types" : STRING_TYPE,
+                    "Description" : "Defines the TLS encryption profile used for HTTPS connections"
+                },
+                {
+                    "Names" : "NodeTransitEncryption",
+                    "Types" : BOOLEAN_TYPE,
+                    "Description" : "Require the use of node to node transit encryption"
                 }
             ]
         },


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for an HTTPS profile option on ES clusters to control TLS encryption setup
- Adds support for configuring a custom hostname/certificate for
- Adds security support for configuring node to node encryption

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Aligns with security best practices and what we offer for our other components

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

