### PR TITLE
feat(topic): add fixed subscription config

### DIFF
--- a/providers/shared/components/topic/id.ftl
+++ b/providers/shared/components/topic/id.ftl
@@ -139,6 +139,32 @@
                 "Description" : "Deliver message as received not with JSON payload strucutre",
                 "Types" : BOOLEAN_TYPE,
                 "Default" : false
+            },
+            {
+                "Names": "Endpoints",
+                "Description": "Fixed endpoints to add to the subscription",
+                "SubObjects": true,
+                "Children": [
+                    {
+                        "Names": "Protocol",
+                        "Description": "The protocol to use when sending the message",
+                        "Types" : STRING_TYPE,
+                        "Values" : [
+                            "http",
+                            "https",
+                            "email",
+                            "email-json",
+                            "sms"
+                        ],
+                        "Mandatory": true
+                    },
+                    {
+                        "Names": "Address",
+                        "Description": "The address that receives the notification (URI, email address, phone number)",
+                        "Types" : STRING_TYPE,
+                        "Mandatory": true
+                    }
+                ]
             }
         ]
 /]


### PR DESCRIPTION

## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds the ability to define fixed addresses on a topic subscription

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
We currently use external links to send notifications to endpoints like email addresses, phone numbers etc. This can be complicated to setup for simple tasks like sending notification emails. The fixed endpoint option here provides a more explicit way to do it. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

