### PR TITLE
feat(waf): add support for waf on userpools

### DIFF
--- a/providers/shared/references/IPAddressGroup/id.ftl
+++ b/providers/shared/references/IPAddressGroup/id.ftl
@@ -139,11 +139,9 @@
         [#case "__segment__"]
             [#local segmentCIDR = [] ]
             [#list getZones() as zone]
-                [#local zoneIP =
-                    getExistingReference(
-                        formatComponentEIPId("mgmt", "nat", zone),
-                        IP_ADDRESS_ATTRIBUTE_TYPE
-                    ) ]
+                [#local zoneIP = getExistingReference(
+                    formatResourceId(AWS_EIP_RESOURCE_TYPE, "mgmt", "nat", zone.Id)
+                )]
                 [#if zoneIP?has_content]
                     [#local segmentCIDR += [zoneIP + "/32" ] ]
                 [/#if]

--- a/providers/shared/references/SecurityProfile/id.ftl
+++ b/providers/shared/references/SecurityProfile/id.ftl
@@ -225,6 +225,21 @@
                     "Types" : STRING_TYPE
                 }
             ]
+        },
+        {
+            "Names" : "userpool",
+            "Children" : [
+                {
+                    "Names" : "WAFProfile",
+                    "Types" : STRING_TYPE,
+                    "Default" : "default"
+                },
+                {
+                    "Names" : "WAFValueSet",
+                    "Types" : STRING_TYPE,
+                    "Default" : "default"
+                }
+            ]
         }
     ]
 /]

--- a/providers/shared/references/WAFProfile/id.ftl
+++ b/providers/shared/references/WAFProfile/id.ftl
@@ -28,7 +28,7 @@
                     "Names": "Action",
                     "Description" : "The action to perform when the rule is matched",
                     "Types" : STRING_TYPE,
-                    "Values": [ "BLOCK", "ALLOW"]
+                    "Values": [ "BLOCK", "ALLOW", "CHALLENGE", "COUNT"]
                 },
                 {
                     "Names": "Action:BLOCK",
@@ -96,6 +96,19 @@
                                     ]
                                 }
                             ]
+                        }
+                    ]
+                },
+                {
+                    "Names": "Action:CHALLENGE",
+                    "Description": "What to do when the WAF hits a challenge action",
+                    "Children": [
+                        {
+                            "Names": "Engine",
+                            "Description": "The type of challenge to issue",
+                            "Types": STRING_TYPE,
+                            "Values": ["CAPTCHA", "Transparent"],
+                            "Default" : "CAPTCHA"
                         }
                     ]
                 }

--- a/providers/shared/references/WAFProfile/reference.ftl
+++ b/providers/shared/references/WAFProfile/reference.ftl
@@ -40,6 +40,7 @@
                     "Conditions" : conditionList,
                     "Action" : (ruleEntry.Action)!"",
                     "Action:BLOCK": (ruleEntry["Action:BLOCK"])!{},
+                    "Action:CHALLENGE": (ruleEntry["Action:CHALLENGE"])!{},
                     "Engine": rules[ruleListEntry].Engine,
                     "Engine:RateLimit": rules[ruleListEntry]["Engine:RateLimit"],
                     "Engine:VendorManaged" : rules[ruleListEntry]["Engine:VendorManaged"]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Enable WAF for userpool components
- Add support for Challenge controls on WAF to require CAPTCHA or bot challenges
- Updates the Id lookup for NAT services

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Given the focus on user services from attack adding WAF based services to userpools allows for tight control over how the user pool can be accessed

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and on active deployment

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

