### PR TITLE
feat: WAF ACL's to support IPv6

### DIFF
--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -1267,6 +1267,7 @@
       ],
       "blacklistedips": [],
       "whitelistedips": [],
+      "whitelistedipsipv6": [],
       "blacklistedcountrycodes": [],
       "whitelistedcountrycodes": [],
       "sqlheaders": [

--- a/providers/shared/inputseeders/shared/masterdata.json
+++ b/providers/shared/inputseeders/shared/masterdata.json
@@ -1622,6 +1622,17 @@
         }
       ]
     },
+    "whitelistipsipv6": {
+      "Type": "IPMatch",
+      "Description": "Whitelist IPV6 IPs",
+      "Filters": [
+        {
+          "Targets": [
+            "whitelistedipsipv6"
+          ]
+        }
+      ]
+    },
     "blacklistcountries": {
       "Type": "GeoMatch",
       "Description": "Blacklist Countries",
@@ -1764,6 +1775,16 @@
       "Conditions": [
         {
           "Condition": "whitelistips",
+          "Negated": false
+        }
+      ]
+    },
+    "whitelistipsipv6": {
+      "Description": "Whitelist IPV6 IPs",
+      "NameSuffix": "whitelistipsipv6",
+      "Conditions": [
+        {
+          "Condition": "whitelistipsipv6",
           "Negated": false
         }
       ]


### PR DESCRIPTION
- Adds a new WAF Rule `whitelistipsipv6`
- Adds a new WAF Condition `whitelistipsipv6`

Works alongside https://github.com/hamlet-io/engine-plugin-aws/pull/809