### PR TITLE
fix: naming for stack output file

### DIFF
--- a/engine/output.ftl
+++ b/engine/output.ftl
@@ -721,16 +721,6 @@
                     [/#if]
                     [#break]
 
-                [#case "stack" ]
-                    [#local filename_parts =
-                        mergeObjects(
-                            filename_parts,
-                            {
-                                "entrance_prefix" : "",
-                                "alternative_prefix" : ""
-                            }
-                        )]
-                    [#break]
             [/#switch]
             [#break]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
Reinstate the naming used for the stack output file generated by the engine

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The file wasn't being written properly when pushing a new image

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

