### PR TITLE
feat(cdn): add support for configuring aliases

### DIFF
--- a/providers/shared/components/cdn/id.ftl
+++ b/providers/shared/components/cdn/id.ftl
@@ -105,6 +105,18 @@
                 "AttributeSet" : CERTIFICATE_ATTRIBUTESET_TYPE
             },
             {
+                "Names" : ["Aliases"],
+                "Description": "Hostnames included on the CDN",
+                "SubObjects" : true,
+                "Children" : [
+                    {
+                        "Names" : "Hostname",
+                        "Description" : "The hostname of the alias",
+                        "AttributeSet" : CERTIFICATE_ATTRIBUTESET_TYPE
+                    }
+                ]
+            },
+            {
                 "Names" : "AssumeSNI",
                 "Description" : "Use TLS Server Name Identification to route clients requests to the CDN",
                 "Types" : BOOLEAN_TYPE,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for configuring full hostname based aliases on cdn components

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Currently adding multiple aliases to a CDN relies on the multiple parent support in the domains component that CDN uses. However this doesn't allow you to have different hostnames just different domains. 

Adding the explicit ability to add multiple aliases allows you to control this as required. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

