### PR TITLE
feat(user): add user name control

### DIFF
--- a/providers/shared/components/user/id.ftl
+++ b/providers/shared/components/user/id.ftl
@@ -82,6 +82,83 @@
                 "Types" : ARRAY_OF_STRING_TYPE,
                 "Description" : "Limit User access based on IP Address",
                 "Default" : []
+            },
+            {
+                "Names": "Username",
+                "Children" : [
+                    {
+                        "Names": "UseIdValues",
+                        "Description" : "When formatting the name use the Id of the parts instead of the Name",
+                        "Types" : BOOLEAN_TYPE,
+                        "Default" : true
+                    },
+                    {
+                        "Names" : "IncludeOrder",
+                        "Description" : "The order the includes are added in",
+                        "Types" : ARRAY_OF_STRING_TYPE,
+                        "Default": [
+                            "Product",
+                            "Environment",
+                            "Segment",
+                            "Component",
+                            "Instance",
+                            "Version",
+                            "Name"
+                        ]
+                    },
+                    {
+                        "Names" : "Include",
+                        "Description": "The parts of the occurrence context to include in the name",
+                        "Children" : [
+                            {
+                                "Names": "Product",
+                                "Types": BOOLEAN_TYPE,
+                                "Default": true
+                            },
+                            {
+                                "Names": "Environment",
+                                "Types": BOOLEAN_TYPE,
+                                "Default" : true
+                            },
+                            {
+                                "Names": "Segment",
+                                "Types": BOOLEAN_TYPE,
+                                "Default" : true
+                            },
+                            {
+                                "Names" : "Tier",
+                                "Types" : BOOLEAN_TYPE,
+                                "Default" : true
+                            },
+                            {
+                                "Names" : "Component",
+                                "Types" : BOOLEAN_TYPE,
+                                "Default" : true
+                            },
+                            {
+                                "Names" : "Instance",
+                                "Types" : BOOLEAN_TYPE,
+                                "Default" : true
+                            },
+                            {
+                                "Names" : "Version",
+                                "Types" : BOOLEAN_TYPE,
+                                "Default" : true
+                            },
+                            {
+                                "Names" : "Name",
+                                "Types" : BOOLEAN_TYPE,
+                                "Default" : false
+                            }
+                        ]
+                    },
+                    {
+                        "Names" : "Name",
+                        "Description" : "A custom field used to set a specifc name",
+                        "Types" : STRING_TYPE,
+                        "Default" : ""
+                    }
+                ]
             }
         ]
     dependencies=[APIGATEWAY_COMPONENT_TYPE]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds the ability to control the components included in the name of a user

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When creating and managing user accounts in hamlet, sometimes you want to create centralised accounts that are used for management purposes. In these cases they are only deployed to one environment so you can make the user names as small as possible

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

