### PR TITLE
feat(apigateway): private APIs

### DIFF
--- a/providers/shared/components/apigateway/id.ftl
+++ b/providers/shared/components/apigateway/id.ftl
@@ -83,6 +83,7 @@ object.
             },
             {
                 "Names" : "Links",
+                "Description" : "For a private API, provide VPC Endpoints via an inbound link from an external service with a \"VPC_ENDPOINTS\" attribute",
                 "SubObjects" : true,
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
             },
@@ -93,7 +94,7 @@ object.
             {
                 "Names" : "EndpointType",
                 "Types" : STRING_TYPE,
-                "Values" : ["EDGE", "REGIONAL"],
+                "Values" : ["EDGE", "REGIONAL", "PRIVATE"],
                 "Default" : "EDGE"
             },
             {
@@ -103,14 +104,14 @@ object.
             },
             {
                 "Names" : ["AuthorisationModel", "AuthorizationModel", "Authentication"],
-                "Description" : "Model to use where IP filtering is part of the desired authorization approach",
+                "Description" : "Authorization Model to use in conjunction with resource based policy filtering",
                 "Types" : STRING_TYPE,
                 "Values" : [
-                    "IP",
-                    "AUTHORISER_OR_IP", "AUTHORIZER_OR_IP",
-                    "AUTHORISER_AND_IP", "AUTHORIZER_AND_IP"
+                    "SOURCE", "IP",
+                    "AUTHORISER_OR_SOURCE", "AUTHORIZER_OR_SOURCE", "AUTHORISER_OR_IP", "AUTHORIZER_OR_IP",
+                    "AUTHORISER_AND_SOURCE", "AUTHORIZER_AND_SOURCE", "AUTHORISER_AND_IP", "AUTHORIZER_AND_IP"
                 ],
-                "Default" : "IP"
+                "Default" : "SOURCE"
             },
             {
                 "Names" : "CloudFront",


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add the option of private APIs. For these APIS, traffic filtering is done on the basis of VPC endpoints rather than IP addresses. The VPC endpoints are assumed to be configured via inbound links to external services, which should provide a VPC_ENDPOINTS attribute containing a command separated list of vpc endpoint names.

Adjust the available values for the authorisation model to support either IPs or VPC Endpoints.

## Motivation and Context
- support new AWS feature
- support more security conscious deployment

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

