### PR TITLE
feat(vpcendpoint): policy support

### DIFF
--- a/providers/shared/components/gateway/id.ftl
+++ b/providers/shared/components/gateway/id.ftl
@@ -166,6 +166,12 @@
                 "Default" : true
             },
             {
+                "Names" : [ "Extensions" ],
+                "Description" : "Extensions to invoke as part of component processing",
+                "Types" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            },
+            {
                 "Names" : "Links",
                 "SubObjects" : true,
                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
Add the ability to add policy to vpcendpoint gateway destinations via extensions.

## Motivation and Context
To limit the access provided, support link based extensions that add an explicit 
policy to aws service privatelinks.

As this is new support, don't provide alternative names for the `Extensions` attribute.

## How Has This Been Tested?
- local generation
- customer site following release
- 
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

