### PR TITLE
feat(mta): add support for bouncing emails

### DIFF
--- a/providers/shared/components/mta/id.ftl
+++ b/providers/shared/components/mta/id.ftl
@@ -84,12 +84,17 @@
             {
                 "Names" : "Action",
                 "Types" : STRING_TYPE,
-                "Values" : ["forward", "drop", "log"],
+                "Values" : [
+                    "forward",
+                    "receive-bounce",
+                    "drop",
+                    "log"
+                ],
                 "Mandatory" : true
             },
             {
                 "Names" : "EventTypes",
-                "Description" : "Expected events to log  (send only)",
+                "Description" : "Expected events to log (send only)",
                 "Types" : ARRAY_OF_STRING_TYPE,
                 "Default" : [
                     "reject",
@@ -111,6 +116,42 @@
                 "Names" : "Links",
                 "SubObjects" : true,
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+            },
+            {
+                "Names" : "Action:receive-bounce",
+                "Description" : "Specific configuration for using the receive-bounce action",
+                "Children" : [
+                    {
+                        "Names": "BounceType",
+                        "Description" : "The type of bounce to return to the sender - _custom lets you define it",
+                        "Values" : [ "no_address_found", "unauthorised", "custom" ],
+                        "Default" : "no_address_found"
+                    },
+                    {
+                        "Names": "BounceType:custom",
+                        "Description" : "Custom configuration to define the bounce details",
+                        "Children" : [
+                            {
+                                "Names": "Message",
+                                "Description": "The human readable message to return",
+                                "Types": STRING_TYPE,
+                                "Default" : ""
+                            },
+                            {
+                                "Names" : "SmtpReplyCode",
+                                "Description": "The RFC 5321 code to return",
+                                "Types" : STRING_TYPE,
+                                "Default" : "550"
+                            },
+                            {
+                                "Names": "SmtpStatusCode",
+                                "Description": "The RFC 3463 enhanced status code to return",
+                                "Types" : STRING_TYPE,
+                                "Default" : "0.0.0"
+                            }
+                        ]
+                    }
+                ]
             }
         ]
 /]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds MTA rule support for bouncing emails on receive

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Bounce messages provide more contextual information for when people send emails to an email domain. This allows for bounces to be defined based on rules and applied as required

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

