### PR TITLE
feat(ecs): task service limits, readonlyds, depend

### DIFF
--- a/providers/shared/attributesets/container/id.ftl
+++ b/providers/shared/attributesets/container/id.ftl
@@ -5,7 +5,7 @@
     properties=[
         {
                 "Type"  : "Description",
-                "Value" : "Descirbes each container that will be used as part of a service or task"
+                "Value" : "Describes each container that will be used as part of a service or task"
         }
     ]
     attributes=[
@@ -64,17 +64,25 @@
             "Default" : []
         },
         {
+            "Names" : "Essential",
+            "Description" : "If the container exits the task/service stops all containers and restarts",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : true
+        },
+        {
             "Names" : "Privileged",
+            "Description": "Enable privileged host mode for the container",
             "Types" : BOOLEAN_TYPE,
             "Default" : false
         },
         {
             "Names" : ["MaximumMemory", "MemoryMaximum", "MaxMemory"],
-            "Types" : NUMBER_TYPE,
-            "Description" : "Set to 0 to not set a maximum"
+            "Description" : "A hard limit of memory available to the contianer - Set to 0 to not set a maximum",
+            "Types" : NUMBER_TYPE
         },
         {
             "Names" : ["MemoryReservation", "Memory", "ReservedMemory"],
+            "Description" : "A fixed allocation that is assigned to to this container",
             "Types" : NUMBER_TYPE,
             "Mandatory" : true
         },
@@ -121,7 +129,30 @@
             "Names" : "ContainerNetworkLinks",
             "Types" : ARRAY_OF_STRING_TYPE,
             "Default" : []
-        }
+        },
+        {
+            "Names" : "DependsOn",
+            "Description": "Defines depdencies between containers in the same task - this container won't start unless these depdencies are met",
+            "SubObjects" : true,
+            "Children" : [
+                {
+                    "Names" : "ContainerName",
+                    "Description" : "The name of the container to depend on uses the key of this object if not present",
+                    "Types" : STRING_TYPE
+                },
+                {
+                    "Names" : "Condition",
+                    "Description" : "The required state of the container to start this one",
+                    "Values" : [
+                        "START",
+                        "COMPLETE",
+                        "SUCCESS",
+                        "HEALTHY"
+                    ],
+                    "Default" : "START"
+                }
+            ]
+        },
         {
             "Names" : "Profiles",
             "Children" :
@@ -132,6 +163,12 @@
                         "Default" : "default"
                     }
                 ]
+        },
+        {
+            "Names": "ReadonlyRootFilesystem",
+            "Descriptions": "Makes the root of the filesystem read-only",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : false
         },
         {
             "Names" : "RunMode",

--- a/providers/shared/attributesets/container/id.ftl
+++ b/providers/shared/attributesets/container/id.ftl
@@ -77,7 +77,7 @@
         },
         {
             "Names" : ["MaximumMemory", "MemoryMaximum", "MaxMemory"],
-            "Description" : "A hard limit of memory available to the contianer - Set to 0 to not set a maximum",
+            "Description" : "A hard limit of memory available to the container - Set to 0 to not set a maximum",
             "Types" : NUMBER_TYPE
         },
         {
@@ -132,7 +132,7 @@
         },
         {
             "Names" : "DependsOn",
-            "Description": "Defines depdencies between containers in the same task - this container won't start unless these depdencies are met",
+            "Description": "Defines dependencies between containers in the same task - this container won't start unless these dependencies are met",
             "SubObjects" : true,
             "Children" : [
                 {

--- a/providers/shared/attributesets/containerservice/id.ftl
+++ b/providers/shared/attributesets/containerservice/id.ftl
@@ -23,6 +23,18 @@
             "Default" : false
         },
         {
+            "Names" : "Cpu",
+            "Description" : "The Cpu available to all containers in the service - 0 will defer to the container allocations",
+            "Types" : NUMBER_TYPE,
+            "Default": 0
+        },
+        {
+            "Names" : "Memory",
+            "Description" : "The memory available to all containers in the service - 0 will defer to the container allocations",
+            "Types" : NUMBER_TYPE,
+            "Default": 0
+        },
+        {
             "Names" : "Containers",
             "SubObjects" : true,
             "AttributeSet" : CONTAINER_ATTRIBUTESET_TYPE

--- a/providers/shared/attributesets/containertask/id.ftl
+++ b/providers/shared/attributesets/containertask/id.ftl
@@ -28,6 +28,18 @@
             "AttributeSet" : CONTAINER_ATTRIBUTESET_TYPE
         },
         {
+            "Names" : "Cpu",
+            "Description" : "The Cpu available to all containers in the task - 0 will defer to the container allocations",
+            "Types" : NUMBER_TYPE,
+            "Default": 0
+        },
+        {
+            "Names" : "Memory",
+            "Description" : "The memory available to all containers in the task - 0 will defer to the container allocations",
+            "Types" : NUMBER_TYPE,
+            "Default": 0
+        },
+        {
             "Names" : "UseTaskRole",
             "Types" : BOOLEAN_TYPE,
             "Default" : true


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds task level Cpu/Memory limit configuration
- Adds readonly fs container option
- Adds dependsOn configuration to specific dependencies between containers

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Enabling root only file systems requires adding volumes for directories like /tmp. However doing this creates directories owned by root. Running an init container before the actual container lets you align the new volume permissions with what is expected

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

