### PR TITLE
refactor(s3): object ownership support

### DIFF
--- a/legacy/account/account_audit.ftl
+++ b/legacy/account/account_audit.ftl
@@ -59,6 +59,26 @@
                         }
                     },
                     false
+                ),
+                getPolicyStatement(
+                    [
+                        "s3:PutObject"
+                    ],
+                    [
+                        getArn(auditBucketId),
+                        {
+                            "Fn::Join": [
+                                "/",
+                                [
+                                    getArn(auditBucketId),
+                                    "*"
+                                ]
+                            ]
+                        }
+                    ],
+                    {
+                        "Service": "logging.s3.amazonaws.com"
+                    }
                 )
             ]]
 
@@ -219,7 +239,6 @@
                 encryptionSource="AES256"
                 lifecycleRules=lifecycleRules
                 versioning=true
-                cannedACL="LogDeliveryWrite"
                 publicAccessBlockConfiguration=(
                     getPublicAccessBlockConfiguration()
                 )

--- a/providers/shared/components/s3/id.ftl
+++ b/providers/shared/components/s3/id.ftl
@@ -220,6 +220,12 @@
                         "Default" : "Daily"
                     }
                 ]
+            },
+            {
+                "Names" : "ObjectOwnership",
+                "Values" : [ "owner", "ownerpreferred", "writer"],
+                "Types" : STRING_TYPE,
+                "Description" : "Explicitly control the way in which object ownership should be treated"
             }
         ]
 /]


### PR DESCRIPTION


## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description
Add support for control of the object ownership for the bucket.

Also, per https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html, switch from using an ACL to using bucket policy to permit logging to the audit bucket.

## Motivation and Context
- align with AWS best practices
- avoid deployment failures where an SCP enforces bucket owner object ownership.
- 
## How Has This Been Tested?
Local generation. Use in customer site will also be undertaken once part of the unicycle release.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

