### PR TITLE
chore: bump default RDS SSLCertificateAuthority as 2019 CA expiring

### DIFF
--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -1856,7 +1856,7 @@
         "WAFValueSet": "default"
       },
       "db": {
-        "SSLCertificateAuthority": "rds-ca-2019"
+        "SSLCertificateAuthority": "rds-ca-rsa2048-g1"
       },
       "es": {
         "ProtocolPolicy": "https-only",


### PR DESCRIPTION
# Description

Updates the default SSLCertificateAuthority for RDS from `rds-ca-2019` to `rds-ca-rsa2048-g1`, as the former is expiring next month.

According to the [AWS docs for this](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html), the recommended CA to move to to ensure the same standards is `rds-ca-rsa2048-g1`.