### PR TITLE
feat(lb): add support for multiple paths

### DIFF
--- a/providers/shared/components/lb/id.ftl
+++ b/providers/shared/components/lb/id.ftl
@@ -127,7 +127,7 @@
             {
                 "Names" : "Path",
                 "Description" : "The http path the rule will be matched on",
-                "Types" : STRING_TYPE,
+                "Types" : ARRAY_OF_STRING_TYPE,
                 "Default" : "default"
             },
             {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Allows for setting an array of paths for a lb port rule

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for consolidating load balancer rules that do the same thing across different paths

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

