### PR TITLE
feat: private endpoint services

### DIFF
--- a/engine/common.ftl
+++ b/engine/common.ftl
@@ -416,20 +416,17 @@
 [/#function]
 
 [#function getNetworkEndpoints endpointGroups zone region ]
-    [#local services = []]
+    [#local services = [] ]
+    [#local allZoneServiceEndpoints = {} ]
     [#local networkEndpoints = {}]
 
     [#local regionObject = getRegions()[region]]
     [#local zoneNetworkEndpoints = (regionObject.Zones[zone].NetworkEndpoints)![] ]
 
     [#list endpointGroups as endpointGroup ]
-        [#if networkEndpointGroups[endpointGroup]?? ]
-            [#list networkEndpointGroups[endpointGroup].Services as service ]
-                [#if !services?seq_contains(service) ]
-                    [#local services += [ service ]]
-                [/#if]
-            [/#list]
-        [/#if]
+        [#local services = getUniqueArrayElements( services, (networkEndpointGroups[endpointGroup].Services)![] ) ]
+        [#-- These services are assumed to be required in all zones --]
+        [#local allZoneServiceEndpoints += (networkEndpointGroups[endpointGroup].AllZoneServices)!{} ]
     [/#list]
 
     [#list services as service ]
@@ -443,7 +440,7 @@
         [/#list]
     [/#list]
 
-    [#return networkEndpoints]
+    [#return networkEndpoints + allZoneServiceEndpoints]
 [/#function]
 
 

--- a/providers/shared/references/NetworkEndpointGroup/id.ftl
+++ b/providers/shared/references/NetworkEndpointGroup/id.ftl
@@ -1,19 +1,34 @@
 [#ftl]
 
-[@addReference 
+[@addReference
     type=NETWORKENDPOINTGROUP_REFERENCE_TYPE
     pluralType="NetworkEndpointGroups"
     properties=[
             {
                 "Type"  : "Description",
-                "Value" : "A group of network endpoints" 
+                "Value" : "A group of network endpoints"
             }
         ]
     attributes=[
         {
             "Names" : "Services",
-            "Types" : ARRAY_OF_STRING_TYPE,
-            "Mandatory" : true
+            "Types" : ARRAY_OF_STRING_TYPE
+        },
+        {
+            "Names" : "AllZoneServices",
+            "SubObjects" : true,
+            "Children" : [
+                {
+                    "Names" : "Type",
+                    "Types" : STRING_TYPE,
+                    "Mandatory" : true
+                },
+                {
+                    "Names" : "ServiceName",
+                    "Types" : STRING_TYPE,
+                    "Mandatory" : true
+                }
+            ]
         }
     ]
 /]


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Extend the processing of endpoint services to support privately defined endpoints, as opposed to the public ones offered by cloud providers. 

These endpoints are assumed to be required in all zones supported by the network of the tier in which the gateway is defined.

## Motivation and Context
Support the use of customer defined service endpoints in AWS.

## How Has This Been Tested?
Local template generation. I'll also apply on customer site.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

