### PR TITLE
feat(mta): add stop after match action

### DIFF
--- a/providers/shared/components/mta/id.ftl
+++ b/providers/shared/components/mta/id.ftl
@@ -93,6 +93,12 @@
                 "Mandatory" : true
             },
             {
+                "Names": "StopAfterMatch",
+                "Type": BOOLEAN_TYPE,
+                "Description" : "If this rule is matched don't apply any other rules after this one",
+                "Default" : false
+            },
+            {
                 "Names" : "EventTypes",
                 "Description" : "Expected events to log (send only)",
                 "Types" : ARRAY_OF_STRING_TYPE,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds the ability to stop further processing if a rule is matched

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The mail processing engine in some providers will process all matched rules rather than the first match, you could add another rule after the one where it should stop, but this makes it easier to setup

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

