### PR TITLE
fix: don't list disabled suboccurrences

### DIFF
--- a/providers/shared/components/shared/setup.ftl
+++ b/providers/shared/components/shared/setup.ftl
@@ -24,19 +24,12 @@
 
 [#macro shared_occurrences_state occurrence ]
     [#local allOccurrences = asFlattenedArray( [ occurrence, occurrence.Occurrences![] ], true )]
-    [#list allOccurrences as occurrence ]
-
-        [#local occurrencestate = {}]
-        [#list occurrence as k, v ]
-            [#if k != "Occurrences" ]
-                [#local occurrencestate = mergeObjects(occurrencestate, { k : v }) ]
-            [/#if]
-        [/#list]
-
+    [#-- Only include enabled suboccurrences --]
+    [#list allOccurrences?filter(x -> x.Configuration.Solution.Enabled) as occurrence ]
         [@stateEntry
             type="Occurrences"
             id=occurrence.Core.TypedFullName
-            state=occurrencestate
+            state=removeObjectAttributes(occurrence, "Occurrences")
         /]
     [/#list]
 [/#macro]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
When generating an occurrence list, don't include sub-occurrences that are disabled. Any component processing should perform an equivalent check but at present the sub-occurrence still appears in the list.

## Motivation and Context
The same doesn't happen to occurrences since the general flow logic completely excludes any occurrence that is disabled.
this fix ensures the behaviour is the same for occurrences or sub-occurrences.

## How Has This Been Tested?
Local cli execution.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

