### PR TITLE
fix: image settings

### DIFF
--- a/engine/commonApplication.ftl
+++ b/engine/commonApplication.ftl
@@ -66,6 +66,7 @@
 
 
 [#function defaultEnvironment occurrence links baselineLinks={}]
+    [#local image = getOccurrenceImage(occurrence) ]
     [#return
         occurrence.Configuration.Environment.General +
         occurrence.Configuration.Environment.Build +
@@ -75,7 +76,9 @@
         baselineLinks?has_content?then(
             getDefaultBaselineVariables(baselineLinks),
             {}
-        )
+        ) +
+        attributeIfContent("BUILD_REFERENCE", image.Reference!"") +
+        attributeIfContent("APP_REFERENCE", image.Tag!"")
     ]
 [/#function]
 


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Add the reference and tag from the image details as default environment settings so inclusion of these in config files doesn't fail when image components are used.

## Motivation and Context
Currently the inclusion of build information into an spa config file assumes the settings have come via the builds section of the CMDB. With the introduction of image components, this information is available via the occurrence image details rather than via build settings. 

By initialising the default environment with the values from the image information, existing fragment and extension files will continue to work with image components.

## How Has This Been Tested?
Customer site

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

