### PR TITLE
feat(lb): client IP control

### DIFF
--- a/providers/shared/components/lb/id.ftl
+++ b/providers/shared/components/lb/id.ftl
@@ -362,6 +362,13 @@
                                 "AttributeSet" : LINK_ATTRIBUTESET_TYPE
                             }
                         ]
+                    },
+                    {
+                        "Names" : "ClientIP",
+                        "Description" : "How to provide client IP to the target. By default, the lb address will be presented",
+                        "Types" : STRING_TYPE,
+                        "Values" : ["preserve", "proxy_protocol", "lb"],
+                        "Default" : "lb"
                     }
                 ]
             },


### PR DESCRIPTION

## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Provide the ability to control the way in which client IP information will be provided to a target.

## Motivation and Context
The default mirrors the current situation where the lb client is hidden and the lb address is presented.

## How Has This Been Tested?
- Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

