### PR TITLE
fix: include region for deployment checking

### DIFF
--- a/providers/shared/layers/Account/id.ftl
+++ b/providers/shared/layers/Account/id.ftl
@@ -467,9 +467,13 @@
 
 [#-- Temporary function --]
 [#-- TODO(mfl) remove once integrated into the input pipeline --]
-[#function getAccountLayerRegion ]
+[#function getAccountLayerRegion deploymentUnit="" ]
     [#local account = getActiveLayer(ACCOUNT_LAYER_TYPE) ]
-    [#return (account[getCLODeploymentUnit()].Region)!account.Region!""]
+    [#local deploymentUnit = deploymentUnit?has_content?then(
+        deploymentUnit,
+        getCLODeploymentUnit()
+    )]
+    [#return (account[deploymentUnit].Region)!account.Region!""]
 [/#function]
 
 [#function getAccountLayerFilters filter]

--- a/providers/shared/layers/Product/id.ftl
+++ b/providers/shared/layers/Product/id.ftl
@@ -133,9 +133,13 @@
 
 [#-- Temporary function --]
 [#-- TODO(mfl) remove once integrated into the input pipeline --]
-[#function getProductLayerRegion ]
+[#function getProductLayerRegion deploymentUnit=""]
     [#local product = getActiveLayer(PRODUCT_LAYER_TYPE, false) ]
-    [#return (product[getCLODeploymentUnit()].Region)!product.Region!"" ]
+    [#local deploymentUnit = deploymentUnit?has_content?then(
+        deploymentUnit,
+        getCLODeploymentUnit()
+    )]
+    [#return (product[deploymentUnit].Region)!product.Region!"" ]
 [/#function]
 
 [#function getProductLayerFilters filter]

--- a/providers/shared/services/resource.ftl
+++ b/providers/shared/services/resource.ftl
@@ -11,8 +11,18 @@
         ""
       )
   ]
-  [#return !(pointObject.Value?has_content &&
-    (pointObject.DeploymentUnit != currentDeploymentUnit))]
+
+  [#local unitRegion = getAccountLayerRegion(deploymentUnit)?has_content?then(
+    getAccountLayerRegion(deploymentUnit),
+    getProductLayerRegion(deploymentUnit)
+  )]
+
+  [#return !(pointObject.Value?has_content
+      && (
+        (pointObject.DeploymentUnit != currentDeploymentUnit)
+        || (pointObject.Region != unitRegion)
+      )
+    )]
 [/#function]
 
 [#-- Is a resource part of the current deployment unit --]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Include the region of the point and the deployment unit when trying to determine if a deployment is a part of the current unit

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When generating a unit that has the same resource Id in each region the deployment detection would treat the other region as part of the same deployment and not allow for the resource to be created in a new deployment.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally. 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

