### PR TITLE
feat(network): support for network profile on net

### DIFF
--- a/providers/shared/components/network/id.ftl
+++ b/providers/shared/components/network/id.ftl
@@ -147,6 +147,12 @@
                         "Names" : "Logging",
                         "Types" : STRING_TYPE,
                         "Default" : "default"
+                    },
+                    {
+                        "Names" : "Network",
+                        "Description" : "The network profile rules applied to the default access control groups",
+                        "Types" : STRING_TYPE,
+                        "Default" : "default"
                     }
                 ]
             }
@@ -207,6 +213,12 @@
                 "Names" : "Rules",
                 "SubObjects" : true,
                 "Children" : [
+                    {
+                        "Names" : "Enabled",
+                        "Description" : "Enable the rule",
+                        "Types": BOOLEAN_TYPE,
+                        "Default": true
+                    },
                     {
                         "Names" : "Priority",
                         "Types" : NUMBER_TYPE,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds the ability to set a network profile on a network. This applies to network resources created as part of the network itself such as default security groups
- Adds enabled attribute for network rules on a user defined ACL

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for control over default resources created as part of a network 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

